### PR TITLE
feat: add CRD schema validation during server startup

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -99,6 +99,7 @@ jobs:
             \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
             \"labels\":[\
               \"Basic && (ClusterResource || NodePort || StorageClass)\", \
+              \"CRDSchemaCheck\", \
               \"ResourceFiltering && !FSBackup\", \
               \"ResourceModifier || (Backups && BackupsSync) || PrivilegesMgmt || OrderedResources\", \
               \"(NamespaceMapping && Single && FSBackup) || (NamespaceMapping && Multiple && FSBackup)\"\

--- a/changelogs/unreleased/9910-kaovilai
+++ b/changelogs/unreleased/9910-kaovilai
@@ -1,0 +1,1 @@
+Add CRD schema validation during server startup, configurable via --crd-schema-check flag (warn/strict/skip)

--- a/pkg/cmd/server/config/config.go
+++ b/pkg/cmd/server/config/config.go
@@ -182,6 +182,7 @@ type Config struct {
 	ItemBlockWorkerCount                int
 	ConcurrentBackups                   int
 	GlobalBackupVolumePoliciesConfigMap string
+	CRDSchemaCheck                      *flag.Enum
 }
 
 func GetDefaultConfig() *Config {
@@ -215,6 +216,7 @@ func GetDefaultConfig() *Config {
 		CredentialsDirectory:           credentials.DefaultStoreDirectory(),
 		ItemBlockWorkerCount:           DefaultItemBlockWorkerCount,
 		ConcurrentBackups:              DefaultConcurrentBackups,
+		CRDSchemaCheck:                 flag.NewEnum("warn", "warn", "strict", "skip"),
 	}
 
 	return config
@@ -281,5 +283,10 @@ func (c *Config) BindFlags(flags *pflag.FlagSet) {
 		"global-backup-volume-policies-configmap",
 		c.GlobalBackupVolumePoliciesConfigMap,
 		"The name of a ConfigMap in the Velero install namespace holding global backup volume policies that are merged into every backup. Optional.",
+	)
+	flags.Var(
+		c.CRDSchemaCheck,
+		"crd-schema-check",
+		fmt.Sprintf("CRD schema validation mode during server startup. Valid values are %s.", strings.Join(c.CRDSchemaCheck.AllowedValues(), ", ")),
 	)
 }

--- a/pkg/cmd/server/config/config_test.go
+++ b/pkg/cmd/server/config/config_test.go
@@ -29,3 +29,23 @@ func TestGlobalBackupVolumePoliciesConfigMapFlag(t *testing.T) {
 	require.NoError(t, flags.Parse([]string{"--global-backup-volume-policies-configmap", "global-volume-policy"}))
 	assert.Equal(t, "global-volume-policy", config.GlobalBackupVolumePoliciesConfigMap)
 }
+
+func TestCRDSchemaCheckFlag(t *testing.T) {
+	config := GetDefaultConfig()
+	assert.Equal(t, "warn", config.CRDSchemaCheck.String())
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.BindFlags(flags)
+	require.NoError(t, flags.Parse([]string{"--crd-schema-check", "strict"}))
+	assert.Equal(t, "strict", config.CRDSchemaCheck.String())
+}
+
+func TestCRDSchemaCheckFlagRejectsInvalidValue(t *testing.T) {
+	config := GetDefaultConfig()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.BindFlags(flags)
+	err := flags.Parse([]string{"--crd-schema-check", "foo"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid value")
+}

--- a/pkg/cmd/server/crd_check.go
+++ b/pkg/cmd/server/crd_check.go
@@ -1,0 +1,244 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/sirupsen/logrus"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	velerov2alpha1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
+)
+
+type crdSchemaExpectation struct {
+	crdName            string
+	specType           reflect.Type
+	statusType         reflect.Type
+	apiGroupVersion    string
+	storedVersionLabel string
+}
+
+func expectedCRDSchemas() []crdSchemaExpectation {
+	var expectations []crdSchemaExpectation
+
+	for kind, info := range velerov1api.CustomResources() {
+		exp := crdSchemaExpectation{
+			crdName:            info.PluralName + "." + velerov1api.SchemeGroupVersion.Group,
+			apiGroupVersion:    velerov1api.SchemeGroupVersion.Version,
+			storedVersionLabel: kind,
+		}
+		itemType := reflect.TypeOf(info.ItemType)
+		if itemType.Kind() == reflect.Pointer {
+			itemType = itemType.Elem()
+		}
+		if structField, ok := itemType.FieldByName("Spec"); ok {
+			exp.specType = structField.Type
+		}
+		if statusField, ok := itemType.FieldByName("Status"); ok {
+			exp.statusType = statusField.Type
+		}
+		expectations = append(expectations, exp)
+	}
+
+	for kind, info := range velerov2alpha1api.CustomResources() {
+		exp := crdSchemaExpectation{
+			crdName:            info.PluralName + "." + velerov2alpha1api.SchemeGroupVersion.Group,
+			apiGroupVersion:    velerov2alpha1api.SchemeGroupVersion.Version,
+			storedVersionLabel: kind,
+		}
+		itemType := reflect.TypeOf(info.ItemType)
+		if itemType.Kind() == reflect.Pointer {
+			itemType = itemType.Elem()
+		}
+		if structField, ok := itemType.FieldByName("Spec"); ok {
+			exp.specType = structField.Type
+		}
+		if statusField, ok := itemType.FieldByName("Status"); ok {
+			exp.statusType = statusField.Type
+		}
+		expectations = append(expectations, exp)
+	}
+
+	return expectations
+}
+
+// jsonFieldNames extracts top-level JSON field names from a Go struct type using reflection.
+func jsonFieldNames(t reflect.Type) sets.Set[string] {
+	if t == nil {
+		return nil
+	}
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+
+	fields := sets.New[string]()
+	for field := range t.Fields() {
+		tag := field.Tag.Get("json")
+		// An anonymous field with no JSON tag is promoted/flattened by encoding/json.
+		// One with an explicit tag name (e.g. `json:"metadata,omitempty"`) is instead
+		// marshaled as a regular named field, not inlined.
+		if field.Anonymous && tag == "" {
+			embedded := jsonFieldNames(field.Type)
+			fields = fields.Union(embedded)
+			continue
+		}
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" {
+			continue
+		}
+		fields.Insert(name)
+	}
+	return fields
+}
+
+// schemaPropertyNames extracts top-level property names from a CRD OpenAPI schema.
+// The second return value is false if path could not be traversed (schema is nil,
+// or an intermediate/final segment is missing), distinct from reaching a node that
+// legitimately declares no properties (true, empty set).
+func schemaPropertyNames(schema *apiextv1.JSONSchemaProps, path string) (sets.Set[string], bool) {
+	if schema == nil {
+		return nil, false
+	}
+
+	current := schema
+	for segment := range strings.SplitSeq(path, ".") {
+		if segment == "" {
+			continue
+		}
+		if current.Properties == nil {
+			return nil, false
+		}
+		next, ok := current.Properties[segment]
+		if !ok {
+			return nil, false
+		}
+		current = &next
+	}
+
+	names := sets.New[string]()
+	if current.Properties == nil {
+		return names, true
+	}
+	for name := range current.Properties {
+		names.Insert(name)
+	}
+	return names, true
+}
+
+func (s *server) validateCRDSchemas() error {
+	mode := s.config.CRDSchemaCheck.String()
+	if mode == "skip" {
+		s.logger.Info("CRD schema validation skipped (--crd-schema-check=skip)")
+		return nil
+	}
+
+	s.logger.Info("Validating CRD schemas match server expectations")
+
+	apiextClient, err := apiextclient.NewForConfig(s.kubeClientConfig)
+	if err != nil {
+		return errors.Wrap(err, "creating apiextensions client for CRD schema validation")
+	}
+
+	return runCRDSchemaValidation(s.ctx, apiextClient, expectedCRDSchemas(), mode, s.logger)
+}
+
+func runCRDSchemaValidation(ctx context.Context, client apiextclient.Interface, expectations []crdSchemaExpectation, mode string, logger logrus.FieldLogger) error {
+	var allMissing []string
+
+	for _, exp := range expectations {
+		crd, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(
+			ctx, exp.crdName, metav1.GetOptions{})
+		if err != nil {
+			logger.WithField("crd", exp.crdName).WithError(err).Warn("Could not fetch CRD for schema validation")
+			allMissing = append(allMissing, fmt.Sprintf("%s: could not fetch CRD (%v)", exp.crdName, err))
+			continue
+		}
+
+		var versionSchema *apiextv1.CustomResourceValidation
+		for _, v := range crd.Spec.Versions {
+			if v.Name == exp.apiGroupVersion {
+				versionSchema = v.Schema
+				break
+			}
+		}
+		if versionSchema == nil || versionSchema.OpenAPIV3Schema == nil {
+			logger.WithField("crd", exp.crdName).Warn("CRD has no OpenAPI schema for version " + exp.apiGroupVersion)
+			allMissing = append(allMissing, fmt.Sprintf("%s: no OpenAPI schema for version %s", exp.crdName, exp.apiGroupVersion))
+			continue
+		}
+
+		schema := versionSchema.OpenAPIV3Schema
+
+		missing := checkMissing(exp.specType, schema, "spec", exp.crdName)
+		missing = append(missing, checkMissing(exp.statusType, schema, "status", exp.crdName)...)
+
+		allMissing = append(allMissing, missing...)
+	}
+
+	if len(allMissing) > 0 {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "CRD schema mismatch detected — %d field(s) expected by server not found in installed CRDs. "+
+			"Update CRDs with: velero install --crds-only\n", len(allMissing))
+		for _, m := range allMissing {
+			sb.WriteString("  - " + m + "\n")
+		}
+		msg := sb.String()
+
+		if mode == "strict" {
+			return errors.New(msg)
+		}
+		logger.Error(msg)
+	} else {
+		logger.Info("All CRD schemas match server expectations")
+	}
+
+	return nil
+}
+
+func checkMissing(goType reflect.Type, schema *apiextv1.JSONSchemaProps, section, crdName string) []string {
+	if goType == nil {
+		return nil
+	}
+	expectedFields := jsonFieldNames(goType)
+	installedFields, ok := schemaPropertyNames(schema, section)
+	if !ok {
+		installedFields = sets.New[string]()
+	}
+
+	var missing []string
+	for field := range expectedFields {
+		if !installedFields.Has(field) {
+			missing = append(missing, fmt.Sprintf("%s: %s.%s", crdName, section, field))
+		}
+	}
+	return missing
+}

