### PR TITLE
Skip povdolumerestore creation when restore excludes pv/pvc

### DIFF
--- a/changelogs/unreleased/4769-half-life666
+++ b/changelogs/unreleased/4769-half-life666
@@ -1,0 +1,1 @@
+Skip podvolumerestore creation when restore excludes pv/pvc

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1296,7 +1296,10 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 			return warnings, errs
 		}
 
-		if len(restic.GetVolumeBackupsForPod(ctx.podVolumeBackups, pod, originalNamespace)) > 0 {
+		// Do not create podvolumerestore when current restore excludes pv/pvc
+		if ctx.resourceIncludesExcludes.ShouldInclude(kuberesource.PersistentVolumeClaims.String()) &&
+			ctx.resourceIncludesExcludes.ShouldInclude(kuberesource.PersistentVolumes.String()) &&
+			len(restic.GetVolumeBackupsForPod(ctx.podVolumeBackups, pod, originalNamespace)) > 0 {
 			restorePodVolumeBackups(ctx, createdObj, originalNamespace)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: half-life666 <half-life@jibudata.com>

Thank you for contributing to Velero!

# Please add a summary of your change
Do podvolumerestore only when restore includes pv/pvc

# Does your change fix a particular issue?

Fixes # [issue 4754](https://github.com/vmware-tanzu/velero/issues/4754)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [X] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
