### PR TITLE
Fix restore finalization overwriting dynamically provisioned PV labels

### DIFF
--- a/changelogs/unreleased/9903-Joeavaikath
+++ b/changelogs/unreleased/9903-Joeavaikath
@@ -1,1 +1,1 @@
-Apply ResourceModifier rules during restore finalization for dynamic PVs
+Fix restore finalization overwriting dynamically provisioned PV labels with stale backup values

--- a/changelogs/unreleased/9903-Joeavaikath
+++ b/changelogs/unreleased/9903-Joeavaikath
@@ -1,0 +1,1 @@
+Apply ResourceModifier rules during restore finalization for dynamic PVs

--- a/pkg/controller/restore_finalizer_controller.go
+++ b/pkg/controller/restore_finalizer_controller.go
@@ -421,7 +421,16 @@ func (ctx *finalizerContext) patchDynamicPVWithVolumeInfo() (errs results.Result
 					// patch PV's reclaim policy and label using the corresponding data stored in volume info
 					if needPatch(pv, volInfo.PVInfo) {
 						updatedPV := pv.DeepCopy()
-						updatedPV.Labels = volInfo.PVInfo.Labels
+
+						if updatedPV.Labels == nil {
+							updatedPV.Labels = make(map[string]string)
+						}
+						for k, v := range volInfo.PVInfo.Labels {
+							if _, exists := updatedPV.Labels[k]; !exists {
+								updatedPV.Labels[k] = v
+							}
+						}
+
 						updatedPV.Spec.PersistentVolumeReclaimPolicy = corev1api.PersistentVolumeReclaimPolicy(volInfo.PVInfo.ReclaimPolicy)
 						if err := kubeutil.PatchResource(pv, updatedPV, ctx.crClient); err != nil {
 							return false, err
@@ -553,11 +562,8 @@ func needPatch(newPV *corev1api.PersistentVolume, pvInfo *volume.PVInfo) bool {
 	}
 
 	newPVLabels, pvLabels := newPV.Labels, pvInfo.Labels
-	for k, v := range pvLabels {
+	for k := range pvLabels {
 		if _, ok := newPVLabels[k]; !ok {
-			return true
-		}
-		if newPVLabels[k] != v {
 			return true
 		}
 	}

--- a/pkg/controller/restore_finalizer_controller_test.go
+++ b/pkg/controller/restore_finalizer_controller_test.go
@@ -634,6 +634,87 @@ func Test_restoreFinalizerReconciler_finishProcessing(t *testing.T) {
 	}
 }
 
+func TestNeedPatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		newPV    *corev1api.PersistentVolume
+		pvInfo   *volume.PVInfo
+		expected bool
+	}{
+		{
+			name: "reclaim policy differs",
+			newPV: builder.ForPersistentVolume("pv1").
+				ReclaimPolicy(corev1api.PersistentVolumeReclaimDelete).Result(),
+			pvInfo: &volume.PVInfo{
+				ReclaimPolicy: string(corev1api.PersistentVolumeReclaimRetain),
+				Labels:        map[string]string{},
+			},
+			expected: true,
+		},
+		{
+			name: "backup has label new PV does not",
+			newPV: builder.ForPersistentVolume("pv1").
+				ObjectMeta(builder.WithLabels("existing", "val")).
+				ReclaimPolicy(corev1api.PersistentVolumeReclaimDelete).Result(),
+			pvInfo: &volume.PVInfo{
+				ReclaimPolicy: string(corev1api.PersistentVolumeReclaimDelete),
+				Labels:        map[string]string{"existing": "val", "missing": "val"},
+			},
+			expected: true,
+		},
+		{
+			name: "same labels same values",
+			newPV: builder.ForPersistentVolume("pv1").
+				ObjectMeta(builder.WithLabels("key", "val")).
+				ReclaimPolicy(corev1api.PersistentVolumeReclaimDelete).Result(),
+			pvInfo: &volume.PVInfo{
+				ReclaimPolicy: string(corev1api.PersistentVolumeReclaimDelete),
+				Labels:        map[string]string{"key": "val"},
+			},
+			expected: false,
+		},
+		{
+			name: "same label key different values",
+			newPV: builder.ForPersistentVolume("pv1").
+				ObjectMeta(builder.WithLabels("topology.kubernetes.io/zone", "us-west-2a")).
+				ReclaimPolicy(corev1api.PersistentVolumeReclaimDelete).Result(),
+			pvInfo: &volume.PVInfo{
+				ReclaimPolicy: string(corev1api.PersistentVolumeReclaimDelete),
+				Labels:        map[string]string{"topology.kubernetes.io/zone": "us-east-1a"},
+			},
+			expected: false,
+		},
+		{
+			name: "new PV has labels backup does not",
+			newPV: builder.ForPersistentVolume("pv1").
+				ObjectMeta(builder.WithLabels("provisioner-label", "val")).
+				ReclaimPolicy(corev1api.PersistentVolumeReclaimDelete).Result(),
+			pvInfo: &volume.PVInfo{
+				ReclaimPolicy: string(corev1api.PersistentVolumeReclaimDelete),
+				Labels:        map[string]string{},
+			},
+			expected: false,
+		},
+		{
+			name: "both labels nil",
+			newPV: builder.ForPersistentVolume("pv1").
+				ReclaimPolicy(corev1api.PersistentVolumeReclaimDelete).Result(),
+			pvInfo: &volume.PVInfo{
+				ReclaimPolicy: string(corev1api.PersistentVolumeReclaimDelete),
+				Labels:        nil,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := needPatch(tc.newPV, tc.pvInfo)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestRestoreOperationList(t *testing.T) {
 	var empty []*itemoperation.RestoreOperation
 	tests := []struct {


### PR DESCRIPTION
## Summary

During restore finalization, `patchDynamicPVWithVolumeInfo()` overwrites the dynamically provisioned PV's entire label map with labels captured at backup time (`updatedPV.Labels = volInfo.PVInfo.Labels`). This replaces correct provisioner-set labels (e.g. topology zone/region) with stale values from the source cluster, breaking pod scheduling in cross-environment restores.

This PR changes the wholesale label replacement to a merge: only labels from the backup that are absent on the new PV are added. Labels already present — such as topology labels set by the CSI driver or cloud provisioner — are preserved. This avoids needing to enumerate topology labels and requires no user configuration.

### Changes

- Replace wholesale label assignment with a merge loop that skips labels already present on the dynamically provisioned PV
- Update `needPatch` to only trigger when backup labels are missing from the new PV, not when values differ
- Add unit tests for `needPatch` covering all cases: reclaim policy diff, missing labels, matching labels, conflicting values, extra labels on new PV, and nil labels

### Root cause

The volume info generation in `internal/volume/volumes_information.go` captures all PV labels unfiltered (`Labels: pvcPVInfo.PV.Labels`) across all 6 `generateVolumeInfo*` methods. The restore finalizer then applied these wholesale, overwriting provisioner-set topology labels with stale backup values.

## Does your change fix a particular issue?

Fixes #9358

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.