--- a/pkg/cmd/server/crd_check_test.go
+++ b/pkg/cmd/server/crd_check_test.go
@@ -1,0 +1,373 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	fakeapiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type TestBase struct {
+	Name  string `json:"name"`
+	Count int    `json:"count,omitempty"`
+}
+
+type testSpec struct {
+	Name    string `json:"name"`
+	Count   int    `json:"count,omitempty"`
+	Ignored string `json:"-"`
+	private string
+}
+
+type testSpecWithEmbedded struct {
+	TestBase
+	Extra string `json:"extra"`
+}
+
+// testSpecWithNamedEmbedded mirrors BackupSpec embedding Metadata with an
+// explicit json tag: encoding/json marshals it as a nested "base" object,
+// not promoted/flattened fields.
+type testSpecWithNamedEmbedded struct {
+	TestBase `json:"base,omitempty"`
+	Extra    string `json:"extra"`
+}
+
+func TestJsonFieldNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    reflect.Type
+		expected []string
+	}{
+		{
+			name:     "simple struct",
+			input:    reflect.TypeFor[testSpec](),
+			expected: []string{"name", "count"},
+		},
+		{
+			name:     "pointer to struct",
+			input:    reflect.TypeFor[*testSpec](),
+			expected: []string{"name", "count"},
+		},
+		{
+			name:     "struct with anonymous embedded",
+			input:    reflect.TypeFor[testSpecWithEmbedded](),
+			expected: []string{"name", "count", "extra"},
+		},
+		{
+			name:     "nil type",
+			input:    nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := jsonFieldNames(tc.input)
+			if tc.expected == nil {
+				assert.Nil(t, result)
+				return
+			}
+			for _, field := range tc.expected {
+				assert.True(t, result.Has(field), "expected field %q", field)
+			}
+			assert.False(t, result.Has("Ignored"))
+			assert.False(t, result.Has("private"))
+		})
+	}
+
+	t.Run("embedded field with explicit json tag name is not promoted", func(t *testing.T) {
+		result := jsonFieldNames(reflect.TypeFor[testSpecWithNamedEmbedded]())
+		assert.True(t, result.Has("base"))
+		assert.True(t, result.Has("extra"))
+		assert.False(t, result.Has("name"), "embedded fields should nest under their tag name, not promote")
+		assert.False(t, result.Has("count"), "embedded fields should nest under their tag name, not promote")
+	})
+}
+
+func TestSchemaPropertyNames(t *testing.T) {
+	schema := &apiextv1.JSONSchemaProps{
+		Properties: map[string]apiextv1.JSONSchemaProps{
+			"spec": {
+				Properties: map[string]apiextv1.JSONSchemaProps{
+					"name":  {Type: "string"},
+					"count": {Type: "integer"},
+				},
+			},
+			"status": {
+				Properties: map[string]apiextv1.JSONSchemaProps{
+					"phase":   {Type: "string"},
+					"message": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	t.Run("extract spec properties", func(t *testing.T) {
+		result, ok := schemaPropertyNames(schema, "spec")
+		require.True(t, ok)
+		require.NotNil(t, result)
+		assert.True(t, result.Has("name"))
+		assert.True(t, result.Has("count"))
+		assert.Equal(t, 2, result.Len())
+	})
+
+	t.Run("extract status properties", func(t *testing.T) {
+		result, ok := schemaPropertyNames(schema, "status")
+		require.True(t, ok)
+		require.NotNil(t, result)
+		assert.True(t, result.Has("phase"))
+		assert.True(t, result.Has("message"))
+	})
+
+	t.Run("nonexistent path", func(t *testing.T) {
+		result, ok := schemaPropertyNames(schema, "nonexistent")
+		assert.False(t, ok)
+		assert.Nil(t, result)
+	})
+
+	t.Run("nil schema", func(t *testing.T) {
+		result, ok := schemaPropertyNames(nil, "spec")
+		assert.False(t, ok)
+		assert.Nil(t, result)
+	})
+
+	t.Run("section present but empty", func(t *testing.T) {
+		emptySchema := &apiextv1.JSONSchemaProps{
+			Properties: map[string]apiextv1.JSONSchemaProps{
+				"spec": {},
+			},
+		}
+		result, ok := schemaPropertyNames(emptySchema, "spec")
+		assert.True(t, ok)
+		require.NotNil(t, result)
+		assert.Equal(t, 0, result.Len())
+	})
+}
+
+func TestCheckMissing(t *testing.T) {
+	schema := &apiextv1.JSONSchemaProps{
+		Properties: map[string]apiextv1.JSONSchemaProps{
+			"spec": {
+				Properties: map[string]apiextv1.JSONSchemaProps{
+					"name": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	t.Run("missing field detected", func(t *testing.T) {
+		missing := checkMissing(reflect.TypeFor[testSpec](), schema, "spec", "tests.velero.io")
+		assert.Len(t, missing, 1)
+		assert.Contains(t, missing[0], "count")
+	})
+
+	t.Run("no missing fields", func(t *testing.T) {
+		fullSchema := &apiextv1.JSONSchemaProps{
+			Properties: map[string]apiextv1.JSONSchemaProps{
+				"spec": {
+					Properties: map[string]apiextv1.JSONSchemaProps{
+						"name":  {Type: "string"},
+						"count": {Type: "integer"},
+					},
+				},
+			},
+		}
+		missing := checkMissing(reflect.TypeFor[testSpec](), fullSchema, "spec", "tests.velero.io")
+		assert.Empty(t, missing)
+	})
+
+	t.Run("extra fields in CRD are OK", func(t *testing.T) {
+		extraSchema := &apiextv1.JSONSchemaProps{
+			Properties: map[string]apiextv1.JSONSchemaProps{
+				"spec": {
+					Properties: map[string]apiextv1.JSONSchemaProps{
+						"name":      {Type: "string"},
+						"count":     {Type: "integer"},
+						"newField":  {Type: "string"},
+						"anotherEx": {Type: "boolean"},
+					},
+				},
+			},
+		}
+		missing := checkMissing(reflect.TypeFor[testSpec](), extraSchema, "spec", "tests.velero.io")
+		assert.Empty(t, missing)
+	})
+
+	t.Run("nil go type", func(t *testing.T) {
+		missing := checkMissing(nil, schema, "spec", "tests.velero.io")
+		assert.Nil(t, missing)
+	})
+
+	t.Run("missing schema section reports all expected fields missing", func(t *testing.T) {
+		noSpecSchema := &apiextv1.JSONSchemaProps{
+			Properties: map[string]apiextv1.JSONSchemaProps{
+				"status": {
+					Properties: map[string]apiextv1.JSONSchemaProps{
+						"phase": {Type: "string"},
+					},
+				},
+			},
+		}
+		missing := checkMissing(reflect.TypeFor[testSpec](), noSpecSchema, "spec", "tests.velero.io")
+		assert.Len(t, missing, 2)
+		assert.Contains(t, missing, "tests.velero.io: spec.name")
+		assert.Contains(t, missing, "tests.velero.io: spec.count")
+	})
+}
+
+func TestExpectedCRDSchemas(t *testing.T) {
+	expectations := expectedCRDSchemas()
+	assert.NotEmpty(t, expectations)
+
+	crdNames := make(map[string]bool)
+	for _, exp := range expectations {
+		crdNames[exp.crdName] = true
+		assert.NotEmpty(t, exp.crdName, "CRD name should not be empty")
+		assert.NotEmpty(t, exp.apiGroupVersion, "API group version should not be empty")
+	}
+
+	assert.True(t, crdNames["backups.velero.io"], "should include backups CRD")
+	assert.True(t, crdNames["restores.velero.io"], "should include restores CRD")
+	assert.True(t, crdNames["schedules.velero.io"], "should include schedules CRD")
+	assert.True(t, crdNames["datauploads.velero.io"], "should include datauploads CRD")
+	assert.True(t, crdNames["datadownloads.velero.io"], "should include datadownloads CRD")
+}
+
+func makeCRD(name, version string, specProps, statusProps map[string]apiextv1.JSONSchemaProps) *apiextv1.CustomResourceDefinition {
+	return &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: apiextv1.CustomResourceDefinitionSpec{
+			Versions: []apiextv1.CustomResourceDefinitionVersion{
+				{
+					Name: version,
+					Schema: &apiextv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
+							Properties: map[string]apiextv1.JSONSchemaProps{
+								"spec":   {Properties: specProps},
+								"status": {Properties: statusProps},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestRunCRDSchemaValidation(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	expectations := []crdSchemaExpectation{
+		{
+			crdName:         "tests.velero.io",
+			specType:        reflect.TypeFor[testSpec](),
+			apiGroupVersion: "v1",
+		},
+	}
+
+	t.Run("matching schema passes", func(t *testing.T) {
+		crd := makeCRD("tests.velero.io", "v1",
+			map[string]apiextv1.JSONSchemaProps{
+				"name":  {Type: "string"},
+				"count": {Type: "integer"},
+			}, nil)
+		client := fakeapiext.NewSimpleClientset([]runtime.Object{crd}...)
+		err := runCRDSchemaValidation(ctx, client, expectations, "strict", logger)
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing field in strict mode returns error", func(t *testing.T) {
+		crd := makeCRD("tests.velero.io", "v1",
+			map[string]apiextv1.JSONSchemaProps{
+				"name": {Type: "string"},
+			}, nil)
+		client := fakeapiext.NewSimpleClientset([]runtime.Object{crd}...)
+		err := runCRDSchemaValidation(ctx, client, expectations, "strict", logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "count")
+		assert.Contains(t, err.Error(), "CRD schema mismatch")
+	})
+
+	t.Run("missing field in warn mode logs but no error", func(t *testing.T) {
+		crd := makeCRD("tests.velero.io", "v1",
+			map[string]apiextv1.JSONSchemaProps{
+				"name": {Type: "string"},
+			}, nil)
+		client := fakeapiext.NewSimpleClientset([]runtime.Object{crd}...)
+		err := runCRDSchemaValidation(ctx, client, expectations, "warn", logger)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CRD not found in strict mode returns error", func(t *testing.T) {
+		client := fakeapiext.NewSimpleClientset()
+		err := runCRDSchemaValidation(ctx, client, expectations, "strict", logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tests.velero.io")
+		assert.Contains(t, err.Error(), "could not fetch")
+	})
+
+	t.Run("CRD not found in warn mode logs warning but no error", func(t *testing.T) {
+		client := fakeapiext.NewSimpleClientset()
+		err := runCRDSchemaValidation(ctx, client, expectations, "warn", logger)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CRD with no schema for version in strict mode returns error", func(t *testing.T) {
+		crd := makeCRD("tests.velero.io", "v2",
+			map[string]apiextv1.JSONSchemaProps{
+				"name": {Type: "string"},
+			}, nil)
+		client := fakeapiext.NewSimpleClientset([]runtime.Object{crd}...)
+		err := runCRDSchemaValidation(ctx, client, expectations, "strict", logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tests.velero.io")
+		assert.Contains(t, err.Error(), "no OpenAPI schema for version")
+	})
+
+	t.Run("CRD with no schema for version in warn mode logs warning but no error", func(t *testing.T) {
+		crd := makeCRD("tests.velero.io", "v2",
+			map[string]apiextv1.JSONSchemaProps{
+				"name": {Type: "string"},
+			}, nil)
+		client := fakeapiext.NewSimpleClientset([]runtime.Object{crd}...)
+		err := runCRDSchemaValidation(ctx, client, expectations, "warn", logger)
+		assert.NoError(t, err)
+	})
+
+	t.Run("extra fields in CRD are OK", func(t *testing.T) {
+		crd := makeCRD("tests.velero.io", "v1",
+			map[string]apiextv1.JSONSchemaProps{
+				"name":     {Type: "string"},
+				"count":    {Type: "integer"},
+				"newField": {Type: "string"},
+			}, nil)
+		client := fakeapiext.NewSimpleClientset([]runtime.Object{crd}...)
+		err := runCRDSchemaValidation(ctx, client, expectations, "strict", logger)
+		assert.NoError(t, err)
+	})
+}

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -361,6 +361,10 @@ func (s *server) run() error {
 		return err
 	}
 
+	if err := s.validateCRDSchemas(); err != nil {
+		return err
+	}
+
 	s.checkNodeAgent()
 
 	if err := s.initRepoManager(); err != nil {

--- a/test/e2e/basic/crd-schema-check/crd_schema_check.go
+++ b/test/e2e/basic/crd-schema-check/crd_schema_check.go
@@ -1,0 +1,640 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
+	. "github.com/vmware-tanzu/velero/test"
+)
+
+var veleroCfg VeleroConfig
+
+const (
+	crdSchemaCheckCRDName   = "serverstatusrequests.velero.io"
+	crdSchemaCheckFieldPath = "/spec/versions/0/schema/openAPIV3Schema/properties/status/properties/serverVersion"
+	crdSchemaCheckFlag      = "--crd-schema-check="
+
+	// backuprepositories.velero.io is used here (rather than backups.velero.io) because it isn't
+	// touched by concurrently-run E2E tests: mutating and restoring the schema of a CRD that other
+	// tests actively create/read (like Backup) risks racing with their real backup/restore calls.
+	crdSchemaCheckSpecCRDName   = "backuprepositories.velero.io"
+	crdSchemaCheckSpecFieldPath = "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/backupStorageLocation"
+
+	crdSchemaCheckLogMismatch = "CRD schema mismatch detected"
+	crdSchemaCheckLogRunning  = "Validating CRD schemas match server expectations"
+	crdSchemaCheckLogSuccess  = "All CRD schemas match server expectations"
+)
+
+// crdSchemaMutation records a single field removed from a CRD's schema by removeCRDSchemaProperty,
+// so it can be restored independently of any other mutation made in the same test.
+type crdSchemaMutation struct {
+	crdName       string
+	fieldPath     string
+	originalValue json.RawMessage
+}
+
+// CRDSchemaCheckTest exercises the --crd-schema-check server flag (warn/strict/skip) by
+// temporarily removing a known field from an installed CRD's schema and verifying the
+// resulting velero server behavior and log output for each mode.
+func CRDSchemaCheckTest() {
+	var (
+		ctx          context.Context
+		cancel       context.CancelFunc
+		ns           string
+		originalArgs []string
+		mutations    []crdSchemaMutation
+		argsMutated  bool
+	)
+
+	removeAndTrack := func(crdName, path string) {
+		orig, err := removeCRDSchemaProperty(ctx, crdName, path)
+		// Track whenever we have an original value to restore, even if the patch call itself
+		// errored — the underlying kubectl patch may have landed despite a client-observed
+		// error, and skipping the tracking here would leave AfterEach unaware it needs to
+		// restore a CRD schema that's actually been mutated.
+		if orig != nil {
+			mutations = append(mutations, crdSchemaMutation{crdName: crdName, fieldPath: path, originalValue: orig})
+		}
+		Expect(err).ShouldNot(HaveOccurred())
+	}
+
+	BeforeEach(func() {
+		veleroCfg = VeleroCfg
+		ctx, cancel = context.WithTimeout(context.Background(), 15*time.Minute)
+		ns = veleroCfg.VeleroNamespace
+		mutations = nil
+		argsMutated = false
+
+		var err error
+		originalArgs, err = getVeleroContainerArgs(ctx, ns)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		cancel()
+		if CurrentSpecReport().Failed() && veleroCfg.FailFast {
+			fmt.Println("Test case failed and fail fast is enabled. Skip resource clean up.")
+			return
+		}
+
+		// Each restore step is attempted independently (rather than aborting on the first
+		// failure via Expect(...).To(Succeed())) so that a failure restoring a CRD schema
+		// doesn't leave the shared velero Deployment stuck with a test-only --crd-schema-check
+		// arg for the rest of the suite run, and vice versa.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cleanupCancel()
+
+		var cleanupErrs []error
+		crdMutated := len(mutations) > 0
+		if crdMutated {
+			By("Restoring original CRD schema(s)", func() {
+				for _, m := range mutations {
+					if err := restoreCRDSchemaProperty(cleanupCtx, m.crdName, m.fieldPath, m.originalValue); err != nil {
+						cleanupErrs = append(cleanupErrs, err)
+					}
+				}
+			})
+		}
+		if argsMutated {
+			By("Restoring original velero deployment args", func() {
+				if err := setVeleroContainerArgs(cleanupCtx, ns, originalArgs); err != nil {
+					cleanupErrs = append(cleanupErrs, err)
+				} else if err := waitForVeleroRollout(cleanupCtx, ns, 3*time.Minute); err != nil {
+					cleanupErrs = append(cleanupErrs, err)
+				}
+			})
+		} else if crdMutated {
+			// Args were left alone, so the running pod never re-validated against the restored
+			// schema. Restart so the next test starts from a clean, settled pod.
+			By("Restarting velero deployment to pick up restored CRD schema(s)", func() {
+				if err := restartVeleroDeployment(cleanupCtx, ns); err != nil {
+					cleanupErrs = append(cleanupErrs, err)
+				} else if err := waitForVeleroRollout(cleanupCtx, ns, 3*time.Minute); err != nil {
+					cleanupErrs = append(cleanupErrs, err)
+				}
+			})
+		}
+		Expect(cleanupErrs).To(BeEmpty())
+	})
+
+	It("should log a warning and keep running when the CRD schema mismatches in warn mode", func() {
+		By("Removing status.serverVersion from the CRD schema", func() {
+			removeAndTrack(crdSchemaCheckCRDName, crdSchemaCheckFieldPath)
+		})
+
+		By(fmt.Sprintf("Setting velero deployment args to include %swarn", crdSchemaCheckFlag), func() {
+			err := setVeleroContainerArgs(ctx, ns, append(originalArgs, crdSchemaCheckFlag+"warn"))
+			argsMutated = true
+			Expect(err).To(Succeed())
+		})
+
+		By("Waiting for the velero deployment to roll out successfully despite the schema mismatch", func() {
+			Expect(waitForVeleroRollout(ctx, ns, 3*time.Minute)).To(Succeed())
+		})
+
+		By("Verifying the velero pod logs contain the CRD schema mismatch warning", func() {
+			podName, err := getVeleroPodName(ctx, ns)
+			Expect(err).ShouldNot(HaveOccurred())
+			logs, err := getPodLogs(ctx, ns, podName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(logs).To(ContainSubstring(crdSchemaCheckLogMismatch))
+		})
+	})
+
+	It("should fail to start when the CRD schema mismatches in strict mode", func() {
+		oldPods, err := listVeleroPodNames(ctx, ns)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("Removing status.serverVersion from the CRD schema", func() {
+			removeAndTrack(crdSchemaCheckCRDName, crdSchemaCheckFieldPath)
+		})
+
+		By(fmt.Sprintf("Setting velero deployment args to include %sstrict", crdSchemaCheckFlag), func() {
+			err := setVeleroContainerArgs(ctx, ns, append(originalArgs, crdSchemaCheckFlag+"strict"))
+			argsMutated = true
+			Expect(err).To(Succeed())
+		})
+
+		var newPod string
+		By("Waiting for a new velero pod to be created for the updated deployment", func() {
+			newPod, err = waitForNewVeleroPod(ctx, ns, oldPods, 2*time.Minute)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		By("Waiting for the new velero pod to fail to start due to the schema mismatch", func() {
+			Expect(waitForVeleroContainerFailure(ctx, ns, newPod, 3*time.Minute)).To(Succeed())
+		})
+
+		By("Verifying the velero pod logs contain the CRD schema mismatch error", func() {
+			logs, err := getPodLogs(ctx, ns, newPod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(logs).To(ContainSubstring(crdSchemaCheckLogMismatch))
+		})
+	})
+
+	It("should skip CRD schema validation entirely in skip mode", func() {
+		By("Removing status.serverVersion from the CRD schema", func() {
+			removeAndTrack(crdSchemaCheckCRDName, crdSchemaCheckFieldPath)
+		})
+
+		By(fmt.Sprintf("Setting velero deployment args to include %sskip", crdSchemaCheckFlag), func() {
+			err := setVeleroContainerArgs(ctx, ns, append(originalArgs, crdSchemaCheckFlag+"skip"))
+			argsMutated = true
+			Expect(err).To(Succeed())
+		})
+
+		By("Waiting for the velero deployment to roll out successfully", func() {
+			Expect(waitForVeleroRollout(ctx, ns, 3*time.Minute)).To(Succeed())
+		})
+
+		By("Verifying the velero pod logs do not contain CRD schema validation messages", func() {
+			podName, err := getVeleroPodName(ctx, ns)
+			Expect(err).ShouldNot(HaveOccurred())
+			logs, err := getPodLogs(ctx, ns, podName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(logs).NotTo(ContainSubstring(crdSchemaCheckLogRunning))
+		})
+	})
+
+	It("should fail to start when an invalid --crd-schema-check value is provided", func() {
+		oldPods, err := listVeleroPodNames(ctx, ns)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By(fmt.Sprintf("Setting velero deployment args to include %sfoo", crdSchemaCheckFlag), func() {
+			err := setVeleroContainerArgs(ctx, ns, append(originalArgs, crdSchemaCheckFlag+"foo"))
+			argsMutated = true
+			Expect(err).To(Succeed())
+		})
+
+		var newPod string
+		By("Waiting for a new velero pod to be created for the updated deployment", func() {
+			newPod, err = waitForNewVeleroPod(ctx, ns, oldPods, 2*time.Minute)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		By("Waiting for the new velero pod to fail to start due to the invalid flag value", func() {
+			Expect(waitForVeleroContainerFailure(ctx, ns, newPod, 3*time.Minute)).To(Succeed())
+		})
+
+		By("Verifying the velero pod logs contain the invalid value error", func() {
+			logs, err := getPodLogs(ctx, ns, newPod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(logs).To(ContainSubstring("invalid value"))
+		})
+	})
+
+	It("should log a warning and keep running when the CRD schema mismatches in default mode", func() {
+		By("Removing status.serverVersion from the CRD schema", func() {
+			removeAndTrack(crdSchemaCheckCRDName, crdSchemaCheckFieldPath)
+		})
+
+		By("Restarting the velero deployment without changing its args", func() {
+			Expect(restartVeleroDeployment(ctx, ns)).To(Succeed())
+			Expect(waitForVeleroRollout(ctx, ns, 3*time.Minute)).To(Succeed())
+		})
+
+		By("Verifying the velero pod logs contain the CRD schema mismatch warning", func() {
+			podName, err := getVeleroPodName(ctx, ns)
+			Expect(err).ShouldNot(HaveOccurred())
+			logs, err := getPodLogs(ctx, ns, podName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(logs).To(ContainSubstring(crdSchemaCheckLogMismatch))
+		})
+	})
+
+	It("should log success when CRD schemas are unmodified", func() {
+		By("Restarting the velero deployment to capture a fresh validation run", func() {
+			Expect(restartVeleroDeployment(ctx, ns)).To(Succeed())
+			Expect(waitForVeleroRollout(ctx, ns, 3*time.Minute)).To(Succeed())
+		})
+
+		By("Verifying the velero pod logs report success and no mismatch", func() {
+			podName, err := getVeleroPodName(ctx, ns)
+			Expect(err).ShouldNot(HaveOccurred())
+			logs, err := getPodLogs(ctx, ns, podName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(logs).To(ContainSubstring(crdSchemaCheckLogSuccess))
+			Expect(logs).NotTo(ContainSubstring(crdSchemaCheckLogMismatch))
+		})
+	})
+
+	It("should log a warning and keep running when a spec field mismatches in warn mode", func() {
+		By("Removing spec.backupStorageLocation from the backuprepositories CRD schema", func() {
+			removeAndTrack(crdSchemaCheckSpecCRDName, crdSchemaCheckSpecFieldPath)
+		})
+
+		By(fmt.Sprintf("Setting velero deployment args to include %swarn", crdSchemaCheckFlag), func() {
+			err := setVeleroContainerArgs(ctx, ns, append(originalArgs, crdSchemaCheckFlag+"warn"))
+			argsMutated = true
+			Expect(err).To(Succeed())
+		})
+
+		By("Waiting for the velero deployment to roll out successfully despite the schema mismatch", func() {
+			Expect(waitForVeleroRollout(ctx, ns, 3*time.Minute)).To(Succeed())
+		})
+
+		By("Verifying the velero pod logs contain the spec field CRD schema mismatch warning", func() {
+			podName, err := getVeleroPodName(ctx, ns)
+			Expect(err).ShouldNot(HaveOccurred())
+			logs, err := getPodLogs(ctx, ns, podName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(logs).To(ContainSubstring(crdSchemaCheckLogMismatch))
+			Expect(logs).To(ContainSubstring("backuprepositories.velero.io: spec.backupStorageLocation"))
+		})
+	})
+
+	It("should fail to start when multiple CRDs have multiple missing fields in strict mode", func() {
+		oldPods, err := listVeleroPodNames(ctx, ns)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("Removing status.serverVersion from the serverstatusrequests CRD schema", func() {
+			removeAndTrack(crdSchemaCheckCRDName, crdSchemaCheckFieldPath)
+		})
+
+		By("Removing spec.backupStorageLocation from the backuprepositories CRD schema", func() {
+			removeAndTrack(crdSchemaCheckSpecCRDName, crdSchemaCheckSpecFieldPath)
+		})
+
+		By(fmt.Sprintf("Setting velero deployment args to include %sstrict", crdSchemaCheckFlag), func() {
+			err := setVeleroContainerArgs(ctx, ns, append(originalArgs, crdSchemaCheckFlag+"strict"))
+			argsMutated = true
+			Expect(err).To(Succeed())
+		})
+
+		var newPod string
+		By("Waiting for a new velero pod to be created for the updated deployment", func() {
+			newPod, err = waitForNewVeleroPod(ctx, ns, oldPods, 2*time.Minute)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		By("Waiting for the new velero pod to fail to start due to the schema mismatches", func() {
+			Expect(waitForVeleroContainerFailure(ctx, ns, newPod, 3*time.Minute)).To(Succeed())
+		})
+
+		By("Verifying the velero pod logs contain both CRD schema mismatches", func() {
+			logs, err := getPodLogs(ctx, ns, newPod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(logs).To(ContainSubstring("serverstatusrequests.velero.io: status.serverVersion"))
+			Expect(logs).To(ContainSubstring("backuprepositories.velero.io: spec.backupStorageLocation"))
+		})
+	})
+}
+
+// getVeleroContainerArgs returns the current args of the "velero" container in the velero Deployment.
+func getVeleroContainerArgs(ctx context.Context, ns string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "deployment", "velero", "-n", ns,
+		"-o", `jsonpath={.spec.template.spec.containers[?(@.name=="velero")].args}`)
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, stderr)
+	}
+	var args []string
+	stdout = strings.TrimSpace(stdout)
+	if stdout == "" {
+		return args, nil
+	}
+	if err := json.Unmarshal([]byte(stdout), &args); err != nil {
+		return nil, errors.Wrapf(err, "parsing velero container args from %q", stdout)
+	}
+	return args, nil
+}
+
+// setVeleroContainerArgs replaces the args of the "velero" container in the velero Deployment.
+func setVeleroContainerArgs(ctx context.Context, ns string, args []string) error {
+	argsJSON, err := json.Marshal(args)
+	if err != nil {
+		return errors.Wrap(err, "marshaling velero container args")
+	}
+	patch := fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"name":"velero","args":%s}]}}}}`, argsJSON)
+	cmd := exec.CommandContext(ctx, "kubectl", "patch", "deployment", "velero", "-n", ns,
+		"--type=strategic", "-p", patch)
+	_, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return errors.Wrap(err, stderr)
+	}
+	return nil
+}
+
+// getCRDSchemaProperty returns the raw JSON value at path within the CRD's spec.
+func getCRDSchemaProperty(ctx context.Context, crdName, path string) (json.RawMessage, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "crd", crdName, "-o", "json")
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, stderr)
+	}
+	return jsonPointerGet([]byte(stdout), path)
+}
+
+// jsonPointerGet resolves an RFC 6901 JSON Pointer against doc and returns the value found there.
+func jsonPointerGet(doc []byte, pointer string) (json.RawMessage, error) {
+	var v any
+	if err := json.Unmarshal(doc, &v); err != nil {
+		return nil, errors.Wrap(err, "parsing document")
+	}
+
+	pointer = strings.TrimPrefix(pointer, "/")
+	for _, tok := range strings.Split(pointer, "/") {
+		tok = strings.NewReplacer("~1", "/", "~0", "~").Replace(tok)
+		switch node := v.(type) {
+		case map[string]any:
+			val, ok := node[tok]
+			if !ok {
+				return nil, errors.Errorf("path %q not found: missing key %q", pointer, tok)
+			}
+			v = val
+		case []any:
+			idx, err := strconv.Atoi(tok)
+			if err != nil || idx < 0 || idx >= len(node) {
+				return nil, errors.Errorf("path %q not found: invalid index %q", pointer, tok)
+			}
+			v = node[idx]
+		default:
+			return nil, errors.Errorf("path %q not found: unexpected node type at %q", pointer, tok)
+		}
+	}
+	return json.Marshal(v)
+}
+
+// removeCRDSchemaProperty removes the field at path from the CRD's (single-version) OpenAPI schema,
+// returning the field's original value so it can be restored later via restoreCRDSchemaProperty. The
+// original value is returned even when the patch call itself errors (e.g. a client-side timeout on a
+// request that actually landed), so the caller can still track and restore it.
+func removeCRDSchemaProperty(ctx context.Context, crdName, path string) (json.RawMessage, error) {
+	orig, err := getCRDSchemaProperty(ctx, crdName, path)
+	if err != nil {
+		return nil, err
+	}
+
+	patch := fmt.Sprintf(`[{"op":"remove","path":"%s"}]`, path)
+	cmd := exec.CommandContext(ctx, "kubectl", "patch", "crd", crdName, "--type=json", "-p", patch)
+	_, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return orig, errors.Wrap(err, stderr)
+	}
+	return orig, nil
+}
+
+// restoreCRDSchemaProperty adds back the field at path to the CRD's (single-version) OpenAPI schema,
+// using the original value captured by removeCRDSchemaProperty.
+func restoreCRDSchemaProperty(ctx context.Context, crdName, path string, value json.RawMessage) error {
+	patch := fmt.Sprintf(`[{"op":"add","path":"%s","value":%s}]`, path, value)
+	cmd := exec.CommandContext(ctx, "kubectl", "patch", "crd", crdName, "--type=json", "-p", patch)
+	_, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return errors.Wrap(err, stderr)
+	}
+	return nil
+}
+
+// restartVeleroDeployment triggers a rollout restart of the velero Deployment, forcing a fresh
+// pod even when its container args are unchanged (e.g. to re-run CRD schema validation after the
+// CRD schema itself was mutated/restored rather than the deployment's args).
+func restartVeleroDeployment(ctx context.Context, ns string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "rollout", "restart", "deployment/velero", "-n", ns)
+	_, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return errors.Wrap(err, stderr)
+	}
+	return nil
+}
+
+// waitForVeleroRollout waits for the velero Deployment rollout to complete successfully, and for
+// the resulting pod to reach its main run loop. The velero Deployment defines no readiness probe,
+// so Kubernetes reports the pod Ready as soon as its container starts — well before
+// --crd-schema-check validation and controller-runtime cache sync finish. Without the extra wait,
+// a test elsewhere in the suite that immediately performs a real operation (e.g. creating a
+// backup) can race ahead of a just-restarted server that isn't actually ready yet.
+func waitForVeleroRollout(ctx context.Context, ns string, timeout time.Duration) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "rollout", "status", "deployment/velero",
+		"-n", ns, fmt.Sprintf("--timeout=%s", timeout))
+	_, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return errors.Wrap(err, stderr)
+	}
+	return waitForVeleroServerStarting(ctx, ns, timeout)
+}
+
+// waitForVeleroServerStarting polls the current velero pod's logs until the server has logged
+// "Server starting..." (emitted just before the controller-runtime manager starts, after
+// --crd-schema-check validation completes), or timeout elapses.
+func waitForVeleroServerStarting(ctx context.Context, ns string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if podName, err := getVeleroPodName(ctx, ns); err == nil {
+			if logs, err := getPodLogs(ctx, ns, podName); err == nil && strings.Contains(logs, "Server starting...") {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return errors.Errorf("timed out waiting for velero server to start in namespace %s", ns)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+// listVeleroPodNames returns the names of pods matching the velero Deployment's pod label selector.
+func listVeleroPodNames(ctx context.Context, ns string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "pods", "-n", ns, "-l", "deploy=velero",
+		"-o", "jsonpath={.items[*].metadata.name}")
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, stderr)
+	}
+	stdout = strings.TrimSpace(stdout)
+	if stdout == "" {
+		return nil, nil
+	}
+	return strings.Fields(stdout), nil
+}
+
+// getVeleroPodName returns the single Running velero pod name, for use once the deployment has
+// settled on exactly one ready pod (e.g. after a successful rollout). It retries briefly because
+// a terminating old-ReplicaSet pod can still report phase=Running for a few seconds after
+// `kubectl rollout status` considers the rollout complete.
+func getVeleroPodName(ctx context.Context, ns string) (string, error) {
+	var lastErr error
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		cmd := exec.CommandContext(ctx, "kubectl", "get", "pods", "-n", ns, "-l", "deploy=velero",
+			"--field-selector=status.phase=Running",
+			"-o", "jsonpath={.items[*].metadata.name}")
+		stdout, stderr, err := veleroexec.RunCommand(cmd)
+		if err != nil {
+			lastErr = errors.Wrap(err, stderr)
+		} else {
+			pods := strings.Fields(strings.TrimSpace(stdout))
+			if len(pods) == 1 {
+				return pods[0], nil
+			}
+			lastErr = errors.Errorf("expected exactly one Running velero pod, found %d: %v", len(pods), pods)
+		}
+
+		if time.Now().After(deadline) {
+			return "", lastErr
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// waitForNewVeleroPod polls until a velero pod appears whose name was not in oldPods, returning
+// its name. This is needed because a Deployment update surges a new pod alongside the old one
+// rather than replacing it in place when the new pod never becomes ready (as in strict mode).
+func waitForNewVeleroPod(ctx context.Context, ns string, oldPods []string, timeout time.Duration) (string, error) {
+	oldSet := make(map[string]bool, len(oldPods))
+	for _, p := range oldPods {
+		oldSet[p] = true
+	}
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		pods, err := listVeleroPodNames(ctx, ns)
+		if err == nil {
+			for _, p := range pods {
+				if !oldSet[p] {
+					return p, nil
+				}
+			}
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return "", errors.New("timed out waiting for a new velero pod to be created")
+}
+
+type containerStatusInfo struct {
+	RestartCount int32 `json:"restartCount"`
+	State        struct {
+		Waiting *struct {
+			Reason string `json:"reason"`
+		} `json:"waiting"`
+		Terminated *struct {
+			ExitCode int32 `json:"exitCode"`
+		} `json:"terminated"`
+	} `json:"state"`
+}
+
+// veleroContainerFailed reports whether the named pod's "velero" container has failed to start:
+// either it has already restarted, is waiting in a crash-loop backoff state, or its most recent
+// run terminated with a non-zero exit code.
+func veleroContainerFailed(ctx context.Context, ns, podName string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "pod", podName, "-n", ns,
+		"-o", `jsonpath={.status.containerStatuses[?(@.name=="velero")]}`)
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return false, errors.Wrap(err, stderr)
+	}
+	stdout = strings.TrimSpace(stdout)
+	if stdout == "" {
+		return false, nil
+	}
+
+	var status containerStatusInfo
+	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+		return false, errors.Wrapf(err, "parsing container status from %q", stdout)
+	}
+
+	if status.RestartCount > 0 {
+		return true, nil
+	}
+	if status.State.Waiting != nil &&
+		(status.State.Waiting.Reason == "CrashLoopBackOff" || status.State.Waiting.Reason == "Error") {
+		return true, nil
+	}
+	if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+// waitForVeleroContainerFailure polls until veleroContainerFailed reports true for podName.
+func waitForVeleroContainerFailure(ctx context.Context, ns, podName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		failed, err := veleroContainerFailed(ctx, ns, podName)
+		if err == nil && failed {
+			return nil
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return errors.Errorf("timed out waiting for velero pod %s to fail to start", podName)
+}
+
+// getPodLogs returns the current logs of the "velero" container in podName.
+func getPodLogs(ctx context.Context, ns, podName string) (string, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", "logs", podName, "-n", ns, "-c", "velero")
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return "", errors.Wrap(err, stderr)
+	}
+	return stdout, nil
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -36,6 +36,7 @@ import (
 	. "github.com/vmware-tanzu/velero/test/e2e/basic"
 	. "github.com/vmware-tanzu/velero/test/e2e/basic/api-group"
 	. "github.com/vmware-tanzu/velero/test/e2e/basic/backup-volume-info"
+	. "github.com/vmware-tanzu/velero/test/e2e/basic/crd-schema-check"
 	. "github.com/vmware-tanzu/velero/test/e2e/basic/resources-check"
 	. "github.com/vmware-tanzu/velero/test/e2e/bsl-mgmt"
 	. "github.com/vmware-tanzu/velero/test/e2e/migration"
@@ -437,6 +438,12 @@ var _ = Describe(
 	"Storage class of persistent volumes and persistent volume claims can be changed during restores",
 	Label("Basic", "StorageClass"),
 	StorageClasssChangingTest,
+)
+
+var _ = Describe(
+	"The --crd-schema-check server flag controls startup behavior on CRD schema mismatch",
+	Label("Basic", "CRDSchemaCheck"),
+	CRDSchemaCheckTest,
 )
 
 var _ = Describe(


### PR DESCRIPTION
## Summary

- Add CRD schema validation during server startup that checks installed CRD schemas contain all fields the server expects
- Uses reflection on Go API types to derive expected JSON field names, then compares against OpenAPI v3 schema properties in installed CRDs
- Configurable via `--crd-schema-check` flag: `warn` (default), `strict`, `skip`

Fixes #9260

## Design

**Approach**: Schema property validation (from [issue discussion](https://github.com/vmware-tanzu/velero/issues/9260#issuecomment-3286953150))

- Reflects on Go API types (`BackupSpec`, `RestoreSpec`, etc.) at runtime to get expected JSON field names
- Fetches installed CRDs via apiextensions client and extracts OpenAPI v3 schema properties
- Reports missing fields (server expects a field the CRD doesn't have = outdated CRD)
- Extra fields in CRD are OK (forward-compatible)
- No additional RBAC needed — Velero already has CRD Get permissions

**Key decisions**:
- Schema-based over version-label-based (per sseago's feedback — CRD changes can happen without controller-gen upgrades)
- Default to `warn` for backward compatibility
- Suggests `velero install --crds-only` in error message (#9132 already merged)

**Hardening fixes made during review (thanks to Copilot + CodeRabbit findings)**:
- `--crd-schema-check` is now backed by a validated enum flag, so an invalid value (e.g. `--crd-schema-check=foo`) is rejected at parse time instead of silently behaving like `warn`.
- `strict` mode now fails startup when a CRD can't be fetched or has no OpenAPI schema for the expected version, instead of only warning and continuing.
- `schemaPropertyNames` distinguishes "reached the schema node, it legitimately declares no properties" from "couldn't traverse there at all", so a missing `spec`/`status` block is no longer silently skipped.
- `jsonFieldNames` only flattens anonymous/embedded struct fields when they have no `json` tag, matching `encoding/json`'s actual behavior — it previously flattened unconditionally, producing a phantom top-level `spec.labels` expectation for `Backup` (`BackupSpec` embeds `Metadata` as `json:"metadata,omitempty"`, so it's really nested under `spec.metadata.labels`).
- The CRD `Get` call now uses the server's cancellable context (`s.ctx`) instead of `context.TODO()`.
- E2E cleanup tracking (which CRD schemas / container args to restore) is recorded as soon as the original value is known, before asserting on the mutating call's result, so a client-observed error on a patch that actually landed server-side doesn't leave `AfterEach` unaware it needs to restore state.

## Files changed

| File | Change |
|------|--------|
| `pkg/cmd/server/crd_check.go` | New — expected schema extraction + validation logic |
| `pkg/cmd/server/crd_check_test.go` | New — unit tests |
| `pkg/cmd/server/server.go` | Call `validateCRDSchemas()` after `veleroResourcesExist()` |
| `pkg/cmd/server/config/config.go` | Add `CRDSchemaCheck` field (validated enum flag) + `--crd-schema-check` flag |
| `test/e2e/basic/crd-schema-check/crd_schema_check.go` | New — kind E2E test covering warn/strict/skip/default modes, invalid flag rejection, spec-field mismatch, multiple missing fields across multiple CRDs, and a clean no-mismatch success case |
| `test/e2e/e2e_suite_test.go` | Register new `CRDSchemaCheck` Ginkgo test |
| `.github/workflows/e2e-test-kind.yaml` | Give `CRDSchemaCheck` its own isolated CI job/label filter, separate from the Basic test matrix entry — an earlier version shared it with ClusterResource/NodePort/StorageClass and its CRD-mutating tests intermittently raced with those tests' real backup creation, hanging CI for 30 minutes on some k8s versions |

## Test plan

- [x] Unit tests pass for `jsonFieldNames`, `schemaPropertyNames`, `checkMissing`, `expectedCRDSchemas`, `runCRDSchemaValidation` (mode handling, CRD-fetch failure, missing-schema failure)
- [x] E2E: warn mode logs a mismatch and keeps running
- [x] E2E: strict mode fails to start on a status-field mismatch
- [x] E2E: skip mode runs no validation
- [x] E2E: invalid `--crd-schema-check` value fails to start with a clear error
- [x] E2E: default mode (flag omitted) behaves like warn
- [x] E2E: spec-field mismatch (not just status) is detected
- [x] E2E: multiple missing fields across multiple CRDs are all reported in strict mode
- [x] E2E: clean install with unmodified CRDs logs success and no mismatch

> [!Note]
> Responses generated with Claude