### PR TITLE
Add lint-fix make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,6 +375,16 @@ ifneq ($(SKIP_TESTS), 1)
 	@hack/lint.sh
 endif
 
+lint-fix:
+ifneq ($(SKIP_TESTS), 1)
+	@$(MAKE) shell CMD="-c 'hack/lint.sh fix'"
+endif
+
+local-lint-fix:
+ifneq ($(SKIP_TESTS), 1)
+	@hack/lint.sh fix
+endif
+
 update: ## Run all update scripts
 	@$(MAKE) shell CMD="-c 'hack/update-all.sh'"
 

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -20,6 +20,12 @@ golangci-lint cache status
 # Enable GL_DEBUG line below for debug messages for golangci-lint
 # export GL_DEBUG=loader,gocritic,env
 CMD="golangci-lint run"
+
+# Add --fix flag if first argument is "fix"
+if [ "$1" = "fix" ]; then
+    CMD="$CMD --fix"
+fi
+
 echo "Running $CMD"
 
 eval $CMD


### PR DESCRIPTION
This commit adds lint-fix and local-lint-fix make targets that
automatically fix linting issues using golangci-lint --fix.

The implementation reuses the existing hack/lint.sh script by
adding support for a "fix" parameter that enables the --fix flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
