### PR TITLE
Skip restore informer cache for resources without watch support

### DIFF
--- a/changelogs/unreleased/9384-kaovilai
+++ b/changelogs/unreleased/9384-kaovilai
@@ -1,0 +1,1 @@
+Skip the restore informer cache for resources whose API doesn't support the list and watch verbs (e.g. authorization.openshift.io on OpenShift, metrics.k8s.io, or packages.operators.coreos.com from OLM), avoiding endless reflector watch-error logs during restore

--- a/pkg/restore/informer_cache_test.go
+++ b/pkg/restore/informer_cache_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+// verbAwareDiscoveryHelper wraps FakeDiscoveryHelper to return APIResources
+// with verbs populated, which the shared fake omits.
+type verbAwareDiscoveryHelper struct {
+	*velerotest.FakeDiscoveryHelper
+	apiResources map[schema.GroupVersionResource]metav1.APIResource
+}
+
+func (h *verbAwareDiscoveryHelper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, metav1.APIResource, error) {
+	if r, ok := h.apiResources[input]; ok {
+		return input, r, nil
+	}
+	return schema.GroupVersionResource{}, metav1.APIResource{}, fmt.Errorf("APIResource not found for GroupVersionResource %s", input)
+}
+
+func TestInformerCacheSupported(t *testing.T) {
+	watchable := schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}
+	watchless := schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"}
+	verbless := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	unknown := schema.GroupVersionResource{Group: "unknown.io", Version: "v1", Resource: "things"}
+
+	helper := &verbAwareDiscoveryHelper{
+		FakeDiscoveryHelper: velerotest.NewFakeDiscoveryHelper(false, nil),
+		apiResources: map[schema.GroupVersionResource]metav1.APIResource{
+			watchable: {Name: "rolebindings", Verbs: metav1.Verbs{"create", "delete", "get", "list", "watch"}},
+			watchless: {Name: "nodes", Verbs: metav1.Verbs{"get", "list"}},
+			verbless:  {Name: "widgets"},
+		},
+	}
+
+	ctx := &restoreContext{
+		log:                        velerotest.NewLogger(),
+		discoveryHelper:            helper,
+		informerCacheableResources: make(map[schema.GroupVersionResource]bool),
+	}
+
+	assert.True(t, ctx.informerCacheSupported(watchable))
+	// watch verb missing: informer cache must not be used
+	assert.False(t, ctx.informerCacheSupported(watchless))
+	// no verbs reported at all: assume supported, as some discovery sources omit verbs
+	assert.True(t, ctx.informerCacheSupported(verbless))
+	// unknown to discovery: report supported so the informer path surfaces the lookup error
+	assert.True(t, ctx.informerCacheSupported(unknown))
+
+	// results for known resources are memoized, unknown resources are not
+	assert.Equal(t, map[schema.GroupVersionResource]bool{
+		watchable: true,
+		watchless: false,
+		verbless:  true,
+	}, ctx.informerCacheableResources)
+
+	// memoized answers stick even if discovery answers change
+	helper.apiResources[watchless] = metav1.APIResource{Name: "nodes", Verbs: metav1.Verbs{"list", "watch"}}
+	assert.False(t, ctx.informerCacheSupported(watchless))
+
+	// resources unknown at first are re-checked once discovery learns about
+	// them, e.g. after a discovery refresh triggered by restoring CRDs
+	helper.apiResources[unknown] = metav1.APIResource{Name: "things", Verbs: metav1.Verbs{"get", "list"}}
+	assert.False(t, ctx.informerCacheSupported(unknown))
+}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -357,6 +357,7 @@ func (kr *kubernetesRestorer) RestoreWithResolvers(
 		resourceTerminatingTimeout:     kr.resourceTerminatingTimeout,
 		resourceTimeout:                kr.resourceTimeout,
 		resourceClients:                make(map[resourceClientKey]client.Dynamic),
+		informerCacheableResources:     make(map[schema.GroupVersionResource]bool),
 		restoredItems:                  req.RestoredItems,
 		renamedPVs:                     make(map[string]string),
 		pvRenamer:                      kr.pvRenamer,
@@ -410,6 +411,7 @@ type restoreContext struct {
 	resourceTimeout                time.Duration
 	resourceClients                map[resourceClientKey]client.Dynamic
 	dynamicInformerFactory         *informerFactoryWithContext
+	informerCacheableResources     map[schema.GroupVersionResource]bool
 	restoredItems                  map[itemKey]restoredItemStatus
 	renamedPVs                     map[string]string
 	pvRenamer                      func(string) (string, error)
@@ -893,6 +895,11 @@ func (ctx *restoreContext) execute() (results.Result, results.Result) {
 				ctx.log.Infof("failed to create informer for %s: %v", gvr, err)
 				continue
 			}
+			// skip resources whose API doesn't serve the list and watch verbs informers
+			// require, so their reflectors don't endlessly retry and log watch errors
+			if !ctx.informerCacheSupported(gvr) {
+				continue
+			}
 			ctx.dynamicInformerFactory.factory.ForResource(gvr)
 		}
 		ctx.dynamicInformerFactory.factory.Start(ctx.dynamicInformerFactory.context.Done())
@@ -1340,6 +1347,34 @@ func (ctx *restoreContext) getResourceClient(groupResource schema.GroupResource,
 
 	ctx.resourceClients[key] = client
 	return client, nil
+}
+
+// informerCacheSupported reports whether the resource's API serves the list and
+// watch verbs the dynamic informer cache requires. Some API groups reject watch
+// requests even though list/get/create/delete work fine — e.g.
+// authorization.openshift.io on OpenShift, metrics.k8s.io (metrics-server),
+// custom.metrics.k8s.io/external.metrics.k8s.io (HPA custom-metrics adapters),
+// and packages.operators.coreos.com (OLM package-server) — which leaves
+// their informers permanently unable to watch and their reflectors endlessly
+// logging watch errors, so such resources are read via direct API calls instead.
+// Results are memoized per GroupVersionResource. Resources unknown to discovery
+// are reported as supported without memoizing, so the informer path can surface
+// the lookup error and a later discovery refresh (e.g. after restoring CRDs) can
+// change the answer. A resource reporting no verbs at all is treated as supported.
+func (ctx *restoreContext) informerCacheSupported(gvr schema.GroupVersionResource) bool {
+	if supported, ok := ctx.informerCacheableResources[gvr]; ok {
+		return supported
+	}
+	_, apiResource, err := ctx.discoveryHelper.ResourceFor(gvr)
+	if err != nil {
+		return true
+	}
+	supported := len(apiResource.Verbs) == 0 || sets.New(apiResource.Verbs...).HasAll("list", "watch")
+	if !supported {
+		ctx.log.Infof("API server does not support list and watch for %s, using direct API calls instead of the informer cache for this resource", gvr)
+	}
+	ctx.informerCacheableResources[gvr] = supported
+	return supported
 }
 
 func (ctx *restoreContext) getResourceLister(groupResource schema.GroupResource, obj *unstructured.Unstructured, namespace string) (cache.GenericNamespaceLister, error) {
@@ -1844,7 +1879,8 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 
 	// only attempt Get before Create if using informer cache, otherwise this will slow down restore into
 	// new namespace
-	if !ctx.disableInformerCache {
+	useInformerCache := !ctx.disableInformerCache && ctx.informerCacheSupported(newGR.WithVersion(obj.GroupVersionKind().Version))
+	if useInformerCache {
 		restoreLogger.Debugf("Checking for existence %s", obj.GetName())
 		fromCluster, err = ctx.getResource(newGR, obj, namespace)
 	}
@@ -1872,7 +1908,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 		// check for the existence of the object that failed creation due to alreadyExist in cluster, if no error then it implies that object exists.
 		// and if err then itemExists remains false as we were not able to confirm the existence of the object via Get call or creation call.
 		// We return the get error as a warning to notify the user that the object could exist in cluster and we were not able to confirm it.
-		if !ctx.disableInformerCache {
+		if useInformerCache {
 			fromCluster, err = ctx.getResource(newGR, obj, namespace)
 		} else {
 			fromCluster, err = resourceClient.Get(obj.GetName(), metav1.GetOptions{})

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -357,6 +357,7 @@ func (kr *kubernetesRestorer) RestoreWithResolvers(
 		resourceTerminatingTimeout:     kr.resourceTerminatingTimeout,
 		resourceTimeout:                kr.resourceTimeout,
 		resourceClients:                make(map[resourceClientKey]client.Dynamic),
+		informerCacheableResources:     make(map[schema.GroupVersionResource]bool),
 		restoredItems:                  req.RestoredItems,
 		renamedPVs:                     make(map[string]string),
 		pvRenamer:                      kr.pvRenamer,
@@ -410,6 +411,7 @@ type restoreContext struct {
 	resourceTimeout                time.Duration
 	resourceClients                map[resourceClientKey]client.Dynamic
 	dynamicInformerFactory         *informerFactoryWithContext
+	informerCacheableResources     map[schema.GroupVersionResource]bool
 	restoredItems                  map[itemKey]restoredItemStatus
 	renamedPVs                     map[string]string
 	pvRenamer                      func(string) (string, error)
@@ -893,6 +895,11 @@ func (ctx *restoreContext) execute() (results.Result, results.Result) {
 				ctx.log.Infof("failed to create informer for %s: %v", gvr, err)
 				continue
 			}
+			// skip resources whose API doesn't serve the list and watch verbs informers
+			// require, so their reflectors don't endlessly retry and log watch errors
+			if !ctx.informerCacheSupported(gvr) {
+				continue
+			}
 			ctx.dynamicInformerFactory.factory.ForResource(gvr)
 		}
 		ctx.dynamicInformerFactory.factory.Start(ctx.dynamicInformerFactory.context.Done())
@@ -1353,6 +1360,34 @@ func (ctx *restoreContext) getResourceClient(groupResource schema.GroupResource,
 
 	ctx.resourceClients[key] = client
 	return client, nil
+}
+
+// informerCacheSupported reports whether the resource's API serves the list and
+// watch verbs the dynamic informer cache requires. Some API groups reject watch
+// requests even though list/get/create/delete work fine — e.g.
+// authorization.openshift.io on OpenShift, metrics.k8s.io (metrics-server),
+// custom.metrics.k8s.io/external.metrics.k8s.io (HPA custom-metrics adapters),
+// and packages.operators.coreos.com (OLM package-server) — which leaves
+// their informers permanently unable to watch and their reflectors endlessly
+// logging watch errors, so such resources are read via direct API calls instead.
+// Results are memoized per GroupVersionResource. Resources unknown to discovery
+// are reported as supported without memoizing, so the informer path can surface
+// the lookup error and a later discovery refresh (e.g. after restoring CRDs) can
+// change the answer. A resource reporting no verbs at all is treated as supported.
+func (ctx *restoreContext) informerCacheSupported(gvr schema.GroupVersionResource) bool {
+	if supported, ok := ctx.informerCacheableResources[gvr]; ok {
+		return supported
+	}
+	_, apiResource, err := ctx.discoveryHelper.ResourceFor(gvr)
+	if err != nil {
+		return true
+	}
+	supported := len(apiResource.Verbs) == 0 || sets.New(apiResource.Verbs...).HasAll("list", "watch")
+	if !supported {
+		ctx.log.Infof("API server does not support list and watch for %s, using direct API calls instead of the informer cache for this resource", gvr)
+	}
+	ctx.informerCacheableResources[gvr] = supported
+	return supported
 }
 
 func (ctx *restoreContext) getResourceLister(groupResource schema.GroupResource, obj *unstructured.Unstructured, namespace string) (cache.GenericNamespaceLister, error) {
@@ -1887,7 +1922,8 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 
 	// only attempt Get before Create if using informer cache, otherwise this will slow down restore into
 	// new namespace
-	if !ctx.disableInformerCache {
+	useInformerCache := !ctx.disableInformerCache && ctx.informerCacheSupported(newGR.WithVersion(obj.GroupVersionKind().Version))
+	if useInformerCache {
 		restoreLogger.Debugf("Checking for existence %s", obj.GetName())
 		fromCluster, err = ctx.getResource(newGR, obj, namespace)
 	}
@@ -1915,7 +1951,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 		// check for the existence of the object that failed creation due to alreadyExist in cluster, if no error then it implies that object exists.
 		// and if err then itemExists remains false as we were not able to confirm the existence of the object via Get call or creation call.
 		// We return the get error as a warning to notify the user that the object could exist in cluster and we were not able to confirm it.
-		if !ctx.disableInformerCache {
+		if useInformerCache {
 			fromCluster, err = ctx.getResource(newGR, obj, namespace)
 		} else {
 			fromCluster, err = resourceClient.Get(obj.GetName(), metav1.GetOptions{})

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1345,7 +1345,10 @@ func TestRestoreItems(t *testing.T) {
 				AddItems("secrets", builder.ForSecret("ns-1", "sa-1").Data(map[string][]byte{"key-1": []byte("value-1")}).Result()).
 				Done(),
 			apiResources: []*test.APIResource{
-				test.Secrets(builder.ForSecret("ns-1", "sa-1").Data(map[string][]byte{"foo": []byte("bar")}).Result()),
+				withVerbs(
+					test.Secrets(builder.ForSecret("ns-1", "sa-1").Data(map[string][]byte{"foo": []byte("bar")}).Result()),
+					"list", "create", "get", "delete", "watch",
+				),
 			},
 			disableInformer: false,
 			want: []*test.APIResource{
@@ -4502,6 +4505,14 @@ func (cr *createRecorder) reactor() func(kubetesting.Action) (bool, runtime.Obje
 
 func defaultRestore() *builder.RestoreBuilder {
 	return builder.ForRestore(velerov1api.DefaultNamespace, "restore-1").Backup("backup-1")
+}
+
+// withVerbs overrides the discovery verbs reported for an APIResource,
+// e.g. to exercise the dynamic informer cache path for resources whose
+// API serves the watch verb.
+func withVerbs(r *test.APIResource, verbs ...string) *test.APIResource {
+	r.Verbs = verbs
+	return r
 }
 
 // assertAPIContents asserts that the dynamic client on the provided harness contains

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1261,7 +1261,10 @@ func TestRestoreItems(t *testing.T) {
 				AddItems("secrets", builder.ForSecret("ns-1", "sa-1").Data(map[string][]byte{"key-1": []byte("value-1")}).Result()).
 				Done(),
 			apiResources: []*test.APIResource{
-				test.Secrets(builder.ForSecret("ns-1", "sa-1").Data(map[string][]byte{"foo": []byte("bar")}).Result()),
+				withVerbs(
+					test.Secrets(builder.ForSecret("ns-1", "sa-1").Data(map[string][]byte{"foo": []byte("bar")}).Result()),
+					"list", "create", "get", "delete", "watch",
+				),
 			},
 			disableInformer: false,
 			want: []*test.APIResource{
@@ -4188,6 +4191,14 @@ func (cr *createRecorder) reactor() func(kubetesting.Action) (bool, runtime.Obje
 
 func defaultRestore() *builder.RestoreBuilder {
 	return builder.ForRestore(velerov1api.DefaultNamespace, "restore-1").Backup("backup-1")
+}
+
+// withVerbs overrides the discovery verbs reported for an APIResource,
+// e.g. to exercise the dynamic informer cache path for resources whose
+// API serves the watch verb.
+func withVerbs(r *test.APIResource, verbs ...string) *test.APIResource {
+	r.Verbs = verbs
+	return r
 }
 
 // assertAPIContents asserts that the dynamic client on the provided harness contains

--- a/pkg/test/discovery_client.go
+++ b/pkg/test/discovery_client.go
@@ -68,6 +68,11 @@ func (c *DiscoveryClient) WithAPIResource(resource *APIResource) *DiscoveryClien
 		}
 	}
 
+	verbs := resource.Verbs
+	if len(verbs) == 0 {
+		verbs = []string{"list", "create", "get", "delete"}
+	}
+
 	resourceList.APIResources = append(resourceList.APIResources, metav1.APIResource{
 		Name:         resource.Name,
 		SingularName: strings.TrimSuffix(resource.Name, "s"),
@@ -75,7 +80,7 @@ func (c *DiscoveryClient) WithAPIResource(resource *APIResource) *DiscoveryClien
 		Group:        resource.Group,
 		Version:      resource.Version,
 		Kind:         resource.Kind,
-		Verbs:        metav1.Verbs([]string{"list", "create", "get", "delete"}),
+		Verbs:        metav1.Verbs(verbs),
 		ShortNames:   []string{resource.ShortName},
 	})
 

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -31,6 +31,10 @@ type APIResource struct {
 	ShortName  string
 	Namespaced bool
 	Items      []metav1.Object
+	// Verbs overrides the discovery verbs reported for this resource.
+	// When empty, the discovery client fixture defaults to
+	// list/create/get/delete.
+	Verbs []string
 }
 
 // GVR returns a GroupVersionResource representing the resource.


### PR DESCRIPTION
Fixes #10026
Related to #9381 (the errors first surfaced there as a red herring for an unrelated restore failure)

## Problem

Some API groups — e.g. `authorization.openshift.io/v1` on OpenShift — don't serve the `watch` verb at the API server level, regardless of RBAC. When Velero's restore creates dynamic informers for these resources, the initial LIST succeeds (so the cache syncs), but every subsequent WATCH fails and the reflector retries endlessly, logging throughout the restore:

```
level=error msg="Unhandled Error" error="...reflector.go:243: Failed to watch authorization.openshift.io/v1, Resource=rolebindings: the server does not allow this method on the requested resource" logger=UnhandledError
```

This isn't OpenShift-specific. Any resource served by a custom aggregated `APIService` that doesn't implement `rest.Watcher` hits the same failure mode — `watch` is optional in the apiserver library, `list`/`get` are not. Other examples in the wild: `metrics.k8s.io` (metrics-server), `custom.metrics.k8s.io`/`external.metrics.k8s.io` (HPA custom-metrics adapters), and `packages.operators.coreos.com` PackageManifest (OLM package-server, installable on any Kubernetes cluster).

## Design

Checking `WaitForCacheSync()` return values can't catch this: the informer *does* sync (LIST works), so `WaitForCacheSync` reports success — the log spam comes from the reflector's watch retry loop afterward. And for resources that truly can't sync, `WaitForCacheSync` blocks until the factory context is cancelled, so a `synced=false` result only ever surfaces once the restore is already being torn down. Neither case gives a usable signal before informer creation.

So verbs are pre-flighted instead — the discovery helper already knows each resource's supported verbs, so the informer is never created for resources that can't be watched:

- `informerCacheSupported()` checks the resource's `APIResource.Verbs` for `list` and `watch` via the discovery helper, memoized per `GroupVersionResource` (`pkg/restore/restore.go`)
- The informer pre-creation loop in `execute()` skips resources that fail the check, so no reflector ever starts for them
- `restoreItem()` reads those resources via direct API calls instead of the informer cache, matching the per-resource behavior of `--disable-informer-cache` (including skipping the pre-create existence `Get`, which is wasted work on restore into a new namespace)
- Resources unknown to discovery are treated as supported without memoization, so a later discovery refresh (e.g. after restoring CRDs) can change the answer; resources reporting no verbs at all are treated as supported (some discovery sources omit verbs)

Because no reflector is ever started for a watch-less resource, it never issues the WATCH call that the server rejects — the "Unhandled Error ... does not allow this method" log spam has no failing watch left to log, and restore reads the resource directly via the API instead.

Velero's discovery already filters resources on `list, create, get, delete` — `watch` is exactly the verb never checked before informer creation.

## Testing

- `pkg/restore/informer_cache_test.go`: verb combinations (watchable / watch-less / verb-less / unknown-to-discovery) against a vendor-neutral fixture (`metrics.k8s.io/nodes`), memoization behavior, and re-check after discovery learns a resource
- `test.APIResource` (`pkg/test`) gained an optional `Verbs` field so restore tests can override the shared discovery fixture's default verb list; the existing "secret exists, using informer cache" case in `pkg/restore/restore_test.go` now sets `watch` on its resource so it exercises the informer-cache code path its name describes
- All existing `pkg/restore/...` tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.