### PR TITLE
Make daemonset running error describe pod status

### DIFF
--- a/changelogs/unreleased/8793-kaovilai
+++ b/changelogs/unreleased/8793-kaovilai
@@ -1,0 +1,1 @@
+Make daemonset running error describe pod status (#8793)

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -1852,7 +1852,7 @@ end diagnose CSI exposer`,
 			expected: `begin diagnose CSI exposer
 Pod velero/fake-backup, phase Pending, node name fake-node, message 
 Pod condition Initialized, status True, reason , message fake-pod-message
-node-agent is not running in node fake-node, err: daemonset pod not found in running state in node fake-node
+node-agent is not running in node fake-node, err: daemonset pod not found in node fake-node
 PVC velero/fake-backup, phase Pending, binding to 
 VS velero/fake-backup, bind to , readyToUse false, errMessage 
 end diagnose CSI exposer`,

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -2008,7 +2008,7 @@ end diagnose CSI exposer`,
 			expected: `begin diagnose CSI exposer
 Pod velero/fake-backup, phase Pending, node name fake-node, message 
 Pod condition Initialized, status True, reason , message fake-pod-message
-node-agent is not running in node fake-node, err: daemonset pod not found in running state in node fake-node
+node-agent is not running in node fake-node, err: daemonset pod not found in node fake-node
 PVC velero/fake-backup, phase Pending, binding to 
 VS velero/fake-backup, bind to , readyToUse false, errMessage 
 end diagnose CSI exposer`,

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -1104,7 +1104,7 @@ end diagnose restore exposer`,
 			expected: `begin diagnose restore exposer
 Pod velero/fake-restore, phase Pending, node name fake-node, message 
 Pod condition Initialized, status True, reason , message fake-pod-message
-node-agent is not running in node fake-node, err: daemonset pod not found in running state in node fake-node
+node-agent is not running in node fake-node, err: daemonset pod not found in node fake-node
 PVC velero/fake-restore, phase Pending, binding to 
 end diagnose restore exposer`,
 		},

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -1354,7 +1354,7 @@ end diagnose restore exposer`,
 			expected: `begin diagnose restore exposer
 Pod velero/fake-restore, phase Pending, node name fake-node, message 
 Pod condition Initialized, status True, reason , message fake-pod-message
-node-agent is not running in node fake-node, err: daemonset pod not found in running state in node fake-node
+node-agent is not running in node fake-node, err: daemonset pod not found in node fake-node
 PVC velero/fake-restore, phase Pending, binding to 
 end diagnose restore exposer`,
 		},

--- a/pkg/exposer/pod_volume_test.go
+++ b/pkg/exposer/pod_volume_test.go
@@ -716,7 +716,7 @@ end diagnose pod volume exposer`,
 			expected: `begin diagnose pod volume exposer
 Pod velero/fake-backup, phase Pending, node name fake-node, message 
 Pod condition Initialized, status True, reason , message fake-pod-message
