### PR TITLE
docs: Document --write-sparse-files flag for disk space issues during restore

### DIFF
--- a/changelogs/unreleased/9221-kaovilai
+++ b/changelogs/unreleased/9221-kaovilai
@@ -1,0 +1,1 @@
+docs: Add documentation about --write-sparse-files flag for disk space issues during restore

--- a/site/content/docs/main/file-system-backup.md
+++ b/site/content/docs/main/file-system-backup.md
@@ -602,6 +602,12 @@ To understand which backup method was used for your volumes:
 
 **Note:** A volume appearing in the "skipped PVs" summary doesn't mean it wasn't backed up - it may have been backed up via volume snapshot instead.
 
+### Disk space issues during restore
+
+If restores fail due to "no space left on device" errors, the `--write-sparse-files` option may help in specific scenarios. However, this only works if the persistent volume had sparse files during backup that would free up enough space for the restore process. If the volume doesn't contain sparse files, this option will not resolve the disk space issue.
+
+For more information, see [Write Sparse files](restore-reference.md#write-sparse-files) in the restore documentation.
+
 ## Backup Method Decision Flow
 
 When Velero encounters a volume during backup, it follows this decision flow:

--- a/site/content/docs/main/troubleshooting.md
+++ b/site/content/docs/main/troubleshooting.md
@@ -250,6 +250,24 @@ To resolve it, please use Kopia maintenance CLI to set the ownership correctly, 
 
 Please refer to [Issue 9007](https://github.com/velero-io/velero/issues/9007) for more information.
 
+## Disk space issues during restore
+
+If you encounter "no space left on device" errors during restore, the `--write-sparse-files` flag may help in certain scenarios.
+
+Example error message:
+```
+Velero: pod volume restore failed: error restoring volume: error creating .velero directory for done file: mkdir /host_pods/60880bf2-9d1c-47cf-ba8f-5f8db43b385b/volumes/kubernetes.io~csi/pvc-ee79e0f0-ed62-44f7-987e-16efca1d1cd5/mount/.velero: no space left on device
+```
+
+**Important Limitation**: The `--write-sparse-files` flag only works if the persistent volume had sparse files during backup that would free up enough space for the done file. If the volume doesn't contain sparse files, this option will not resolve the disk space issue.
+
+To try using sparse files during restore:
+```bash
+velero restore create <RESTORE_NAME> --from-backup <BACKUP_NAME> --write-sparse-files
+```
+
+See [Write Sparse files](restore-reference.md#write-sparse-files) for more details on using this option.
+
 [1]: debugging-restores.md
 [2]: debugging-install.md
 [3]: file-system-backup.md


### PR DESCRIPTION
- Added cross-references in troubleshooting.md and file-system-backup.md to the Write Sparse files documentation
- Documented how to use --write-sparse-files flag when restores fail due to disk space constraints
- Documentation-only approach per reviewer feedback

Fixes #2812 by providing clear guidance to users when restores fail due to disk space constraints.

The `--write-sparse-files` flag already exists and can help when restoring to volumes that are nearly full, but it only works if the PV had sparse files during backup. This PR adds documentation to help users discover this option when they encounter disk space issues.

**Note**: This is a documentation-only PR. An alternative approach to fundamentally solve the problem is being pursued in PR #9222.

> [!Note]
> Responses generated with Claude

Thank you for contributing to Velero!

# Summary

This PR adds documentation about the `--write-sparse-files` flag to help users when they encounter disk space issues during restore operations. The documentation is added in two places:
1. In the troubleshooting guide with a specific example
2. In the file system backup documentation with a cross-reference

# Does your change fix a particular issue?

Addresses #2812 

Alternative approach: https://github.com/vmware-tanzu/velero/pull/9222

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.