### PR TITLE
feat(csi): allow setting annotation on StorageClass to determine VolumeSnapshotClass

### DIFF
--- a/changelogs/unreleased/8646-cfi2017
+++ b/changelogs/unreleased/8646-cfi2017
@@ -1,0 +1,1 @@
+Add a way to specify the desired VolumeSnapshotClass for CSI snapshot backups using an annotation in the Volumes StorageClass.

--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -135,6 +135,7 @@ const (
 	VolumeSnapshotClassSelectorLabel                = "velero.io/csi-volumesnapshot-class"
 	VolumeSnapshotClassDriverBackupAnnotationPrefix = "velero.io/csi-volumesnapshot-class"
 	VolumeSnapshotClassDriverPVCAnnotation          = "velero.io/csi-volumesnapshot-class"
+	VolumeSnapshotClassDriverStorageClassAnnotation = "velero.io/csi-volumesnapshot-class"
 
 	// https://kubernetes.io/zh-cn/docs/concepts/storage/volume-snapshot-classes/
 	VolumeSnapshotClassKubernetesAnnotation = "snapshot.storage.kubernetes.io/is-default-class"

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -226,7 +226,7 @@ func (p *pvcBackupItemAction) createVolumeSnapshot(
 
 	p.log.Debugf("Fetching VolumeSnapshotClass for %s", storageClass.Provisioner)
 	vsClass, err := csi.GetVolumeSnapshotClass(
-		storageClass.Provisioner,
+		storageClass,
 		backup,
 		&pvc,
 		p.log,

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -388,19 +388,19 @@ func GetVolumeSnapshotClassFromPVCAnnotationsForDriver(
 
 func GetVolumeSnapshotClassFromStorageClassAnnotationsForDriver(storageClass *storagev1api.StorageClass, snapshotClasses *snapshotv1api.VolumeSnapshotClassList) (*snapshotv1api.VolumeSnapshotClass, error) {
 	annotationKey := velerov1api.VolumeSnapshotClassDriverStorageClassAnnotation
-	snapshotClassName, ok := storageClass.ObjectMeta.Annotations[annotationKey]
+	snapshotClassNameFromStorageClassAnnotation, ok := storageClass.ObjectMeta.Annotations[annotationKey]
 	if !ok {
 		return nil, nil
 	}
 	for _, sc := range snapshotClasses.Items {
-		if strings.EqualFold(snapshotClassName, sc.ObjectMeta.Name) {
+		if strings.EqualFold(snapshotClassNameFromStorageClassAnnotation, sc.ObjectMeta.Name) {
 			if !strings.EqualFold(sc.Driver, storageClass.Provisioner) {
 				return nil, errors.Errorf("Incorrect volumesnapshotclass, snapshot class %s is not for driver %s", sc.ObjectMeta.Name, storageClass.Provisioner)
 			}
 			return &sc, nil
 		}
 	}
-	return nil, errors.Errorf("No CSI VolumeSnapshotClass found with name %s for provisioner %s for StorageClass %s", snapshotClassName, storageClass.Provisioner, storageClass.Name)
+	return nil, errors.Errorf("No CSI VolumeSnapshotClass found with name %s for provisioner %s for StorageClass %s", snapshotClassNameFromStorageClassAnnotation, storageClass.Provisioner, storageClass.Name)
 }
 
 // GetVolumeSnapshotClassFromAnnotationsForDriver returns a

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -970,10 +970,10 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 		Provisioner: "foo.csi.k8s.io",
 	}
 
-	foolabelStorageClass := &storagev1api.StorageClass{
+	fooannotationStorageClass := &storagev1api.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
-			Labels: map[string]string{
+			Annotations: map[string]string{
 				"velero.io/csi-volumesnapshot-class": "sctest",
 			},
 		},
@@ -1004,7 +1004,7 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 		Provisioner: "blah.csi.k8s.io",
 	}
 
-	objs := []runtime.Object{hostpathClass, fooClass, barClass, fooClassWithoutLabel, barClass2}
+	objs := []runtime.Object{hostpathClass, sctestClass, fooClass, barClass, fooClassWithoutLabel, barClass2}
 	fakeClient := velerotest.NewFakeControllerRuntimeClient(t, objs...)
 
 	testCases := []struct {
@@ -1033,7 +1033,7 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 		},
 		{
 			name:         "sctest VSC annotations on StorageClass",
-			storageClass: foolabelStorageClass,
+			storageClass: fooannotationStorageClass,
 			pvc:          pvcNone,
 			backup:       backupNone,
 			expectedVSC:  sctestClass,

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -1032,11 +1032,12 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 			expectError:  false,
 		},
 		{
-			name:         "footwithoutlabel VSC annotations on StorageClass",
+			name:         "sctest VSC annotations on StorageClass",
 			storageClass: foolabelStorageClass,
 			pvc:          pvcNone,
 			backup:       backupNone,
 			expectedVSC:  sctestClass,
+			expectError:  false,
 		},
 		{
 			name:         "foowithoutlabel VSC annotations on pvc, but csi driver does not match, no annotation on backup so fallback to default behavior of labels",

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -954,12 +954,27 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 		Driver: "bar.csi.k8s.io",
 	}
 
+	sctestClass := &snapshotv1api.VolumeSnapshotClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sctest",
+		},
+		Driver: "foo.csi.k8s.io",
+	}
+
 	// storageclasses
 	fooStorageClass := &storagev1api.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
+			Name:   "foo",
+			Labels: map[string]string{},
+		},
+		Provisioner: "foo.csi.k8s.io",
+	}
+
+	foolabelStorageClass := &storagev1api.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
 			Labels: map[string]string{
-				"velero.io/csi-volumesnapshot-class": "foo",
+				"velero.io/csi-volumesnapshot-class": "sctest",
 			},
 		},
 		Provisioner: "foo.csi.k8s.io",