-node-agent is not running in node fake-node, err: daemonset pod not found in running state in node fake-node
+node-agent is not running in node fake-node, err: daemonset pod not found in node fake-node
 end diagnose pod volume exposer`,
 		},
 		{

--- a/pkg/nodeagent/node_agent.go
+++ b/pkg/nodeagent/node_agent.go
@@ -108,18 +108,27 @@ func isRunningInNode(ctx context.Context, namespace string, nodeName string, crC
 	if err != nil {
 		return errors.Wrap(err, "failed to list node-agent pods")
 	}
-
+	var podsOnNode []*corev1api.Pod
 	for i := range pods.Items {
-		if kube.IsPodRunning(&pods.Items[i]) != nil {
-			continue
-		}
-
 		if pods.Items[i].Spec.NodeName == nodeName {
-			return nil
+			podsOnNode = append(podsOnNode, &pods.Items[i])
 		}
 	}
 
-	return errors.Errorf("daemonset pod not found in running state in node %s", nodeName)
+	if len(podsOnNode) == 0 {
+		return errors.Errorf("daemonset pod not found in node %s", nodeName)
+	}
+
+	var lastError error
+	for _, pod := range podsOnNode {
+		if err := kube.IsPodRunning(pod); err == nil {
+			return nil
+		} else {
+			lastError = err
+		}
+	}
+
+	return errors.Wrapf(lastError, "daemonset pod not found in running state in node %s", nodeName)
 }
 
 func GetPodSpec(ctx context.Context, kubeClient kubernetes.Interface, namespace string, osType string) (*corev1api.PodSpec, error) {

--- a/pkg/nodeagent/node_agent.go
+++ b/pkg/nodeagent/node_agent.go
@@ -139,18 +139,27 @@ func isRunningInNode(ctx context.Context, namespace string, nodeName string, crC
 	if err != nil {
 		return errors.Wrap(err, "failed to list node-agent pods")
 	}
-
+	var podsOnNode []*corev1api.Pod
 	for i := range pods.Items {
-		if kube.IsPodRunning(&pods.Items[i]) != nil {
-			continue
-		}
-
 		if pods.Items[i].Spec.NodeName == nodeName {
-			return nil
+			podsOnNode = append(podsOnNode, &pods.Items[i])
 		}
 	}
 
-	return errors.Errorf("daemonset pod not found in running state in node %s", nodeName)
+	if len(podsOnNode) == 0 {
+		return errors.Errorf("daemonset pod not found in node %s", nodeName)
+	}
+
+	var lastError error
+	for _, pod := range podsOnNode {
+		if err := kube.IsPodRunning(pod); err == nil {
+			return nil
+		} else {
+			lastError = err
+		}
+	}
+
+	return errors.Wrapf(lastError, "daemonset pod not found in running state in node %s", nodeName)
 }
 
 func GetPodSpec(ctx context.Context, kubeClient kubernetes.Interface, namespace string, osType string) (*corev1api.PodSpec, error) {

--- a/pkg/nodeagent/node_agent_test.go
+++ b/pkg/nodeagent/node_agent_test.go
@@ -123,6 +123,16 @@ func TestIsRunningInNode(t *testing.T) {
 		Phase(corev1api.PodRunning).
 		NodeName("fake-node").
 		Result()
+	nodeAgentPodPending := builder.ForPod("fake-ns", "fake-pod-pending").
+		Labels(map[string]string{"role": "node-agent"}).
+		Phase(corev1api.PodPending).
+		NodeName("fake-node").
+		Result()
+	nodeAgentPodNotRunningOnNode := builder.ForPod("fake-ns", "fake-pod-not-running").
+		Labels(map[string]string{"role": "node-agent"}).
+		Phase(corev1api.PodPending).
+		NodeName("fake-node").
+		Result()
 
 	tests := []struct {
 		name          string
@@ -143,17 +153,17 @@ func TestIsRunningInNode(t *testing.T) {
 			kubeClientObj: []runtime.Object{
 				nonNodeAgentPod,
 			},
-			expectErr: "daemonset pod not found in running state in node fake-node",
+			expectErr: "daemonset pod not found in node fake-node",
 		},
 		{
-			name:      "ds po are not all running",
+			name:      "no pods on target node",
 			namespace: "fake-ns",
 			nodeName:  "fake-node",
 			kubeClientObj: []runtime.Object{
 				nodeAgentPodNotRunning,
 				nodeAgentPodRunning1,
 			},
-			expectErr: "daemonset pod not found in running state in node fake-node",
+			expectErr: "daemonset pod not found in node fake-node",
 		},
 		{
 			name:      "ds pods wrong node name",
@@ -164,7 +174,24 @@ func TestIsRunningInNode(t *testing.T) {
 				nodeAgentPodRunning1,
 				nodeAgentPodRunning2,
 			},
-			expectErr: "daemonset pod not found in running state in node fake-node",
+			expectErr: "daemonset pod not found in node fake-node",
+		},
+		{
+			name:     "all pods on node are not running",
+			nodeName: "fake-node",
+			kubeClientObj: []runtime.Object{
+				nodeAgentPodPending,
+				nodeAgentPodNotRunningOnNode,
+			},
+			expectErr: "daemonset pod not found in running state in node fake-node:",
+		},
+		{
+			name:     "multiple pods on node - one running",
+			nodeName: "fake-node",
+			kubeClientObj: []runtime.Object{
+				nodeAgentPodPending,
+				nodeAgentPodRunning3,
+			},
 		},
 		{
 			name:      "succeed",
@@ -184,7 +211,7 @@ func TestIsRunningInNode(t *testing.T) {
 			kubeClientObj: []runtime.Object{
 				nodeAgentPodOtherNs,
 			},
-			expectErr: "daemonset pod not found in running state in node fake-node",
+			expectErr: "daemonset pod not found in node fake-node",
 		},
 		{
 			name:      "cross-namespace isolation - pod in correct namespace on same node",
@@ -207,7 +234,11 @@ func TestIsRunningInNode(t *testing.T) {
 			if test.expectErr == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, test.expectErr)
+				if test.name == "all pods on node are not running" {
+					assert.Contains(t, err.Error(), test.expectErr)
+				} else {
+					assert.EqualError(t, err, test.expectErr)
+				}
 			}
 		})
 	}

--- a/pkg/nodeagent/node_agent_test.go
+++ b/pkg/nodeagent/node_agent_test.go
@@ -126,6 +126,16 @@ func TestIsRunningInNode(t *testing.T) {
 		Phase(corev1api.PodRunning).
 		NodeName("fake-node").
 		Result()
+	nodeAgentPodPending := builder.ForPod("fake-ns", "fake-pod-pending").
+		Labels(map[string]string{"role": "node-agent"}).
+		Phase(corev1api.PodPending).
+		NodeName("fake-node").
+		Result()
+	nodeAgentPodNotRunningOnNode := builder.ForPod("fake-ns", "fake-pod-not-running").
+		Labels(map[string]string{"role": "node-agent"}).
+		Phase(corev1api.PodPending).
+		NodeName("fake-node").
+		Result()
 
 	tests := []struct {
 		name          string
@@ -146,17 +156,17 @@ func TestIsRunningInNode(t *testing.T) {
 			kubeClientObj: []runtime.Object{
 				nonNodeAgentPod,
 			},
-			expectErr: "daemonset pod not found in running state in node fake-node",
+			expectErr: "daemonset pod not found in node fake-node",
 		},
 		{
-			name:      "ds po are not all running",
+			name:      "no pods on target node",
 			namespace: "fake-ns",
 			nodeName:  "fake-node",
 			kubeClientObj: []runtime.Object{
 				nodeAgentPodNotRunning,
 				nodeAgentPodRunning1,
 			},
-			expectErr: "daemonset pod not found in running state in node fake-node",
+			expectErr: "daemonset pod not found in node fake-node",
 		},
 		{
 			name:      "ds pods wrong node name",
@@ -167,7 +177,24 @@ func TestIsRunningInNode(t *testing.T) {
 				nodeAgentPodRunning1,
 				nodeAgentPodRunning2,
 			},
-			expectErr: "daemonset pod not found in running state in node fake-node",
+			expectErr: "daemonset pod not found in node fake-node",
+		},
+		{
+			name:     "all pods on node are not running",
+			nodeName: "fake-node",
+			kubeClientObj: []runtime.Object{
+				nodeAgentPodPending,
+				nodeAgentPodNotRunningOnNode,
+			},
+			expectErr: "daemonset pod not found in running state in node fake-node:",
+		},
+		{
+			name:     "multiple pods on node - one running",
+			nodeName: "fake-node",
+			kubeClientObj: []runtime.Object{
+				nodeAgentPodPending,
+				nodeAgentPodRunning3,
+			},
 		},
 		{
 			name:      "succeed",
@@ -187,7 +214,7 @@ func TestIsRunningInNode(t *testing.T) {
 			kubeClientObj: []runtime.Object{
 				nodeAgentPodOtherNs,
 			},
-			expectErr: "daemonset pod not found in running state in node fake-node",
+			expectErr: "daemonset pod not found in node fake-node",
 		},
 		{
 			name:      "cross-namespace isolation - pod in correct namespace on same node",
@@ -210,7 +237,11 @@ func TestIsRunningInNode(t *testing.T) {
 			if test.expectErr == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, test.expectErr)
+				if test.name == "all pods on node are not running" {
+					assert.Contains(t, err.Error(), test.expectErr)
+				} else {
+					assert.EqualError(t, err, test.expectErr)
+				}
 			}
 		})
 	}

--- a/pkg/podvolume/backupper_test.go
+++ b/pkg/podvolume/backupper_test.go
@@ -428,7 +428,7 @@ func TestBackupPodVolumes(t *testing.T) {
 			},
 			uploaderType: "kopia",
 			errs: []string{
-				"daemonset pod not found in running state in node fake-node-name",
+				"daemonset pod not found in node fake-node-name",
 			},
 		},
 		{

--- a/pkg/podvolume/backupper_test.go
+++ b/pkg/podvolume/backupper_test.go
@@ -430,7 +430,7 @@ func TestBackupPodVolumes(t *testing.T) {
 			},
 			uploaderType: "kopia",
 			errs: []string{
-				"daemonset pod not found in running state in node fake-node-name",
+				"daemonset pod not found in node fake-node-name",
 			},
 		},
 		{

--- a/pkg/podvolume/restorer_test.go
+++ b/pkg/podvolume/restorer_test.go
@@ -313,7 +313,7 @@ func TestRestorePodVolumes(t *testing.T) {
 			runtimeScheme:   scheme,
 			errs: []expectError{
 				{
-					err: "node-agent pod is not running in node fake-node-name: daemonset pod not found in running state in node fake-node-name",
+					err: "node-agent pod is not running in node fake-node-name: daemonset pod not found in node fake-node-name",
 				},
 			},
 		},

--- a/pkg/util/kube/pod.go
+++ b/pkg/util/kube/pod.go
@@ -54,7 +54,7 @@ type PodResources struct {
 func IsPodRunning(pod *corev1api.Pod) error {
 	return isPodScheduledInStatus(pod, func(pod *corev1api.Pod) error {
 		if pod.Status.Phase != corev1api.PodRunning {
-			return errors.New("pod is not running")
+			return errors.Errorf("pod is not running. phase: %s, reason: %s, message: %s", pod.Status.Phase, pod.Status.Reason, pod.Status.Message)
 		}
 
 		return nil
@@ -66,7 +66,7 @@ func IsPodRunning(pod *corev1api.Pod) error {
 func IsPodScheduled(pod *corev1api.Pod) error {
 	return isPodScheduledInStatus(pod, func(pod *corev1api.Pod) error {
 		if pod.Status.Phase != corev1api.PodRunning && pod.Status.Phase != corev1api.PodPending {
-			return errors.New("pod is not running or pending")
+			return errors.Errorf("pod is not running or pending. phase: %s, reason: %s, message: %s", pod.Status.Phase, pod.Status.Reason, pod.Status.Message)
 		}
 
 		return nil

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -181,7 +181,7 @@ func TestIsPodRunning(t *testing.T) {
 					Phase: "fake-phase",
 				},
 			},
-			err: "pod is not in the expected status, name=fake-pod, namespace=fake-ns, phase=fake-phase: pod is not running",
+			err: "pod is not in the expected status, name=fake-pod, namespace=fake-ns, phase=fake-phase: pod is not running. phase: fake-phase, reason: , message: ",
 		},
 		{
 			name: "pod is being deleted",
@@ -266,7 +266,7 @@ func TestIsPodScheduled(t *testing.T) {
 					Phase: "fake-phase",
 				},
 			},
-			err: "pod is not in the expected status, name=fake-pod, namespace=fake-ns, phase=fake-phase: pod is not running or pending",
+			err: "pod is not in the expected status, name=fake-pod, namespace=fake-ns, phase=fake-phase: pod is not running or pending. phase: fake-phase, reason: , message: ",
 		},
 		{
 			name: "pod is being deleted",

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -204,7 +204,7 @@ func TestIsPodRunning(t *testing.T) {
 					Phase: "fake-phase",
 				},
 			},
-			err: "pod is not in the expected status, name=fake-pod, namespace=fake-ns, phase=fake-phase: pod is not running",
+			err: "pod is not in the expected status, name=fake-pod, namespace=fake-ns, phase=fake-phase: pod is not running. phase: fake-phase, reason: , message: ",
 		},
 		{
 			name: "pod is being deleted",
@@ -289,7 +289,7 @@ func TestIsPodScheduled(t *testing.T) {
 					Phase: "fake-phase",
 				},
 			},
-			err: "pod is not in the expected status, name=fake-pod, namespace=fake-ns, phase=fake-phase: pod is not running or pending",
+			err: "pod is not in the expected status, name=fake-pod, namespace=fake-ns, phase=fake-phase: pod is not running or pending. phase: fake-phase, reason: , message: ",
 		},
 		{
 			name: "pod is being deleted",


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai

# Summary

Makes the "daemonset not running" error describe actual pod status instead of a generic message, so operators can diagnose node-agent issues faster.

- `isRunningInNode` now distinguishes "no node-agent pod found on node" from "node-agent pod(s) found on node but none running", including the underlying pod status in the latter (wrapped, not string-flattened, so the error chain stays unwrappable via `errors.Is`/`As`).
- `IsRunningInNode`/`KbClientIsRunningInNode` take a `namespace` parameter to avoid matching node-agent pods from another namespace on the same node.
- `IsPodRunning`/`IsPodScheduled` errors now report concise phase/reason/message fields instead of dumping the full `PodStatus` (avoids leaking PodIP/HostIP and being brittle across Kubernetes API version bumps).

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
