### PR TITLE
Fix BackupRepositories becoming stale when BSL config changes while Velero is not running

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -101,7 +101,8 @@ jobs:
               \"Basic && (ClusterResource || NodePort || StorageClass)\", \
               \"ResourceFiltering && !FSBackup\", \
               \"ResourceModifier || (Backups && BackupsSync) || PrivilegesMgmt || OrderedResources\", \
-              \"(NamespaceMapping && Single && FSBackup) || (NamespaceMapping && Multiple && FSBackup)\"\
+              \"(NamespaceMapping && Single && FSBackup) || (NamespaceMapping && Multiple && FSBackup)\", \
+              \"BSL && BackupRepository && StartupValidation\"\
             ]}" >> $GITHUB_OUTPUT
 
   # Run E2E test against all Kubernetes versions on kind

--- a/changelogs/unreleased/9236-kaovilai
+++ b/changelogs/unreleased/9236-kaovilai
@@ -1,0 +1,1 @@
+Fix BackupRepositories becoming stale when BSL config changes while Velero is not running

--- a/pkg/apis/velero/v1/labels_annotations.go
+++ b/pkg/apis/velero/v1/labels_annotations.go
@@ -54,6 +54,12 @@ const (
 	// RepositoryTypeLabel is the label key used to identify the type of a repository
 	RepositoryTypeLabel = "velero.io/repository-type"
 
+	// BSLConfigHashAnnotation records a hash of the BSL storage config (bucket, prefix,
+	// CA certificate and config) that a BackupRepository was last made Ready against, so
+	// that BSL changes not observed by the server (e.g. made while it was not running)
+	// can be detected on reconciliation.
+	BSLConfigHashAnnotation = "velero.io/bsl-config-hash"
+
 	// DataUploadLabel is the label key used to identify the dataupload for snapshot backup pod
 	DataUploadLabel = "velero.io/data-upload"
 

--- a/pkg/controller/backup_repository_controller.go
+++ b/pkg/controller/backup_repository_controller.go
@@ -17,11 +17,12 @@ limitations under the License.
 package controller
 
 import (
-	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"reflect"
+	"maps"
 	"slices"
 	"time"
 
@@ -53,6 +54,8 @@ const (
 	repoSyncPeriod                      = 5 * time.Minute
 	defaultMaintainFrequency            = 7 * 24 * time.Hour
 	defaultMaintenanceStatusQueueLength = 25
+
+	msgBSLConfigChanged = "BSL config has changed (possibly while the Velero server was not running), re-establishing repository"
 )
 
 var maintenanceStatusQueueLength = defaultMaintenanceStatusQueueLength
@@ -113,8 +116,9 @@ func (r *BackupRepoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&velerov1api.BackupRepository{}, builder.WithPredicates(kube.SpecChangePredicate{})).
 		WatchesRawSource(s).
 		Watches(
-			// mark BackupRepository as invalid when BSL is created, updated or deleted.
-			// BSL may be recreated after deleting, so also include the create event
+			// mark BackupRepository as invalid when BSL is updated or deleted.
+			// BSL may be recreated after deleting, so Create events are handled
+			// by the dedicated watch below.
 			&velerov1api.BackupStorageLocation{},
 			kube.EnqueueRequestsFromMapUpdateFunc(r.invalidateBackupReposForBSL),
 			builder.WithPredicates(
@@ -134,19 +138,52 @@ func (r *BackupRepoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				),
 			),
 		).
+		Watches(
+			// BSL Create events fire for every existing BSL when the controller
+			// (re)starts, so they are the hook to detect a BSL that was modified or
+			// recreated while the server was not running: repositories whose recorded
+			// BSL config hash no longer matches the BSL are invalidated. Only Ready
+			// repositories with a recorded hash are considered, so a restart with an
+			// unchanged BSL invalidates nothing.
+			&velerov1api.BackupStorageLocation{},
+			kube.EnqueueRequestsFromMapUpdateFunc(r.invalidateStaleReposForBSLOnCreate),
+			builder.WithPredicates(
+				kube.NewCreateEventPredicate(
+					func(client.Object) bool { return true },
+				),
+				kube.NewUpdateEventPredicate(
+					func(client.Object, client.Object) bool { return false },
+				),
+				kube.NewGenericEventPredicate(
+					func(client.Object) bool { return false },
+				),
+				kube.NewDeleteEventPredicate(
+					func(client.Object) bool { return false },
+				),
+			),
+		).
 		Complete(r)
+}
+
+// backupReposForBSL lists the BackupRepositories labeled with the given BSL's name.
+func (r *BackupRepoReconciler) backupReposForBSL(ctx context.Context, bslName string) (*velerov1api.BackupRepositoryList, error) {
+	list := &velerov1api.BackupRepositoryList{}
+	options := &client.ListOptions{
+		LabelSelector: labels.Set(map[string]string{
+			velerov1api.StorageLocationLabel: label.GetValidName(bslName),
+		}).AsSelector(),
+	}
+	if err := r.List(ctx, list, options); err != nil {
+		return nil, err
+	}
+	return list, nil
 }
 
 func (r *BackupRepoReconciler) invalidateBackupReposForBSL(ctx context.Context, bslObj client.Object) []reconcile.Request {
 	bsl := bslObj.(*velerov1api.BackupStorageLocation)
 
-	list := &velerov1api.BackupRepositoryList{}
-	options := &client.ListOptions{
-		LabelSelector: labels.Set(map[string]string{
-			velerov1api.StorageLocationLabel: label.GetValidName(bsl.Name),
-		}).AsSelector(),
-	}
-	if err := r.List(context.TODO(), list, options); err != nil {
+	list, err := r.backupReposForBSL(ctx, bsl.Name)
+	if err != nil {
 		r.logger.WithField("BSL", bsl.Name).WithError(err).Error("unable to list BackupRepositories")
 		return []reconcile.Request{}
 	}
@@ -164,67 +201,65 @@ func (r *BackupRepoReconciler) invalidateBackupReposForBSL(ctx context.Context, 
 	return requests
 }
 
-// needInvalidBackupRepo returns true if the BSL's storage type, bucket, prefix, CACert, or config has changed
+// invalidateStaleReposForBSLOnCreate handles BSL Create events, which fire for every
+// existing BSL when the controller (re)starts. It invalidates Ready BackupRepositories
+// whose recorded BSL config hash no longer matches the BSL, i.e. the BSL was modified
+// or recreated without the BSL watch observing it (e.g. while the server was not
+// running). Repositories in other phases or without a recorded hash are left untouched.
+func (r *BackupRepoReconciler) invalidateStaleReposForBSLOnCreate(ctx context.Context, bslObj client.Object) []reconcile.Request {
+	bsl := bslObj.(*velerov1api.BackupStorageLocation)
+
+	list, err := r.backupReposForBSL(ctx, bsl.Name)
+	if err != nil {
+		r.logger.WithField("BSL", bsl.Name).WithError(err).Error("unable to list BackupRepositories")
+		return []reconcile.Request{}
+	}
+
+	currentHash := bslConfigHash(bsl)
+
+	requests := []reconcile.Request{}
+	for i := range list.Items {
+		repo := &list.Items[i]
+		if repo.Status.Phase != velerov1api.BackupRepositoryPhaseReady {
+			continue
+		}
+
+		storedHash := repo.Annotations[velerov1api.BSLConfigHashAnnotation]
+		if storedHash == "" || storedHash == currentHash {
+			continue
+		}
+
+		r.logger.WithField("BSL", bsl.Name).Infof("BSL config has changed since Backup Repository %s became ready, invalidating it", repo.Name)
+		if err := r.patchBackupRepository(ctx, repo, repoNotReady(msgBSLConfigChanged)); err != nil {
+			r.logger.WithField("BSL", bsl.Name).WithError(err).Errorf("fail to patch BackupRepository %s", repo.Name)
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: repo.Namespace, Name: repo.Name}})
+	}
+
+	return requests
+}
+
+// needInvalidBackupRepo returns true if the BSL's bucket, prefix, CACert, CACertRef,
+// or config has changed, using the same bslConfigHash comparison as the BSL Create
+// event handling.
 func (r *BackupRepoReconciler) needInvalidBackupRepo(oldObj client.Object, newObj client.Object) bool {
 	oldBSL := oldObj.(*velerov1api.BackupStorageLocation)
 	newBSL := newObj.(*velerov1api.BackupStorageLocation)
 
-	oldStorage := oldBSL.Spec.StorageType.ObjectStorage
-	newStorage := newBSL.Spec.StorageType.ObjectStorage
-	oldConfig := oldBSL.Spec.Config
-	newConfig := newBSL.Spec.Config
-
-	if oldStorage == nil {
-		oldStorage = &velerov1api.ObjectStorageLocation{}
+	oldHash := bslConfigHash(oldBSL)
+	newHash := bslConfigHash(newBSL)
+	if oldHash == newHash {
+		return false
 	}
 
-	if newStorage == nil {
-		newStorage = &velerov1api.ObjectStorageLocation{}
-	}
+	r.logger.WithFields(logrus.Fields{
+		"BSL":      newBSL.Name,
+		"old hash": oldHash,
+		"new hash": newHash,
+	}).Info("BSL's storage config has changed, invalid backup repositories")
 
-	logger := r.logger.WithField("BSL", newBSL.Name)
-
-	if oldStorage.Bucket != newStorage.Bucket {
-		logger.WithFields(logrus.Fields{
-			"old bucket": oldStorage.Bucket,
-			"new bucket": newStorage.Bucket,
-		}).Info("BSL's bucket has changed, invalid backup repositories")
-
-		return true
-	}
-
-	if oldStorage.Prefix != newStorage.Prefix {
-		logger.WithFields(logrus.Fields{
-			"old prefix": oldStorage.Prefix,
-			"new prefix": newStorage.Prefix,
-		}).Info("BSL's prefix has changed, invalid backup repositories")
-
-		return true
-	}
-
-	// Check if either CACert or CACertRef has changed
-	if !bytes.Equal(oldStorage.CACert, newStorage.CACert) {
-		logger.Info("BSL's CACert has changed, invalid backup repositories")
-		return true
-	}
-
-	// Check if CACertRef has changed
-	if (oldStorage.CACertRef == nil && newStorage.CACertRef != nil) ||
-		(oldStorage.CACertRef != nil && newStorage.CACertRef == nil) ||
-		(oldStorage.CACertRef != nil && newStorage.CACertRef != nil &&
-			(oldStorage.CACertRef.Name != newStorage.CACertRef.Name ||
-				oldStorage.CACertRef.Key != newStorage.CACertRef.Key)) {
-		logger.Info("BSL's CACertRef has changed, invalid backup repositories")
-		return true
-	}
-
-	if !reflect.DeepEqual(oldConfig, newConfig) {
-		logger.Info("BSL's storage config has changed, invalid backup repositories")
-
-		return true
-	}
-
-	return false
+	return true
 }
 
 func (r *BackupRepoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -250,7 +285,7 @@ func (r *BackupRepoReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if backupRepo.Status.Phase == "" || backupRepo.Status.Phase == velerov1api.BackupRepositoryPhaseNew {
-		if err := r.initializeRepo(ctx, backupRepo, log); err != nil {
+		if err := r.initializeRepo(ctx, backupRepo, bsl, log); err != nil {
 			log.WithError(err).Error("error initialize repository")
 			return ctrl.Result{}, errors.WithStack(err)
 		}
@@ -268,7 +303,7 @@ func (r *BackupRepoReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	switch backupRepo.Status.Phase {
 	case velerov1api.BackupRepositoryPhaseNotReady:
-		ready, err := r.checkNotReadyRepo(ctx, backupRepo, log)
+		ready, err := r.checkNotReadyRepo(ctx, backupRepo, bsl, log)
 		if err != nil {
 			return ctrl.Result{}, err
 		} else if !ready {
@@ -316,7 +351,35 @@ func (r *BackupRepoReconciler) getBSL(ctx context.Context, req *velerov1api.Back
 	return loc, nil
 }
 
-func (r *BackupRepoReconciler) initializeRepo(ctx context.Context, req *velerov1api.BackupRepository, log logrus.FieldLogger) error {
+// bslConfigHash returns a stable hash of the BSL fields that determine where a backup
+// repository lives and how it is connected to. It covers the same fields as
+// needInvalidBackupRepo, which detects BSL changes at runtime.
+func bslConfigHash(bsl *velerov1api.BackupStorageLocation) string {
+	storage := bsl.Spec.StorageType.ObjectStorage
+	if storage == nil {
+		storage = &velerov1api.ObjectStorageLocation{}
+	}
+
+	h := sha256.New()
+	fmt.Fprintf(h, "bucket=%s\nprefix=%s\ncaCert=%x\n", storage.Bucket, storage.Prefix, storage.CACert)
+	if storage.CACertRef != nil {
+		fmt.Fprintf(h, "caCertRef=%s/%s\n", storage.CACertRef.Name, storage.CACertRef.Key)
+	}
+	for _, k := range slices.Sorted(maps.Keys(bsl.Spec.Config)) {
+		fmt.Fprintf(h, "config.%s=%s\n", k, bsl.Spec.Config[k])
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func setBSLConfigHash(repo *velerov1api.BackupRepository, hash string) {
+	if repo.Annotations == nil {
+		repo.Annotations = map[string]string{}
+	}
+	repo.Annotations[velerov1api.BSLConfigHashAnnotation] = hash
+}
+
+func (r *BackupRepoReconciler) initializeRepo(ctx context.Context, req *velerov1api.BackupRepository, bsl *velerov1api.BackupStorageLocation, log logrus.FieldLogger) error {
 	log.WithField("repoConfig", r.backupRepoConfig).Info("Initializing backup repository")
 
 	config, err := getBackupRepositoryConfig(ctx, r, r.backupRepoConfig, r.namespace, req.Name, req.Spec.RepositoryType, log)
@@ -344,6 +407,7 @@ func (r *BackupRepoReconciler) initializeRepo(ctx context.Context, req *velerov1
 	return r.patchBackupRepository(ctx, req, func(rr *velerov1api.BackupRepository) {
 		rr.Status.Phase = velerov1api.BackupRepositoryPhaseReady
 		rr.Status.LastMaintenanceTime = &metav1.Time{Time: time.Now()}
+		setBSLConfigHash(rr, bslConfigHash(bsl))
 	})
 }
 
@@ -550,7 +614,7 @@ func dueForMaintenance(req *velerov1api.BackupRepository, now time.Time) bool {
 	return req.Status.LastMaintenanceTime == nil || req.Status.LastMaintenanceTime.Add(req.Spec.MaintenanceFrequency.Duration).Before(now)
 }
 
-func (r *BackupRepoReconciler) checkNotReadyRepo(ctx context.Context, req *velerov1api.BackupRepository, log logrus.FieldLogger) (bool, error) {
+func (r *BackupRepoReconciler) checkNotReadyRepo(ctx context.Context, req *velerov1api.BackupRepository, bsl *velerov1api.BackupStorageLocation, log logrus.FieldLogger) (bool, error) {
 	log.Info("Checking backup repository for readiness")
 
 	// we need to ensure it (first check, if check fails, attempt to init)
@@ -558,7 +622,10 @@ func (r *BackupRepoReconciler) checkNotReadyRepo(ctx context.Context, req *veler
 	if err := ensureRepo(req, r.repositoryManager); err != nil {
 		return false, r.patchBackupRepository(ctx, req, repoNotReady(err.Error()))
 	}
-	err := r.patchBackupRepository(ctx, req, repoReady())
+	err := r.patchBackupRepository(ctx, req, func(rr *velerov1api.BackupRepository) {
+		repoReady()(rr)
+		setBSLConfigHash(rr, bslConfigHash(bsl))
+	})
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/backup_repository_controller_test.go
+++ b/pkg/controller/backup_repository_controller_test.go
@@ -34,6 +34,7 @@ import (
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/builder"
+	"github.com/vmware-tanzu/velero/pkg/label"
 	"github.com/vmware-tanzu/velero/pkg/metrics"
 	"github.com/vmware-tanzu/velero/pkg/repository"
 	"github.com/vmware-tanzu/velero/pkg/repository/maintenance"
@@ -84,6 +85,27 @@ func mockBackupRepositoryCR() *velerov1api.BackupRepository {
 	}
 }
 
+func mockBackupStorageLocationCR() *velerov1api.BackupStorageLocation {
+	return &velerov1api.BackupStorageLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: velerov1api.DefaultNamespace,
+			Name:      "default",
+		},
+		Spec: velerov1api.BackupStorageLocationSpec{
+			Provider: "aws",
+			StorageType: velerov1api.StorageType{
+				ObjectStorage: &velerov1api.ObjectStorageLocation{
+					Bucket: "test-bucket",
+					Prefix: "test-prefix",
+				},
+			},
+			Config: map[string]string{
+				"region": "us-east-1",
+			},
+		},
+	}
+}
+
 func TestPatchBackupRepository(t *testing.T) {
 	rr := mockBackupRepositoryCR()
 	reconciler := mockBackupRepoReconciler(t, "", nil, nil)
@@ -108,11 +130,15 @@ func TestCheckNotReadyRepo(t *testing.T) {
 		err := reconciler.Client.Create(t.Context(), rr)
 		require.NoError(t, err)
 
-		_, err = reconciler.checkNotReadyRepo(t.Context(), rr, reconciler.logger)
+		bsl := mockBackupStorageLocationCR()
+
+		_, err = reconciler.checkNotReadyRepo(t.Context(), rr, bsl, reconciler.logger)
 		require.NoError(t, err)
 		assert.Equal(t, velerov1api.BackupRepositoryPhaseReady, rr.Status.Phase)
 		// ResticIdentifier should remain empty for kopia
 		assert.Empty(t, rr.Spec.ResticIdentifier)
+		// the BSL config hash should be recorded when the repo becomes ready
+		assert.Equal(t, bslConfigHash(bsl), rr.Annotations[velerov1api.BSLConfigHashAnnotation])
 	})
 }
 
@@ -403,9 +429,172 @@ func TestInitializeRepo(t *testing.T) {
 	err := reconciler.Client.Create(t.Context(), rr)
 	require.NoError(t, err)
 
-	err = reconciler.initializeRepo(t.Context(), rr, reconciler.logger)
+	bsl := mockBackupStorageLocationCR()
+
+	err = reconciler.initializeRepo(t.Context(), rr, bsl, reconciler.logger)
 	require.NoError(t, err)
 	assert.Equal(t, velerov1api.BackupRepositoryPhaseReady, rr.Status.Phase)
+	// the BSL config hash should be recorded when the repo becomes ready
+	assert.Equal(t, bslConfigHash(bsl), rr.Annotations[velerov1api.BSLConfigHashAnnotation])
+}
+
+func TestBSLConfigHash(t *testing.T) {
+	baseHash := bslConfigHash(mockBackupStorageLocationCR())
+
+	assert.Equal(t, baseHash, bslConfigHash(mockBackupStorageLocationCR()), "hash should be deterministic")
+
+	mutations := []struct {
+		name   string
+		mutate func(*velerov1api.BackupStorageLocation)
+	}{
+		{
+			name:   "bucket change",
+			mutate: func(bsl *velerov1api.BackupStorageLocation) { bsl.Spec.ObjectStorage.Bucket = "other-bucket" },
+		},
+		{
+			name:   "prefix change",
+			mutate: func(bsl *velerov1api.BackupStorageLocation) { bsl.Spec.ObjectStorage.Prefix = "other-prefix" },
+		},
+		{
+			name:   "CACert change",
+			mutate: func(bsl *velerov1api.BackupStorageLocation) { bsl.Spec.ObjectStorage.CACert = []byte("fake-cert") },
+		},
+		{
+			name: "CACertRef change",
+			mutate: func(bsl *velerov1api.BackupStorageLocation) {
+				bsl.Spec.ObjectStorage.CACertRef = &corev1api.SecretKeySelector{
+					LocalObjectReference: corev1api.LocalObjectReference{Name: "cert-secret"},
+					Key:                  "ca.crt",
+				}
+			},
+		},
+		{
+			name:   "config change",
+			mutate: func(bsl *velerov1api.BackupStorageLocation) { bsl.Spec.Config["region"] = "us-west-2" },
+		},
+	}
+	for _, test := range mutations {
+		t.Run(test.name, func(t *testing.T) {
+			bsl := mockBackupStorageLocationCR()
+			test.mutate(bsl)
+			assert.NotEqual(t, baseHash, bslConfigHash(bsl))
+		})
+	}
+
+	t.Run("fields not affecting repo connectivity don't change the hash", func(t *testing.T) {
+		bsl := mockBackupStorageLocationCR()
+		bsl.Spec.Provider = "other-provider"
+		bsl.Spec.AccessMode = velerov1api.BackupStorageLocationAccessModeReadOnly
+		bsl.Spec.Credential = &corev1api.SecretKeySelector{
+			LocalObjectReference: corev1api.LocalObjectReference{Name: "creds"},
+			Key:                  "cloud",
+		}
+		assert.Equal(t, baseHash, bslConfigHash(bsl))
+	})
+
+	t.Run("nil object storage", func(t *testing.T) {
+		bsl := mockBackupStorageLocationCR()
+		bsl.Spec.StorageType.ObjectStorage = nil
+		bsl.Spec.Config = nil
+		assert.NotEmpty(t, bslConfigHash(bsl))
+		assert.NotEqual(t, baseHash, bslConfigHash(bsl))
+	})
+}
+
+func TestInvalidateStaleReposForBSLOnCreate(t *testing.T) {
+	bsl := mockBackupStorageLocationCR()
+
+	repoForBSL := func(name string, phase velerov1api.BackupRepositoryPhase, hash string) *velerov1api.BackupRepository {
+		repo := &velerov1api.BackupRepository{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: velerov1api.DefaultNamespace,
+				Name:      name,
+				Labels: map[string]string{
+					velerov1api.StorageLocationLabel: label.GetValidName(bsl.Name),
+				},
+			},
+			Spec: velerov1api.BackupRepositorySpec{
+				BackupStorageLocation: bsl.Name,
+			},
+			Status: velerov1api.BackupRepositoryStatus{
+				Phase: phase,
+			},
+		}
+		if hash != "" {
+			repo.Annotations = map[string]string{velerov1api.BSLConfigHashAnnotation: hash}
+		}
+		return repo
+	}
+
+	tests := []struct {
+		name             string
+		repo             *velerov1api.BackupRepository
+		expectInvalidate bool
+	}{
+		{
+			name:             "ready repo with mismatched hash is invalidated",
+			repo:             repoForBSL("repo", velerov1api.BackupRepositoryPhaseReady, "stale-hash"),
+			expectInvalidate: true,
+		},
+		{
+			name: "ready repo with matching hash is untouched",
+			repo: repoForBSL("repo", velerov1api.BackupRepositoryPhaseReady, bslConfigHash(bsl)),
+		},
+		{
+			name: "ready repo without hash is untouched",
+			repo: repoForBSL("repo", velerov1api.BackupRepositoryPhaseReady, ""),
+		},
+		{
+			name: "not-ready repo is untouched",
+			repo: repoForBSL("repo", velerov1api.BackupRepositoryPhaseNotReady, "stale-hash"),
+		},
+		{
+			name: "repo of another BSL is untouched",
+			repo: func() *velerov1api.BackupRepository {
+				repo := repoForBSL("repo", velerov1api.BackupRepositoryPhaseReady, "stale-hash")
+				repo.Labels[velerov1api.StorageLocationLabel] = "other-bsl"
+				return repo
+			}(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reconciler := mockBackupRepoReconciler(t, "", nil, nil)
+			require.NoError(t, reconciler.Client.Create(t.Context(), test.repo))
+
+			originalPhase := test.repo.Status.Phase
+			requests := reconciler.invalidateStaleReposForBSLOnCreate(t.Context(), bsl)
+
+			after := &velerov1api.BackupRepository{}
+			require.NoError(t, reconciler.Client.Get(t.Context(), types.NamespacedName{Namespace: test.repo.Namespace, Name: test.repo.Name}, after))
+
+			if test.expectInvalidate {
+				assert.Len(t, requests, 1)
+				assert.Equal(t, velerov1api.BackupRepositoryPhaseNotReady, after.Status.Phase)
+				assert.Equal(t, msgBSLConfigChanged, after.Status.Message)
+			} else {
+				assert.Empty(t, requests)
+				assert.Equal(t, originalPhase, after.Status.Phase)
+				assert.Empty(t, after.Status.Message)
+			}
+		})
+	}
+
+	t.Run("list error returns no requests", func(t *testing.T) {
+		reconciler := NewBackupRepoReconciler(
+			velerov1api.DefaultNamespace,
+			velerotest.NewLogger(),
+			clientFake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+			nil,
+			testMaintenanceFrequency,
+			"",
+			"",
+			logrus.InfoLevel,
+			nil,
+			nil,
+		)
+		assert.Empty(t, reconciler.invalidateStaleReposForBSLOnCreate(t.Context(), bsl))
+	})
 }
 
 func TestBackupRepoReconcile(t *testing.T) {
@@ -1580,12 +1769,13 @@ func TestInitializeRepoWithRepositoryTypes(t *testing.T) {
 			nil,
 		)
 
-		err := reconciler.initializeRepo(t.Context(), rr, reconciler.logger)
+		err := reconciler.initializeRepo(t.Context(), rr, location, reconciler.logger)
 		require.NoError(t, err)
 
 		// Verify ResticIdentifier is NOT set for kopia
 		assert.Empty(t, rr.Spec.ResticIdentifier)
 		assert.Equal(t, velerov1api.BackupRepositoryPhaseReady, rr.Status.Phase)
+		assert.Equal(t, bslConfigHash(location), rr.Annotations[velerov1api.BSLConfigHashAnnotation])
 	})
 }
 

--- a/pkg/util/kube/predicate.go
+++ b/pkg/util/kube/predicate.go
@@ -117,3 +117,14 @@ func NewCreateEventPredicate(
 		},
 	}
 }
+
+// NewDeleteEventPredicate creates a new Predicate that checks the Delete event with the provided func
+func NewDeleteEventPredicate(
+	f func(object client.Object) bool,
+) predicate.Predicate {
+	return predicate.Funcs{
+		DeleteFunc: func(event event.DeleteEvent) bool {
+			return f(event.Object)
+		},
+	}
+}

--- a/test/e2e/bsl-mgmt/startup_validation.go
+++ b/test/e2e/bsl-mgmt/startup_validation.go
@@ -1,0 +1,341 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package bslmgmt
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+
+	. "github.com/vmware-tanzu/velero/test"
+	. "github.com/vmware-tanzu/velero/test/util/k8s"
+	. "github.com/vmware-tanzu/velero/test/util/providers"
+	. "github.com/vmware-tanzu/velero/test/util/velero"
+)
+
+func BackupRepoStartupValidationTest() {
+	var veleroCfg VeleroConfig
+	veleroCfg = VeleroCfg
+
+	BeforeEach(func() {
+		if InstallVelero {
+			Expect(PrepareVelero(context.Background(), "BackupRepo Startup Validation", veleroCfg)).To(Succeed())
+		}
+	})
+
+	AfterEach(func() {
+		if !CurrentSpecReport().Failed() || !veleroCfg.FailFast {
+			By("Clean backups after test", func() {
+				DeleteAllBackups(context.Background(), &veleroCfg)
+			})
+		}
+	})
+
+	When("BSL prefix changes while Velero is not running", func() {
+		It("should invalidate stale BackupRepositories on startup and recover", func() {
+			ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Minute)
+			defer ctxCancel()
+
+			ns := "startup-validation"
+			By("Create test namespace", func() {
+				Expect(CreateNamespace(ctx, *veleroCfg.ClientToInstallVelero, ns)).To(Succeed())
+			})
+			defer func() {
+				_ = DeleteNamespace(context.Background(), *veleroCfg.ClientToInstallVelero, ns, true)
+			}()
+
+			podName := "startup-val-pod"
+			By("Create a pod with PVC so FSBackup creates a BackupRepository", func() {
+				_, err := CreatePod(
+					*veleroCfg.ClientToInstallVelero,
+					ns, podName, "", "",
+					[]string{"startup-val-vol"},
+					nil, nil,
+					veleroCfg.ImageRegistryProxy,
+					"",
+				)
+				Expect(err).To(Succeed())
+			})
+
+			By("Wait for pod to be running", func() {
+				Expect(WaitForPods(ctx, *veleroCfg.ClientToInstallVelero, ns, []string{podName})).To(Succeed())
+			})
+
+			backupCfg := BackupConfig{
+				BackupName:               "startup-val-backup",
+				Namespace:                ns,
+				BackupLocation:           "default",
+				DefaultVolumesToFsBackup: true,
+				UseVolumeSnapshots:       false,
+			}
+
+			By("Create a kopia backup to establish BackupRepository", func() {
+				Expect(VeleroBackupNamespace(ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, backupCfg)).To(Succeed(), func() string {
+					RunDebug(ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, backupCfg.BackupName, "")
+					return "Fail to backup workload"
+				})
+			})
+
+			originalHash := ""
+			By("Verify BackupRepository exists and is Ready with the BSL config hash recorded", func() {
+				repos, err := KubectlGetBackupRepository(ctx, "kopia", veleroCfg.VeleroNamespace)
+				Expect(err).To(Succeed())
+				Expect(repos).NotTo(BeEmpty(), "Expected at least one backup repository")
+
+				Eventually(func() string {
+					originalHash = kopiaRepoConfigHash(ctx, veleroCfg.VeleroNamespace, ns)
+					return originalHash
+				}, 2*time.Minute, 5*time.Second).ShouldNot(BeEmpty(),
+					"BackupRepository should have the BSL config hash recorded")
+			})
+
+			By("Scale down Velero deployment to 0", func() {
+				cmd := exec.CommandContext(ctx, "kubectl", "scale", "deployment/velero",
+					"-n", veleroCfg.VeleroNamespace, "--replicas=0")
+				output, err := cmd.CombinedOutput()
+				if err != nil {
+					fmt.Printf("scale down output: %s\n", string(output))
+				}
+				Expect(err).To(Succeed())
+			})
+
+			// Ensure Velero is scaled back up even if an assertion below fails
+			defer func() {
+				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer cleanupCancel()
+				cmd := exec.CommandContext(cleanupCtx, "kubectl", "scale", "deployment/velero",
+					"-n", veleroCfg.VeleroNamespace, "--replicas=1")
+				if output, err := cmd.CombinedOutput(); err != nil {
+					fmt.Printf("warning: failed to scale velero back up: %s\n", string(output))
+				}
+			}()
+
+			By("Wait for Velero pods to terminate", func() {
+				Eventually(func() bool {
+					cmd := exec.CommandContext(ctx, "kubectl", "get", "pods",
+						"-n", veleroCfg.VeleroNamespace, "-l", "deploy=velero",
+						"--no-headers")
+					// only stdout: with zero pods kubectl exits 0 but prints
+					// "No resources found ..." to stderr
+					output, err := cmd.Output()
+					if err != nil {
+						fmt.Printf("failed to query velero pods: %v\n", err)
+						return false
+					}
+					lines := strings.TrimSpace(string(output))
+					if lines == "" {
+						return true
+					}
+					fmt.Printf("Still waiting for velero pods to terminate: %s\n", lines)
+					return false
+				}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Velero pod should terminate")
+			})
+
+			originalPrefix := veleroCfg.BSLPrefix
+			newPrefix := originalPrefix + "-changed"
+
+			// Restore BSL prefix on exit so other tests aren't affected; purge objects
+			// created under the temporary prefix first so the restored (possibly empty)
+			// prefix passes the BSL store layout validation
+			defer func() {
+				restoreCtx, restoreCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer restoreCancel()
+				cleanupObjectsUnderPrefix(veleroCfg, newPrefix)
+				patchJSON := fmt.Sprintf(`{"spec":{"objectStorage":{"prefix":"%s"}}}`, originalPrefix)
+				cmd := exec.CommandContext(restoreCtx, "kubectl", "patch",
+					"backupstoragelocation/default",
+					"-n", veleroCfg.VeleroNamespace,
+					"--type=merge",
+					"-p", patchJSON)
+				if output, err := cmd.CombinedOutput(); err != nil {
+					fmt.Printf("warning: failed to restore BSL prefix: %s\n", string(output))
+				}
+			}()
+
+			By(fmt.Sprintf("Patch BSL prefix from %q to %q while Velero is down", originalPrefix, newPrefix), func() {
+				patchJSON := fmt.Sprintf(`{"spec":{"objectStorage":{"prefix":"%s"}}}`, newPrefix)
+				cmd := exec.CommandContext(ctx, "kubectl", "patch",
+					"backupstoragelocation/default",
+					"-n", veleroCfg.VeleroNamespace,
+					"--type=merge",
+					"-p", patchJSON)
+				output, err := cmd.CombinedOutput()
+				if err != nil {
+					fmt.Printf("patch BSL output: %s\n", string(output))
+				}
+				Expect(err).To(Succeed())
+			})
+
+			By("Scale Velero deployment back to 1", func() {
+				cmd := exec.CommandContext(ctx, "kubectl", "scale", "deployment/velero",
+					"-n", veleroCfg.VeleroNamespace, "--replicas=1")
+				output, err := cmd.CombinedOutput()
+				if err != nil {
+					fmt.Printf("scale up output: %s\n", string(output))
+				}
+				Expect(err).To(Succeed())
+			})
+
+			By("Wait for Velero pod to be ready", func() {
+				Eventually(func() bool {
+					cmd := exec.CommandContext(ctx, "kubectl", "get", "deployment/velero",
+						"-n", veleroCfg.VeleroNamespace,
+						"-o", "jsonpath={.status.readyReplicas}")
+					output, err := cmd.Output()
+					if err != nil {
+						return false
+					}
+					return strings.TrimSpace(string(output)) == "1"
+				}, 3*time.Minute, 5*time.Second).Should(BeTrue(), "Velero deployment should have 1 ready replica")
+			})
+
+			// The controller detects the prefix mismatch on reconciliation and invalidates the repo.
+			// Verify the repo was marked NotReady with the BSL change message.
+			By("Verify BackupRepository was invalidated on startup", func() {
+				Eventually(func() string {
+					cmd := exec.CommandContext(ctx, "kubectl", "get", "backuprepositories",
+						"-n", veleroCfg.VeleroNamespace,
+						"-l", kopiaRepoSelector(ns),
+						"-o", "jsonpath={range .items[*]}{.status.phase}|{.status.message}{end}")
+					output, err := cmd.Output()
+					if err != nil {
+						return ""
+					}
+					result := strings.TrimSpace(string(output))
+					fmt.Printf("BackupRepo state: %s\n", result)
+					// Accept either: still NotReady with our message, OR already recovered to Ready
+					// (the controller re-establishes the repository right after invalidating it)
+					if strings.Contains(result, "BSL config has changed") ||
+						strings.Contains(result, string(velerov1api.BackupRepositoryPhaseReady)) {
+						return result
+					}
+					return ""
+				}, 5*time.Minute, 10*time.Second).ShouldNot(BeEmpty(),
+					"BackupRepository should be invalidated or already recovered")
+			})
+
+			By("Verify BackupRepository recovers to Ready with an updated BSL config hash", func() {
+				Eventually(func() bool {
+					hash := kopiaRepoConfigHash(ctx, veleroCfg.VeleroNamespace, ns)
+					phase := kopiaRepoPhase(ctx, veleroCfg.VeleroNamespace, ns)
+					return hash != "" && hash != originalHash && phase == string(velerov1api.BackupRepositoryPhaseReady)
+				}, 5*time.Minute, 10*time.Second).Should(BeTrue(),
+					"BackupRepository should be Ready with a hash different from the original after the BSL prefix change")
+			})
+
+			By("Run another backup at the changed prefix", func() {
+				backupCfg.BackupName = "startup-val-backup-2"
+				Expect(VeleroBackupNamespace(ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, backupCfg)).To(Succeed(), func() string {
+					RunDebug(ctx, veleroCfg.VeleroCLI, veleroCfg.VeleroNamespace, backupCfg.BackupName, "")
+					return "Fail to backup workload after the BSL prefix change"
+				})
+			})
+
+			By("Delete the backup created at the changed prefix while the BSL still points there", func() {
+				Expect(DeleteBackup(ctx, backupCfg.BackupName, &veleroCfg)).To(Succeed())
+			})
+
+			By("Clean up repository data under the changed prefix", func() {
+				cleanupObjectsUnderPrefix(veleroCfg, newPrefix)
+			})
+
+			By("Restore original BSL prefix", func() {
+				patchJSON := fmt.Sprintf(`{"spec":{"objectStorage":{"prefix":"%s"}}}`, originalPrefix)
+				cmd := exec.CommandContext(ctx, "kubectl", "patch",
+					"backupstoragelocation/default",
+					"-n", veleroCfg.VeleroNamespace,
+					"--type=merge",
+					"-p", patchJSON)
+				output, err := cmd.CombinedOutput()
+				if err != nil {
+					fmt.Printf("restore BSL output: %s\n", string(output))
+				}
+				Expect(err).To(Succeed())
+			})
+
+			By("Verify BackupRepository recovers to Ready", func() {
+				Eventually(func() bool {
+					return kopiaRepoPhase(ctx, veleroCfg.VeleroNamespace, ns) == string(velerov1api.BackupRepositoryPhaseReady)
+				}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "BackupRepository should recover to Ready")
+			})
+
+			By("Verify BSL config hash returns to the original after the prefix is restored", func() {
+				Eventually(func() string {
+					return kopiaRepoConfigHash(ctx, veleroCfg.VeleroNamespace, ns)
+				}, 5*time.Minute, 10*time.Second).Should(Equal(originalHash),
+					"BackupRepository hash should match the original once the BSL prefix is restored")
+			})
+		})
+	})
+}
+
+// kopiaRepoSelector returns a label selector matching the kopia BackupRepository for
+// the given volume namespace.
+func kopiaRepoSelector(volumeNamespace string) string {
+	return fmt.Sprintf("%s=%s,%s=%s",
+		velerov1api.VolumeNamespaceLabel, volumeNamespace,
+		velerov1api.RepositoryTypeLabel, velerov1api.BackupRepositoryTypeKopia)
+}
+
+// cleanupObjectsUnderPrefix removes the velero store layout directories created under a
+// temporary BSL prefix. Without this, restoring the original (possibly empty) prefix
+// leaves unknown top-level directories in the bucket that fail the BSL's store layout
+// validation and turn it Unavailable.
+func cleanupObjectsUnderPrefix(veleroCfg VeleroConfig, prefix string) {
+	for _, dir := range []string{"backups", "restores", "kopia", "restic", "metadata", "plugins"} {
+		if err := DeleteObjectsInBucket(veleroCfg.ObjectStoreProvider, veleroCfg.CloudCredentialsFile,
+			veleroCfg.BSLBucket, prefix, veleroCfg.BSLConfig, dir, ""); err != nil {
+			fmt.Printf("cleanup of %s/%s from object store: %v\n", prefix, dir, err)
+		}
+	}
+}
+
+// kopiaRepoConfigHash returns the BSL config hash annotation of the kopia BackupRepository
+// for the given volume namespace, or an empty string if it is not (yet) set.
+func kopiaRepoConfigHash(ctx context.Context, namespace, volumeNamespace string) string {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "backuprepositories",
+		"-n", namespace,
+		"-l", kopiaRepoSelector(volumeNamespace),
+		"-o", `jsonpath={.items[*].metadata.annotations.velero\.io/bsl-config-hash}`)
+	output, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("failed to get repo config hash: %v\n", err)
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+// kopiaRepoPhase returns the phase of the kopia BackupRepository for the given volume
+// namespace, or an empty string if it cannot be determined.
+func kopiaRepoPhase(ctx context.Context, namespace, volumeNamespace string) string {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "backuprepositories",
+		"-n", namespace,
+		"-l", kopiaRepoSelector(volumeNamespace),
+		"-o", "jsonpath={.items[*].status.phase}")
+	output, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("failed to get repo phase: %v\n", err)
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -612,6 +612,15 @@ var _ = Describe(
 )
 
 var _ = Describe(
+	"BackupRepositories are invalidated when BSL config changes while Velero is not running",
+	// Serial: scales the velero deployment down/up and patches the default BSL —
+	// must not run alongside other specs
+	Label("BSL", "BackupRepository", "StartupValidation"),
+	Serial,
+	BackupRepoStartupValidationTest,
+)
+
+var _ = Describe(
 	"Migrate resources between clusters by FileSystem backup",
 	Label("Migration", "FSB"),
 	MigrationWithFS,


### PR DESCRIPTION
## Summary

Fix BackupRepositories becoming stale when BSL config changes while Velero is not running (#8279). When the BSL is modified or recreated (e.g. different prefix) while the server is down, existing BackupRepositories stay `Ready` with stale config and backups fail with `"repository not initialized in the provided storage"`.

## Root cause

BSL changes while Velero is down are unobservable, and BSL Create events were filtered out on restart — stale repositories stay `Ready` pointing at the old location.

## Fix

Detection is entirely BSL-watch-event-driven; nothing runs per-reconcile.

- A hash of the connectivity-affecting BSL fields (bucket, prefix, CACert, CACertRef, config) is recorded on the BackupRepository (`velero.io/bsl-config-hash` annotation) whenever it becomes `Ready`.
- **BSL Create events** — which fire for every existing BSL when the controller starts — are handled by a dedicated watch that invalidates only `Ready` repositories whose recorded hash no longer matches the BSL. A restart with an unchanged BSL invalidates nothing; repositories from before this change (no recorded hash) are left untouched until they naturally transition to Ready.
- **BSL Update events** (runtime changes) use the same comparison: `needInvalidBackupRepo` now compares the old and new BSL's config hash instead of separate field-by-field logic — one comparison function for both paths.
- Invalidated repositories recover through the existing NotReady reconciliation (`checkNotReadyRepo` → `ensureRepo`/`PrepareRepo`). Repository initialization remains exclusively with the repo controller — the data path is untouched. If a backup reaches a stale-Ready repository before the Create event is processed at startup, it fails transiently and self-heals on retry.

## E2E

Own kind matrix job (`BSL && BackupRepository && StartupValidation`), marked `Serial`; objects under the temporary prefix are purged before restoring the original one. Prefix change while Velero is down → repository invalidated and re-established, hash changes and returns to the original when the prefix is restored, and a backup succeeds at the new prefix.

## Known limitations (out of scope)

- The node-agent's cached kopia config can still point at the old location if the node-agent pods survive the outage and the old data exists — pre-existing behavior, unchanged here. Not hit in #8279's scenario (recreating the DPA also recreates the node-agent, clearing the cache).
- Repositories created before this change are not drift-checked until they first transition through Ready with the new version and get a hash recorded.

## Notes

Reimplements the earlier approach on this PR (one-shot startup validation with four raw config annotations; previous head preserved at [`8279-annotation-approach-backup`](https://github.com/kaovilai/velero/tree/8279-annotation-approach-backup)): detection is now event-driven with a single hash annotation and never touches repositories that predate it.

Fixes #8279

> [!Note]
> Responses generated with Claude