@@ -967,30 +982,24 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 
 	barStorageClass := &storagev1api.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "bar",
-			Labels: map[string]string{
-				"velero.io/csi-volumesnapshot-class": "foo",
-			},
+			Name:   "bar",
+			Labels: map[string]string{},
 		},
 		Provisioner: "bar.csi.k8s.io",
 	}
 
 	hostpathStorageClass := &storagev1api.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "hostpath",
-			Labels: map[string]string{
-				"velero.io/csi-volumesnapshot-class": "foo",
-			},
+			Name:   "hostpath",
+			Labels: map[string]string{},
 		},
 		Provisioner: "hostpath.csi.k8s.io",
 	}
 
 	blahStorageClass := &storagev1api.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "blah",
-			Labels: map[string]string{
-				"velero.io/csi-volumesnapshot-class": "foo",
-			},
+			Name:   "blah",
+			Labels: map[string]string{},
 		},
 		Provisioner: "blah.csi.k8s.io",
 	}
@@ -1021,6 +1030,13 @@ func TestGetVolumeSnapshotClass(t *testing.T) {
 			backup:       backupNone,
 			expectedVSC:  fooClassWithoutLabel,
 			expectError:  false,
+		},
+		{
+			name:         "footwithoutlabel VSC annotations on StorageClass",
+			storageClass: foolabelStorageClass,
+			pvc:          pvcNone,
+			backup:       backupNone,
+			expectedVSC:  sctestClass,
 		},
 		{
 			name:         "foowithoutlabel VSC annotations on pvc, but csi driver does not match, no annotation on backup so fallback to default behavior of labels",

--- a/site/content/docs/main/csi.md
+++ b/site/content/docs/main/csi.md
@@ -86,7 +86,18 @@ This section documents some of the choices made during implementing the CSI snap
         ```
         Note: Please ensure all your annotations are in lowercase. And follow the following format: `velero.io/csi-volumesnapshot-class_<driver name> = <VolumeSnapshotClass Name>`
 
-    3. **Choosing VolumeSnapshotClass for a particular PVC:**
+    3. **Choose VolumeSnapshotClass for a particular StorageClass:**
+    If you want to use a particular VolumeSnapshotClass for a particular StorageClass, you can add an annotation to the StorageClass to indicate which VolumeSnapshotClass to use. For example, if you want to use the VolumeSnapshotClass `test-snapclass` for a particular backup for snapshotting PVCs of a given StorageClass, you can annotate it:
+        ```yaml
+        apiVersion: storage/v1
+        kind: StorageClass
+        metadata:
+          name: test-storageclass
+          annotations:
+            velero.io/csi-volumesnapshot-class: "test-snapclass"
+        ```
+
+    4. **Choosing VolumeSnapshotClass for a particular PVC:**
     If you want to use a particular VolumeSnapshotClass for a particular PVC, you can add a annotation to the PVC to indicate which VolumeSnapshotClass to use. This overrides any annotation added to backup or schedule. For example, if you want to use the VolumeSnapshotClass `test-snapclass` for a particular PVC, you can create a PVC like this:
         ```yaml
         apiVersion: v1


### PR DESCRIPTION
Fixes #8807

This PR adds a way to specify the desired VolumeSnapshotClass by annotation in the StorageClass.

An example use case here is Nutanix: The Nutanix CSI driver uses a single provisioner but allows for StorageClasses on either NFS (NutanixFiles) or Volumes (NutanixVolumes). These two StorageClasses require differently configured VolumeSnapshotClasses even though they use the same provisioner. 

In Velero, currently, this is only supported by setting an annotation on every PVC you want to back up. 

A more scalable approach is to allow setting a default for the StorageClass.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
