### PR TITLE
Support copying namespace-scoped secrets/configmaps for backup and restore PVC provisioning

### DIFF
--- a/changelogs/unreleased/9920-shubham-pampattiwar
+++ b/changelogs/unreleased/9920-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Support copying namespace-scoped secrets for backup PVC provisioning to enable datamover backups of encrypted CSI volumes

--- a/changelogs/unreleased/9920-shubham-pampattiwar
+++ b/changelogs/unreleased/9920-shubham-pampattiwar
@@ -1,1 +1,1 @@
-Support copying namespace-scoped secrets for backup PVC provisioning to enable datamover backups of encrypted CSI volumes
+Support copying namespace-scoped secrets and configmaps for backup and restore PVC provisioning to enable datamover backup/restore of encrypted CSI volumes

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,16 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumerclaims
   - persistentvolumes
   - pods

--- a/pkg/controller/data_download_controller.go
+++ b/pkg/controller/data_download_controller.go
@@ -131,6 +131,7 @@ func NewDataDownloadReconciler(
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get
 // +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get
 // +kubebuilder:rbac:groups="",resources=persistentvolumerclaims,verbs=get
+// +kubebuilder:rbac:groups="",resources=secrets;configmaps,verbs=get;list;create;delete
 
 func (r *DataDownloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.logger.WithFields(logrus.Fields{

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -270,24 +270,6 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 		}
 
-		// Copy secrets required for backup PVC provisioning (e.g., encrypted volumes with KMS).
-		// This must happen before Expose() since Expose() errors are non-retryable.
-		// On collision (same secret name, different data from another DataUpload), requeue.
-		if du.Spec.CSISnapshot != nil {
-			if bpvcConfig, exists := r.backupPVCConfig[du.Spec.CSISnapshot.StorageClass]; exists {
-				for _, secretName := range bpvcConfig.SecretNames {
-					if copyErr := kube.CopySecret(ctx, r.kubeClient.CoreV1(), secretName,
-						du.Spec.SourceNamespace, du.Namespace, du.Name, log); copyErr != nil {
-						if errors.Is(copyErr, kube.ErrSecretCollision) {
-							log.Infof("Secret %s collision detected, requeue later", secretName)
-							return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
-						}
-						return r.errorOut(ctx, du, copyErr, "error copying secret for backup PVC", log)
-					}
-				}
-			}
-		}
-
 		log.Info("Data upload starting")
 
 		accepted, err := r.acceptDataUpload(ctx, du)
@@ -301,6 +283,26 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 
 		log.Info("Data upload is accepted")
+
+		// Copy secrets and configmaps required for backup PVC provisioning
+		// (e.g., encrypted volumes with KMS). Done after accept so only the
+		// accepting node handles it, avoiding multi-node contest.
+		if du.Spec.CSISnapshot != nil {
+			if bpvcConfig, exists := r.backupPVCConfig[du.Spec.CSISnapshot.StorageClass]; exists {
+				for _, secretName := range bpvcConfig.SecretNames {
+					if copyErr := kube.CopySecret(ctx, r.kubeClient.CoreV1(), secretName,
+						du.Spec.SourceNamespace, du.Namespace, du.Name, log); copyErr != nil {
+						return r.errorOut(ctx, du, copyErr, "error copying secret for backup PVC", log)
+					}
+				}
+				for _, cmName := range bpvcConfig.ConfigMapNames {
+					if copyErr := kube.CopyConfigMap(ctx, r.kubeClient.CoreV1(), cmName,
+						du.Spec.SourceNamespace, du.Namespace, du.Name, log); copyErr != nil {
+						return r.errorOut(ctx, du, copyErr, "error copying configmap for backup PVC", log)
+					}
+				}
+			}
+		}
 
 		exposeParam, err := r.setupExposeParam(du)
 		if err != nil {

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -270,6 +270,24 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
 		}
 
+		// Copy secrets required for backup PVC provisioning (e.g., encrypted volumes with KMS).
+		// This must happen before Expose() since Expose() errors are non-retryable.
+		// On collision (same secret name, different data from another DataUpload), requeue.
+		if du.Spec.CSISnapshot != nil {
+			if bpvcConfig, exists := r.backupPVCConfig[du.Spec.CSISnapshot.StorageClass]; exists {
+				for _, secretName := range bpvcConfig.SecretNames {
+					if copyErr := kube.CopySecret(ctx, r.kubeClient.CoreV1(), secretName,
+						du.Spec.SourceNamespace, du.Namespace, du.Name, log); copyErr != nil {
+						if errors.Is(copyErr, kube.ErrSecretCollision) {
+							log.Infof("Secret %s collision detected, requeue later", secretName)
+							return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+						}
+						return r.errorOut(ctx, du, copyErr, "error copying secret for backup PVC", log)
+					}
+				}
+			}
+		}
+
 		log.Info("Data upload starting")
 
 		accepted, err := r.acceptDataUpload(ctx, du)

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -284,26 +284,6 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		log.Info("Data upload is accepted")
 
-		// Copy secrets and configmaps required for backup PVC provisioning
-		// (e.g., encrypted volumes with KMS). Done after accept so only the
-		// accepting node handles it, avoiding multi-node contest.
-		if du.Spec.CSISnapshot != nil {
-			if bpvcConfig, exists := r.backupPVCConfig[du.Spec.CSISnapshot.StorageClass]; exists {
-				for _, secretName := range bpvcConfig.SecretNames {
-					if copyErr := kube.CopySecret(ctx, r.kubeClient.CoreV1(), secretName,
-						du.Spec.SourceNamespace, du.Namespace, du.Name, log); copyErr != nil {
-						return r.errorOut(ctx, du, copyErr, "error copying secret for backup PVC", log)
-					}
-				}
-				for _, cmName := range bpvcConfig.ConfigMapNames {
-					if copyErr := kube.CopyConfigMap(ctx, r.kubeClient.CoreV1(), cmName,
-						du.Spec.SourceNamespace, du.Namespace, du.Name, log); copyErr != nil {
-						return r.errorOut(ctx, du, copyErr, "error copying configmap for backup PVC", log)
-					}
-				}
-			}
-		}
-
 		exposeParam, err := r.setupExposeParam(du)
 		if err != nil {
 			return r.errorOut(ctx, du, err, "failed to set exposer parameters", log)

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -143,6 +143,7 @@ func NewDataUploadReconciler(
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get
 // +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get
 // +kubebuilder:rbac:groups="",resources=persistentvolumerclaims,verbs=get
+// +kubebuilder:rbac:groups="",resources=secrets;configmaps,verbs=get;list;create;delete
 
 func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.logger.WithFields(logrus.Fields{

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -139,6 +139,27 @@ func (e *csiSnapshotExposer) Expose(ctx context.Context, ownerObject corev1api.O
 		"owner": ownerObject.Name,
 	})
 
+	// Copy secrets and configmaps from source namespace to Velero namespace if configured.
+	// Done before creating any intermediate objects so failure doesn't require cleanup.
+	// These are needed by CSI drivers that require namespace-scoped resources for volume
+	// provisioning (e.g., encrypted volumes with KMS tokens and tenant Vault configs).
+	if value, exists := csiExposeParam.BackupPVCConfig[csiExposeParam.StorageClass]; exists {
+		for _, secretName := range value.SecretNames {
+			if copyErr := kube.CopySecret(ctx, e.kubeClient.CoreV1(), secretName,
+				csiExposeParam.SourceNamespace, ownerObject.Namespace, ownerObject.Name, curLog); copyErr != nil {
+				return errors.Wrapf(copyErr, "error copying secret %s from %s to %s",
+					secretName, csiExposeParam.SourceNamespace, ownerObject.Namespace)
+			}
+		}
+		for _, cmName := range value.ConfigMapNames {
+			if copyErr := kube.CopyConfigMap(ctx, e.kubeClient.CoreV1(), cmName,
+				csiExposeParam.SourceNamespace, ownerObject.Namespace, ownerObject.Name, curLog); copyErr != nil {
+				return errors.Wrapf(copyErr, "error copying configmap %s from %s to %s",
+					cmName, csiExposeParam.SourceNamespace, ownerObject.Namespace)
+			}
+		}
+	}
+
 	volumeTopology, err := kube.GetVolumeTopology(ctx, e.kubeClient.CoreV1(), e.kubeClient.StorageV1(), csiExposeParam.SourcePVName, csiExposeParam.StorageClass)
 	if err != nil {
 		return errors.Wrapf(err, "error getting volume topology for PV %s, storage class %s", csiExposeParam.SourcePVName, csiExposeParam.StorageClass)
@@ -245,28 +266,6 @@ func (e *csiSnapshotExposer) Expose(ctx context.Context, ownerObject corev1api.O
 				delete(backupPVCAnnotations, util.VSphereCNSFastCloneAnno)
 			} else {
 				intoleratableNodes = n
-			}
-		}
-	}
-
-	// Copy secrets and configmaps from source namespace to Velero namespace if configured.
-	// These are needed by CSI drivers that require namespace-scoped resources for volume
-	// provisioning (e.g., encrypted volumes with KMS tokens and tenant Vault configs).
-	if value, exists := csiExposeParam.BackupPVCConfig[csiExposeParam.StorageClass]; exists {
-		for _, secretName := range value.SecretNames {
-			if copyErr := kube.CopySecret(ctx, e.kubeClient.CoreV1(), secretName,
-				csiExposeParam.SourceNamespace, ownerObject.Namespace, ownerObject.Name, curLog); copyErr != nil {
-				err = errors.Wrapf(copyErr, "error copying secret %s from %s to %s",
-					secretName, csiExposeParam.SourceNamespace, ownerObject.Namespace)
-				return err
-			}
-		}
-		for _, cmName := range value.ConfigMapNames {
-			if copyErr := kube.CopyConfigMap(ctx, e.kubeClient.CoreV1(), cmName,
-				csiExposeParam.SourceNamespace, ownerObject.Namespace, ownerObject.Name, curLog); copyErr != nil {
-				err = errors.Wrapf(copyErr, "error copying configmap %s from %s to %s",
-					cmName, csiExposeParam.SourceNamespace, ownerObject.Namespace)
-				return err
 			}
 		}
 	}

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -516,6 +516,8 @@ func (e *csiSnapshotExposer) CleanUp(ctx context.Context, ownerObject corev1api.
 
 	kube.DeleteSecretsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
 		kube.BackupPVCSecretLabel, ownerObject.Name, e.log)
+	kube.DeleteConfigMapsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
+		kube.BackupPVCSecretLabel, ownerObject.Name, e.log)
 
 	csi.DeleteVolumeSnapshotIfAny(ctx, e.csiSnapshotClient, backupVSName, ownerObject.Namespace, e.log)
 	csi.DeleteVolumeSnapshotIfAny(ctx, e.csiSnapshotClient, vsName, sourceNamespace, e.log)

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -514,6 +514,9 @@ func (e *csiSnapshotExposer) CleanUp(ctx context.Context, ownerObject corev1api.
 	kube.DeletePodIfAny(ctx, e.kubeClient.CoreV1(), backupPodName, ownerObject.Namespace, e.log)
 	kube.DeletePVAndPVCIfAny(ctx, e.kubeClient.CoreV1(), backupPVCName, ownerObject.Namespace, cleanUpTimeout, e.log)
 
+	kube.DeleteSecretsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
+		kube.BackupPVCSecretLabel, ownerObject.Name, e.log)
+
 	csi.DeleteVolumeSnapshotIfAny(ctx, e.csiSnapshotClient, backupVSName, ownerObject.Namespace, e.log)
 	csi.DeleteVolumeSnapshotIfAny(ctx, e.csiSnapshotClient, vsName, sourceNamespace, e.log)
 }

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -249,6 +249,28 @@ func (e *csiSnapshotExposer) Expose(ctx context.Context, ownerObject corev1api.O
 		}
 	}
 
+	// Copy secrets and configmaps from source namespace to Velero namespace if configured.
+	// These are needed by CSI drivers that require namespace-scoped resources for volume
+	// provisioning (e.g., encrypted volumes with KMS tokens and tenant Vault configs).
+	if value, exists := csiExposeParam.BackupPVCConfig[csiExposeParam.StorageClass]; exists {
+		for _, secretName := range value.SecretNames {
+			if copyErr := kube.CopySecret(ctx, e.kubeClient.CoreV1(), secretName,
+				csiExposeParam.SourceNamespace, ownerObject.Namespace, ownerObject.Name, curLog); copyErr != nil {
+				err = errors.Wrapf(copyErr, "error copying secret %s from %s to %s",
+					secretName, csiExposeParam.SourceNamespace, ownerObject.Namespace)
+				return err
+			}
+		}
+		for _, cmName := range value.ConfigMapNames {
+			if copyErr := kube.CopyConfigMap(ctx, e.kubeClient.CoreV1(), cmName,
+				csiExposeParam.SourceNamespace, ownerObject.Namespace, ownerObject.Name, curLog); copyErr != nil {
+				err = errors.Wrapf(copyErr, "error copying configmap %s from %s to %s",
+					cmName, csiExposeParam.SourceNamespace, ownerObject.Namespace)
+				return err
+			}
+		}
+	}
+
 	backupPVC, err := e.createBackupPVC(ctx, ownerObject, backupVS.Name, backupPVCStorageClass, csiExposeParam.AccessMode, volumeSize, backupPVCReadOnly, backupPVCAnnotations, csiExposeParam.DataMover)
 	if err != nil {
 		return errors.Wrap(err, "error to create backup pvc")

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -45,7 +45,8 @@ import (
 )
 
 // BackupPVCSecretLabel is the label applied to secrets and configmaps copied to the
-// Velero namespace for backup PVC provisioning. The value is the owning DataUpload name.
+// Velero namespace for backup PVC provisioning. The value is the owning DataUpload/DataDownload
+// UID, which is a stable, valid label value (the owner name may exceed the label-value limit).
 const BackupPVCSecretLabel = "velero.io/backup-pvc-secret" //nolint:gosec // not a credential
 
 // CSISnapshotExposeParam define the input param for Expose of CSI snapshots
@@ -166,7 +167,7 @@ func (e *csiSnapshotExposer) Expose(ctx context.Context, ownerObject corev1api.O
 	// These are needed by CSI drivers that require namespace-scoped resources for volume
 	// provisioning (e.g., encrypted volumes with KMS tokens and tenant Vault configs).
 	if value, exists := csiExposeParam.BackupPVCConfig[csiExposeParam.StorageClass]; exists {
-		copyLabels := map[string]string{BackupPVCSecretLabel: ownerObject.Name}
+		copyLabels := map[string]string{BackupPVCSecretLabel: string(ownerObject.UID)}
 		for _, secretName := range value.SecretNames {
 			if copyErr := kube.CopySecret(ctx, e.kubeClient.CoreV1(), secretName,
 				csiExposeParam.SourceNamespace, ownerObject.Namespace, copyLabels, curLog); copyErr != nil {
@@ -541,9 +542,9 @@ func (e *csiSnapshotExposer) CleanUp(ctx context.Context, ownerObject corev1api.
 	kube.DeletePVAndPVCIfAny(ctx, e.kubeClient.CoreV1(), backupPVCName, ownerObject.Namespace, cleanUpTimeout, e.log)
 
 	kube.DeleteSecretsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
-		BackupPVCSecretLabel, ownerObject.Name, e.log)
+		BackupPVCSecretLabel, string(ownerObject.UID), e.log)
 	kube.DeleteConfigMapsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
-		BackupPVCSecretLabel, ownerObject.Name, e.log)
+		BackupPVCSecretLabel, string(ownerObject.UID), e.log)
 
 	csi.DeleteVolumeSnapshotIfAny(ctx, e.csiSnapshotClient, backupVSName, ownerObject.Namespace, e.log)
 	csi.DeleteVolumeSnapshotIfAny(ctx, e.csiSnapshotClient, vsName, sourceNamespace, e.log)

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -44,6 +44,10 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
 )
 
+// BackupPVCSecretLabel is the label applied to secrets and configmaps copied to the
+// Velero namespace for backup PVC provisioning. The value is the owning DataUpload name.
+const BackupPVCSecretLabel = "velero.io/backup-pvc-secret" //nolint:gosec // not a credential
+
 // CSISnapshotExposeParam define the input param for Expose of CSI snapshots
 type CSISnapshotExposeParam struct {
 	// SnapshotName is the original volume snapshot name
@@ -139,27 +143,6 @@ func (e *csiSnapshotExposer) Expose(ctx context.Context, ownerObject corev1api.O
 		"owner": ownerObject.Name,
 	})
 
-	// Copy secrets and configmaps from source namespace to Velero namespace if configured.
-	// Done before creating any intermediate objects so failure doesn't require cleanup.
-	// These are needed by CSI drivers that require namespace-scoped resources for volume
-	// provisioning (e.g., encrypted volumes with KMS tokens and tenant Vault configs).
-	if value, exists := csiExposeParam.BackupPVCConfig[csiExposeParam.StorageClass]; exists {
-		for _, secretName := range value.SecretNames {
-			if copyErr := kube.CopySecret(ctx, e.kubeClient.CoreV1(), secretName,
-				csiExposeParam.SourceNamespace, ownerObject.Namespace, ownerObject.Name, curLog); copyErr != nil {
-				return errors.Wrapf(copyErr, "error copying secret %s from %s to %s",
-					secretName, csiExposeParam.SourceNamespace, ownerObject.Namespace)
-			}
-		}
-		for _, cmName := range value.ConfigMapNames {
-			if copyErr := kube.CopyConfigMap(ctx, e.kubeClient.CoreV1(), cmName,
-				csiExposeParam.SourceNamespace, ownerObject.Namespace, ownerObject.Name, curLog); copyErr != nil {
-				return errors.Wrapf(copyErr, "error copying configmap %s from %s to %s",
-					cmName, csiExposeParam.SourceNamespace, ownerObject.Namespace)
-			}
-		}
-	}
-
 	volumeTopology, err := kube.GetVolumeTopology(ctx, e.kubeClient.CoreV1(), e.kubeClient.StorageV1(), csiExposeParam.SourcePVName, csiExposeParam.StorageClass)
 	if err != nil {
 		return errors.Wrapf(err, "error getting volume topology for PV %s, storage class %s", csiExposeParam.SourcePVName, csiExposeParam.StorageClass)
@@ -177,6 +160,28 @@ func (e *csiSnapshotExposer) Expose(ctx context.Context, ownerObject corev1api.O
 	}
 
 	curLog.Info("Volumesnapshot is ready")
+
+	// Copy secrets and configmaps from source namespace to Velero namespace if configured.
+	// Done before creating any intermediate objects so failure doesn't require cleanup.
+	// These are needed by CSI drivers that require namespace-scoped resources for volume
+	// provisioning (e.g., encrypted volumes with KMS tokens and tenant Vault configs).
+	if value, exists := csiExposeParam.BackupPVCConfig[csiExposeParam.StorageClass]; exists {
+		copyLabels := map[string]string{BackupPVCSecretLabel: ownerObject.Name}
+		for _, secretName := range value.SecretNames {
+			if copyErr := kube.CopySecret(ctx, e.kubeClient.CoreV1(), secretName,
+				csiExposeParam.SourceNamespace, ownerObject.Namespace, copyLabels, curLog); copyErr != nil {
+				return errors.Wrapf(copyErr, "error copying secret %s from %s to %s",
+					secretName, csiExposeParam.SourceNamespace, ownerObject.Namespace)
+			}
+		}
+		for _, cmName := range value.ConfigMapNames {
+			if copyErr := kube.CopyConfigMap(ctx, e.kubeClient.CoreV1(), cmName,
+				csiExposeParam.SourceNamespace, ownerObject.Namespace, copyLabels, curLog); copyErr != nil {
+				return errors.Wrapf(copyErr, "error copying configmap %s from %s to %s",
+					cmName, csiExposeParam.SourceNamespace, ownerObject.Namespace)
+			}
+		}
+	}
 
 	vsc, err := csi.GetVolumeSnapshotContentForVolumeSnapshot(ctx, volumeSnapshot, e.csiSnapshotClient)
 	if err != nil {
@@ -536,9 +541,9 @@ func (e *csiSnapshotExposer) CleanUp(ctx context.Context, ownerObject corev1api.
 	kube.DeletePVAndPVCIfAny(ctx, e.kubeClient.CoreV1(), backupPVCName, ownerObject.Namespace, cleanUpTimeout, e.log)
 
 	kube.DeleteSecretsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
-		kube.BackupPVCSecretLabel, ownerObject.Name, e.log)
+		BackupPVCSecretLabel, ownerObject.Name, e.log)
 	kube.DeleteConfigMapsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
-		kube.BackupPVCSecretLabel, ownerObject.Name, e.log)
+		BackupPVCSecretLabel, ownerObject.Name, e.log)
 
 	csi.DeleteVolumeSnapshotIfAny(ctx, e.csiSnapshotClient, backupVSName, ownerObject.Namespace, e.log)
 	csi.DeleteVolumeSnapshotIfAny(ctx, e.csiSnapshotClient, vsName, sourceNamespace, e.log)

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -2366,10 +2366,10 @@ func TestCleanUp_SecretsAndConfigMaps(t *testing.T) {
 	exposer.CleanUp(t.Context(), ownerObject, "", "app-ns")
 
 	_, err := fakeKubeClient.CoreV1().Secrets("velero").Get(t.Context(), "kms-token", metav1.GetOptions{})
-	assert.Error(t, err, "owned secret should be deleted")
+	require.Error(t, err, "owned secret should be deleted")
 
 	_, err = fakeKubeClient.CoreV1().ConfigMaps("velero").Get(t.Context(), "kms-config", metav1.GetOptions{})
-	assert.Error(t, err, "owned configmap should be deleted")
+	require.Error(t, err, "owned configmap should be deleted")
 
 	_, err = fakeKubeClient.CoreV1().Secrets("velero").Get(t.Context(), "other-secret", metav1.GetOptions{})
 	assert.NoError(t, err, "unrelated secret should not be deleted")

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -2198,3 +2198,179 @@ func TestGetCBTInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestExpose_SecretCopy(t *testing.T) {
+	backup := &velerov1.Backup{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: velerov1.SchemeGroupVersion.String(),
+			Kind:       "Backup",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: velerov1.DefaultNamespace,
+			Name:      "fake-backup",
+			UID:       "fake-uid",
+		},
+	}
+
+	ownerObject := corev1api.ObjectReference{
+		Kind:       backup.Kind,
+		Namespace:  backup.Namespace,
+		Name:       backup.Name,
+		UID:        backup.UID,
+		APIVersion: backup.APIVersion,
+	}
+
+	t.Run("copies secret from source namespace", func(t *testing.T) {
+		srcSecret := &corev1api.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "kms-token", Namespace: "app-ns"},
+			Data:       map[string][]byte{"token": []byte("vault-token")},
+			Type:       corev1api.SecretTypeOpaque,
+		}
+		fakeKubeClient := fake.NewSimpleClientset(srcSecret)
+		fakeSnapshotClient := snapshotFake.NewSimpleClientset()
+
+		exposer := csiSnapshotExposer{
+			kubeClient:        fakeKubeClient,
+			csiSnapshotClient: fakeSnapshotClient.SnapshotV1(),
+			log:               velerotest.NewLogger(),
+		}
+
+		param := &CSISnapshotExposeParam{
+			SourceNamespace:  "app-ns",
+			SnapshotName:     "fake-vs",
+			StorageClass:     "encrypted-sc",
+			OperationTimeout: time.Millisecond,
+			ExposeTimeout:    time.Millisecond,
+			BackupPVCConfig: map[string]velerotypes.BackupPVC{
+				"encrypted-sc": {
+					SecretNames: []string{"kms-token"},
+				},
+			},
+		}
+
+		// Expose will fail later (no VS exists), but the secret copy should succeed
+		_ = exposer.Expose(t.Context(), ownerObject, param)
+
+		copied, err := fakeKubeClient.CoreV1().Secrets(ownerObject.Namespace).Get(
+			t.Context(), "kms-token", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, []byte("vault-token"), copied.Data["token"])
+		assert.Equal(t, ownerObject.Name, copied.Labels[kube.BackupPVCSecretLabel])
+	})
+
+	t.Run("copies configmap from source namespace", func(t *testing.T) {
+		srcCM := &corev1api.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "kms-config", Namespace: "app-ns"},
+			Data:       map[string]string{"vaultAddress": "https://vault.example.com"},
+		}
+		fakeKubeClient := fake.NewSimpleClientset(srcCM)
+		fakeSnapshotClient := snapshotFake.NewSimpleClientset()
+
+		exposer := csiSnapshotExposer{
+			kubeClient:        fakeKubeClient,
+			csiSnapshotClient: fakeSnapshotClient.SnapshotV1(),
+			log:               velerotest.NewLogger(),
+		}
+
+		param := &CSISnapshotExposeParam{
+			SourceNamespace:  "app-ns",
+			SnapshotName:     "fake-vs",
+			StorageClass:     "encrypted-sc",
+			OperationTimeout: time.Millisecond,
+			ExposeTimeout:    time.Millisecond,
+			BackupPVCConfig: map[string]velerotypes.BackupPVC{
+				"encrypted-sc": {
+					ConfigMapNames: []string{"kms-config"},
+				},
+			},
+		}
+
+		_ = exposer.Expose(t.Context(), ownerObject, param)
+
+		copied, err := fakeKubeClient.CoreV1().ConfigMaps(ownerObject.Namespace).Get(
+			t.Context(), "kms-config", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "https://vault.example.com", copied.Data["vaultAddress"])
+		assert.Equal(t, ownerObject.Name, copied.Labels[kube.BackupPVCSecretLabel])
+	})
+
+	t.Run("returns error when source secret missing", func(t *testing.T) {
+		fakeKubeClient := fake.NewSimpleClientset()
+		fakeSnapshotClient := snapshotFake.NewSimpleClientset()
+
+		exposer := csiSnapshotExposer{
+			kubeClient:        fakeKubeClient,
+			csiSnapshotClient: fakeSnapshotClient.SnapshotV1(),
+			log:               velerotest.NewLogger(),
+		}
+
+		param := &CSISnapshotExposeParam{
+			SourceNamespace:  "app-ns",
+			SnapshotName:     "fake-vs",
+			StorageClass:     "encrypted-sc",
+			OperationTimeout: time.Millisecond,
+			ExposeTimeout:    time.Millisecond,
+			BackupPVCConfig: map[string]velerotypes.BackupPVC{
+				"encrypted-sc": {
+					SecretNames: []string{"missing-secret"},
+				},
+			},
+		}
+
+		err := exposer.Expose(t.Context(), ownerObject, param)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error copying secret")
+	})
+}
+
+func TestCleanUp_SecretsAndConfigMaps(t *testing.T) {
+	ownerObject := corev1api.ObjectReference{
+		Kind:       "Backup",
+		Namespace:  "velero",
+		Name:       "du-123",
+		UID:        "fake-uid",
+		APIVersion: "v1",
+	}
+
+	secret := &corev1api.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kms-token", Namespace: "velero",
+			Labels: map[string]string{kube.BackupPVCSecretLabel: "du-123"},
+			UID:    "secret-uid",
+		},
+	}
+	cm := &corev1api.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kms-config", Namespace: "velero",
+			Labels: map[string]string{kube.BackupPVCSecretLabel: "du-123"},
+			UID:    "cm-uid",
+		},
+	}
+	unrelatedSecret := &corev1api.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "other-secret", Namespace: "velero",
+			Labels: map[string]string{kube.BackupPVCSecretLabel: "du-456"},
+			UID:    "other-uid",
+		},
+	}
+
+	fakeKubeClient := fake.NewSimpleClientset(secret, cm, unrelatedSecret)
+	fakeSnapshotClient := snapshotFake.NewSimpleClientset()
+
+	exposer := csiSnapshotExposer{
+		kubeClient:        fakeKubeClient,
+		csiSnapshotClient: fakeSnapshotClient.SnapshotV1(),
+		log:               velerotest.NewLogger(),
+	}
+
+	exposer.CleanUp(t.Context(), ownerObject, "", "app-ns")
+
+	_, err := fakeKubeClient.CoreV1().Secrets("velero").Get(t.Context(), "kms-token", metav1.GetOptions{})
+	assert.Error(t, err, "owned secret should be deleted")
+
+	_, err = fakeKubeClient.CoreV1().ConfigMaps("velero").Get(t.Context(), "kms-config", metav1.GetOptions{})
+	assert.Error(t, err, "owned configmap should be deleted")
+
+	_, err = fakeKubeClient.CoreV1().Secrets("velero").Get(t.Context(), "other-secret", metav1.GetOptions{})
+	assert.NoError(t, err, "unrelated secret should not be deleted")
+}

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -2278,7 +2278,7 @@ func TestExpose_SecretCopy(t *testing.T) {
 			t.Context(), "kms-token", metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, []byte("vault-token"), copied.Data["token"])
-		assert.Equal(t, ownerObject.Name, copied.Labels[BackupPVCSecretLabel])
+		assert.Equal(t, string(ownerObject.UID), copied.Labels[BackupPVCSecretLabel])
 	})
 
 	t.Run("copies configmap from source namespace", func(t *testing.T) {
@@ -2306,7 +2306,7 @@ func TestExpose_SecretCopy(t *testing.T) {
 			t.Context(), "kms-config", metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, "https://vault.example.com", copied.Data["vaultAddress"])
-		assert.Equal(t, ownerObject.Name, copied.Labels[BackupPVCSecretLabel])
+		assert.Equal(t, string(ownerObject.UID), copied.Labels[BackupPVCSecretLabel])
 	})
 
 	t.Run("returns error when source secret missing", func(t *testing.T) {
@@ -2342,21 +2342,21 @@ func TestCleanUp_SecretsAndConfigMaps(t *testing.T) {
 	secret := &corev1api.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kms-token", Namespace: "velero",
-			Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+			Labels: map[string]string{BackupPVCSecretLabel: string(ownerObject.UID)},
 			UID:    "secret-uid",
 		},
 	}
 	cm := &corev1api.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kms-config", Namespace: "velero",
-			Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+			Labels: map[string]string{BackupPVCSecretLabel: string(ownerObject.UID)},
 			UID:    "cm-uid",
 		},
 	}
 	unrelatedSecret := &corev1api.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "other-secret", Namespace: "velero",
-			Labels: map[string]string{BackupPVCSecretLabel: "du-456"},
+			Labels: map[string]string{BackupPVCSecretLabel: "other-owner-uid"},
 			UID:    "other-uid",
 		},
 	}

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -2220,14 +2220,45 @@ func TestExpose_SecretCopy(t *testing.T) {
 		APIVersion: backup.APIVersion,
 	}
 
+	// The secret/configmap copy runs after GetVolumeTopology and WaitVolumeSnapshotReady,
+	// so a StorageClass and a ready VolumeSnapshot are needed to reach the copy block.
+	scObj := &storagev1api.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "encrypted-sc"},
+	}
+	readyVS := func() *snapshotv1api.VolumeSnapshot {
+		vscName := "fake-vsc"
+		return &snapshotv1api.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{Name: "fake-vs", Namespace: "app-ns"},
+			Spec: snapshotv1api.VolumeSnapshotSpec{
+				Source: snapshotv1api.VolumeSnapshotSource{VolumeSnapshotContentName: &vscName},
+			},
+			Status: &snapshotv1api.VolumeSnapshotStatus{
+				BoundVolumeSnapshotContentName: &vscName,
+				ReadyToUse:                     boolptr.True(),
+				RestoreSize:                    resource.NewQuantity(1234, ""),
+			},
+		}
+	}
+
+	param := func() *CSISnapshotExposeParam {
+		return &CSISnapshotExposeParam{
+			SourceNamespace:  "app-ns",
+			SourcePVName:     "fake-pv",
+			SnapshotName:     "fake-vs",
+			StorageClass:     "encrypted-sc",
+			OperationTimeout: time.Millisecond,
+			ExposeTimeout:    time.Second,
+		}
+	}
+
 	t.Run("copies secret from source namespace", func(t *testing.T) {
 		srcSecret := &corev1api.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "kms-token", Namespace: "app-ns"},
 			Data:       map[string][]byte{"token": []byte("vault-token")},
 			Type:       corev1api.SecretTypeOpaque,
 		}
-		fakeKubeClient := fake.NewSimpleClientset(srcSecret)
-		fakeSnapshotClient := snapshotFake.NewSimpleClientset()
+		fakeKubeClient := fake.NewSimpleClientset(srcSecret, scObj)
+		fakeSnapshotClient := snapshotFake.NewSimpleClientset(readyVS())
 
 		exposer := csiSnapshotExposer{
 			kubeClient:        fakeKubeClient,
@@ -2235,27 +2266,19 @@ func TestExpose_SecretCopy(t *testing.T) {
 			log:               velerotest.NewLogger(),
 		}
 
-		param := &CSISnapshotExposeParam{
-			SourceNamespace:  "app-ns",
-			SnapshotName:     "fake-vs",
-			StorageClass:     "encrypted-sc",
-			OperationTimeout: time.Millisecond,
-			ExposeTimeout:    time.Millisecond,
-			BackupPVCConfig: map[string]velerotypes.BackupPVC{
-				"encrypted-sc": {
-					SecretNames: []string{"kms-token"},
-				},
-			},
+		p := param()
+		p.BackupPVCConfig = map[string]velerotypes.BackupPVC{
+			"encrypted-sc": {SecretNames: []string{"kms-token"}},
 		}
 
-		// Expose will fail later (no VS exists), but the secret copy should succeed
-		_ = exposer.Expose(t.Context(), ownerObject, param)
+		// Expose will fail later (no VSC exists), but the secret copy should succeed
+		_ = exposer.Expose(t.Context(), ownerObject, p)
 
 		copied, err := fakeKubeClient.CoreV1().Secrets(ownerObject.Namespace).Get(
 			t.Context(), "kms-token", metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, []byte("vault-token"), copied.Data["token"])
-		assert.Equal(t, ownerObject.Name, copied.Labels[kube.BackupPVCSecretLabel])
+		assert.Equal(t, ownerObject.Name, copied.Labels[BackupPVCSecretLabel])
 	})
 
 	t.Run("copies configmap from source namespace", func(t *testing.T) {
@@ -2263,8 +2286,8 @@ func TestExpose_SecretCopy(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "kms-config", Namespace: "app-ns"},
 			Data:       map[string]string{"vaultAddress": "https://vault.example.com"},
 		}
-		fakeKubeClient := fake.NewSimpleClientset(srcCM)
-		fakeSnapshotClient := snapshotFake.NewSimpleClientset()
+		fakeKubeClient := fake.NewSimpleClientset(srcCM, scObj)
+		fakeSnapshotClient := snapshotFake.NewSimpleClientset(readyVS())
 
 		exposer := csiSnapshotExposer{
 			kubeClient:        fakeKubeClient,
@@ -2272,31 +2295,23 @@ func TestExpose_SecretCopy(t *testing.T) {
 			log:               velerotest.NewLogger(),
 		}
 
-		param := &CSISnapshotExposeParam{
-			SourceNamespace:  "app-ns",
-			SnapshotName:     "fake-vs",
-			StorageClass:     "encrypted-sc",
-			OperationTimeout: time.Millisecond,
-			ExposeTimeout:    time.Millisecond,
-			BackupPVCConfig: map[string]velerotypes.BackupPVC{
-				"encrypted-sc": {
-					ConfigMapNames: []string{"kms-config"},
-				},
-			},
+		p := param()
+		p.BackupPVCConfig = map[string]velerotypes.BackupPVC{
+			"encrypted-sc": {ConfigMapNames: []string{"kms-config"}},
 		}
 
-		_ = exposer.Expose(t.Context(), ownerObject, param)
+		_ = exposer.Expose(t.Context(), ownerObject, p)
 
 		copied, err := fakeKubeClient.CoreV1().ConfigMaps(ownerObject.Namespace).Get(
 			t.Context(), "kms-config", metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, "https://vault.example.com", copied.Data["vaultAddress"])
-		assert.Equal(t, ownerObject.Name, copied.Labels[kube.BackupPVCSecretLabel])
+		assert.Equal(t, ownerObject.Name, copied.Labels[BackupPVCSecretLabel])
 	})
 
 	t.Run("returns error when source secret missing", func(t *testing.T) {
-		fakeKubeClient := fake.NewSimpleClientset()
-		fakeSnapshotClient := snapshotFake.NewSimpleClientset()
+		fakeKubeClient := fake.NewSimpleClientset(scObj)
+		fakeSnapshotClient := snapshotFake.NewSimpleClientset(readyVS())
 
 		exposer := csiSnapshotExposer{
 			kubeClient:        fakeKubeClient,
@@ -2304,20 +2319,12 @@ func TestExpose_SecretCopy(t *testing.T) {
 			log:               velerotest.NewLogger(),
 		}
 
-		param := &CSISnapshotExposeParam{
-			SourceNamespace:  "app-ns",
-			SnapshotName:     "fake-vs",
-			StorageClass:     "encrypted-sc",
-			OperationTimeout: time.Millisecond,
-			ExposeTimeout:    time.Millisecond,
-			BackupPVCConfig: map[string]velerotypes.BackupPVC{
-				"encrypted-sc": {
-					SecretNames: []string{"missing-secret"},
-				},
-			},
+		p := param()
+		p.BackupPVCConfig = map[string]velerotypes.BackupPVC{
+			"encrypted-sc": {SecretNames: []string{"missing-secret"}},
 		}
 
-		err := exposer.Expose(t.Context(), ownerObject, param)
+		err := exposer.Expose(t.Context(), ownerObject, p)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "error copying secret")
 	})
@@ -2335,21 +2342,21 @@ func TestCleanUp_SecretsAndConfigMaps(t *testing.T) {
 	secret := &corev1api.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kms-token", Namespace: "velero",
-			Labels: map[string]string{kube.BackupPVCSecretLabel: "du-123"},
+			Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
 			UID:    "secret-uid",
 		},
 	}
 	cm := &corev1api.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kms-config", Namespace: "velero",
-			Labels: map[string]string{kube.BackupPVCSecretLabel: "du-123"},
+			Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
 			UID:    "cm-uid",
 		},
 	}
 	unrelatedSecret := &corev1api.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "other-secret", Namespace: "velero",
-			Labels: map[string]string{kube.BackupPVCSecretLabel: "du-456"},
+			Labels: map[string]string{BackupPVCSecretLabel: "du-456"},
 			UID:    "other-uid",
 		},
 	}

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -196,6 +196,36 @@ func (e *genericRestoreExposer) Expose(ctx context.Context, ownerObject corev1ap
 		}
 	}
 
+	// Copy secrets and configmaps from the target namespace to the Velero namespace if configured.
+	// These are needed by CSI drivers that require namespace-scoped resources for volume
+	// provisioning of the restorePVC (e.g., encrypted volumes with KMS tokens and tenant Vault configs).
+	copyLabels := map[string]string{BackupPVCSecretLabel: ownerObject.Name}
+	for _, secretName := range param.RestorePVCConfig.SecretNames {
+		if copyErr := kube.CopySecret(ctx, e.kubeClient.CoreV1(), secretName,
+			param.TargetNamespace, ownerObject.Namespace, copyLabels, curLog); copyErr != nil {
+			err = errors.Wrapf(copyErr, "error copying secret %s from %s to %s",
+				secretName, param.TargetNamespace, ownerObject.Namespace)
+			return err
+		}
+	}
+	for _, cmName := range param.RestorePVCConfig.ConfigMapNames {
+		if copyErr := kube.CopyConfigMap(ctx, e.kubeClient.CoreV1(), cmName,
+			param.TargetNamespace, ownerObject.Namespace, copyLabels, curLog); copyErr != nil {
+			err = errors.Wrapf(copyErr, "error copying configmap %s from %s to %s",
+				cmName, param.TargetNamespace, ownerObject.Namespace)
+			return err
+		}
+	}
+
+	defer func() {
+		if err != nil {
+			kube.DeleteSecretsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
+				BackupPVCSecretLabel, ownerObject.Name, curLog)
+			kube.DeleteConfigMapsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
+				BackupPVCSecretLabel, ownerObject.Name, curLog)
+		}
+	}()
+
 	restorePVC, err := e.createRestorePVC(ctx, ownerObject, targetPVC, selectedNode, param.DataMover)
 	if err != nil {
 		return errors.Wrap(err, "error to create restore pvc")
@@ -397,6 +427,11 @@ func (e *genericRestoreExposer) CleanUp(ctx context.Context, ownerObject corev1a
 	kube.DeletePodIfAny(ctx, e.kubeClient.CoreV1(), restorePodName, ownerObject.Namespace, e.log)
 	kube.DeletePVAndPVCIfAny(ctx, e.kubeClient.CoreV1(), restorePVCName, ownerObject.Namespace, 0, e.log)
 	kube.DeletePVAndPVCIfAny(ctx, e.kubeClient.CoreV1(), cachePVCName, ownerObject.Namespace, 0, e.log)
+
+	kube.DeleteSecretsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
+		BackupPVCSecretLabel, ownerObject.Name, e.log)
+	kube.DeleteConfigMapsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
+		BackupPVCSecretLabel, ownerObject.Name, e.log)
 }
 
 func (e *genericRestoreExposer) RebindVolume(ctx context.Context, ownerObject corev1api.ObjectReference, param GenericRestoreRebindVolumeParam) error {

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -199,7 +199,7 @@ func (e *genericRestoreExposer) Expose(ctx context.Context, ownerObject corev1ap
 	// Copy secrets and configmaps from the target namespace to the Velero namespace if configured.
 	// These are needed by CSI drivers that require namespace-scoped resources for volume
 	// provisioning of the restorePVC (e.g., encrypted volumes with KMS tokens and tenant Vault configs).
-	copyLabels := map[string]string{BackupPVCSecretLabel: ownerObject.Name}
+	copyLabels := map[string]string{BackupPVCSecretLabel: string(ownerObject.UID)}
 	for _, secretName := range param.RestorePVCConfig.SecretNames {
 		if copyErr := kube.CopySecret(ctx, e.kubeClient.CoreV1(), secretName,
 			param.TargetNamespace, ownerObject.Namespace, copyLabels, curLog); copyErr != nil {
@@ -220,9 +220,9 @@ func (e *genericRestoreExposer) Expose(ctx context.Context, ownerObject corev1ap
 	defer func() {
 		if err != nil {
 			kube.DeleteSecretsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
-				BackupPVCSecretLabel, ownerObject.Name, curLog)
+				BackupPVCSecretLabel, string(ownerObject.UID), curLog)
 			kube.DeleteConfigMapsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
-				BackupPVCSecretLabel, ownerObject.Name, curLog)
+				BackupPVCSecretLabel, string(ownerObject.UID), curLog)
 		}
 	}()
 
@@ -429,9 +429,9 @@ func (e *genericRestoreExposer) CleanUp(ctx context.Context, ownerObject corev1a
 	kube.DeletePVAndPVCIfAny(ctx, e.kubeClient.CoreV1(), cachePVCName, ownerObject.Namespace, 0, e.log)
 
 	kube.DeleteSecretsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
-		BackupPVCSecretLabel, ownerObject.Name, e.log)
+		BackupPVCSecretLabel, string(ownerObject.UID), e.log)
 	kube.DeleteConfigMapsWithLabel(ctx, e.kubeClient.CoreV1(), ownerObject.Namespace,
-		BackupPVCSecretLabel, ownerObject.Name, e.log)
+		BackupPVCSecretLabel, string(ownerObject.UID), e.log)
 }
 
 func (e *genericRestoreExposer) RebindVolume(ctx context.Context, ownerObject corev1api.ObjectReference, param GenericRestoreRebindVolumeParam) error {

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -411,12 +411,12 @@ func TestRestoreExpose_SecretCopy(t *testing.T) {
 		copiedSecret, err := fakeKubeClient.CoreV1().Secrets(ownerObject.Namespace).Get(t.Context(), "kms-token", metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, []byte("vault-token"), copiedSecret.Data["token"])
-		assert.Equal(t, ownerObject.Name, copiedSecret.Labels[BackupPVCSecretLabel])
+		assert.Equal(t, string(ownerObject.UID), copiedSecret.Labels[BackupPVCSecretLabel])
 
 		copiedCM, err := fakeKubeClient.CoreV1().ConfigMaps(ownerObject.Namespace).Get(t.Context(), "kms-config", metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, "https://vault.example.com", copiedCM.Data["vaultAddress"])
-		assert.Equal(t, ownerObject.Name, copiedCM.Labels[BackupPVCSecretLabel])
+		assert.Equal(t, string(ownerObject.UID), copiedCM.Labels[BackupPVCSecretLabel])
 	})
 
 	t.Run("returns error when source secret missing", func(t *testing.T) {

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -34,6 +34,7 @@ import (
 
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+	velerotypes "github.com/vmware-tanzu/velero/pkg/types"
 	"github.com/vmware-tanzu/velero/pkg/util/datamover"
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
 )
@@ -351,6 +352,88 @@ func TestRestoreExpose(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRestoreExpose_SecretCopy(t *testing.T) {
+	scName := "fake-sc"
+	restore := &velerov1.Restore{
+		TypeMeta:   metav1.TypeMeta{APIVersion: velerov1.SchemeGroupVersion.String(), Kind: "Restore"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: velerov1.DefaultNamespace, Name: "fake-restore", UID: "fake-uid"},
+	}
+	ownerObject := corev1api.ObjectReference{
+		Kind:       restore.Kind,
+		Namespace:  restore.Namespace,
+		Name:       restore.Name,
+		UID:        restore.UID,
+		APIVersion: restore.APIVersion,
+	}
+	targetPVCObj := &corev1api.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "fake-ns", Name: "fake-target-pvc"},
+		Spec:       corev1api.PersistentVolumeClaimSpec{StorageClassName: &scName},
+	}
+	storageClass := &storagev1api.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fake-sc"}}
+	daemonSet := &appsv1api.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "velero", Name: "node-agent"},
+		TypeMeta:   metav1.TypeMeta{Kind: "DaemonSet", APIVersion: appsv1api.SchemeGroupVersion.String()},
+		Spec: appsv1api.DaemonSetSpec{
+			Template: corev1api.PodTemplateSpec{
+				Spec: corev1api.PodSpec{Containers: []corev1api.Container{{Image: "fake-image"}}},
+			},
+		},
+	}
+
+	t.Run("copies secret and configmap from target namespace", func(t *testing.T) {
+		srcSecret := &corev1api.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "kms-token", Namespace: "fake-ns"},
+			Data:       map[string][]byte{"token": []byte("vault-token")},
+			Type:       corev1api.SecretTypeOpaque,
+		}
+		srcCM := &corev1api.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "kms-config", Namespace: "fake-ns"},
+			Data:       map[string]string{"vaultAddress": "https://vault.example.com"},
+		}
+		fakeKubeClient := fake.NewSimpleClientset(targetPVCObj, storageClass, daemonSet, srcSecret, srcCM)
+		exposer := genericRestoreExposer{kubeClient: fakeKubeClient, log: velerotest.NewLogger()}
+
+		err := exposer.Expose(t.Context(), ownerObject, GenericRestoreExposeParam{
+			TargetPVCName:    "fake-target-pvc",
+			TargetNamespace:  "fake-ns",
+			HostingPodLabels: map[string]string{},
+			Resources:        corev1api.ResourceRequirements{},
+			ExposeTimeout:    time.Millisecond,
+			RestorePVCConfig: velerotypes.RestorePVC{
+				SecretNames:    []string{"kms-token"},
+				ConfigMapNames: []string{"kms-config"},
+			},
+		})
+		require.NoError(t, err)
+
+		copiedSecret, err := fakeKubeClient.CoreV1().Secrets(ownerObject.Namespace).Get(t.Context(), "kms-token", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, []byte("vault-token"), copiedSecret.Data["token"])
+		assert.Equal(t, ownerObject.Name, copiedSecret.Labels[BackupPVCSecretLabel])
+
+		copiedCM, err := fakeKubeClient.CoreV1().ConfigMaps(ownerObject.Namespace).Get(t.Context(), "kms-config", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "https://vault.example.com", copiedCM.Data["vaultAddress"])
+		assert.Equal(t, ownerObject.Name, copiedCM.Labels[BackupPVCSecretLabel])
+	})
+
+	t.Run("returns error when source secret missing", func(t *testing.T) {
+		fakeKubeClient := fake.NewSimpleClientset(targetPVCObj, storageClass, daemonSet)
+		exposer := genericRestoreExposer{kubeClient: fakeKubeClient, log: velerotest.NewLogger()}
+
+		err := exposer.Expose(t.Context(), ownerObject, GenericRestoreExposeParam{
+			TargetPVCName:    "fake-target-pvc",
+			TargetNamespace:  "fake-ns",
+			HostingPodLabels: map[string]string{},
+			Resources:        corev1api.ResourceRequirements{},
+			ExposeTimeout:    time.Millisecond,
+			RestorePVCConfig: velerotypes.RestorePVC{SecretNames: []string{"missing-secret"}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error copying secret")
+	})
 }
 
 func TestRebindVolume(t *testing.T) {

--- a/pkg/types/node_agent.go
+++ b/pkg/types/node_agent.go
@@ -59,6 +59,12 @@ type BackupPVC struct {
 
 	// Annotations permits setting annotations for the backupPVC
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// SecretNames is a list of secret names to copy from the source PVC namespace
+	// to the Velero namespace before creating the backupPVC. The secrets are deleted
+	// after the DataUpload completes. This is needed for CSI drivers that require
+	// namespace-scoped secrets for volume provisioning (e.g., encrypted volumes).
+	SecretNames []string `json:"secretNames,omitempty"`
 }
 
 type RestorePVC struct {

--- a/pkg/types/node_agent.go
+++ b/pkg/types/node_agent.go
@@ -65,6 +65,13 @@ type BackupPVC struct {
 	// after the DataUpload completes. This is needed for CSI drivers that require
 	// namespace-scoped secrets for volume provisioning (e.g., encrypted volumes).
 	SecretNames []string `json:"secretNames,omitempty"`
+
+	// ConfigMapNames is a list of configmap names to copy from the source PVC namespace
+	// to the Velero namespace before creating the backupPVC. The configmaps are deleted
+	// after the DataUpload completes. This is needed for CSI drivers that require
+	// namespace-scoped configmaps for volume provisioning (e.g., tenant-specific
+	// Vault connection overrides for encrypted volumes).
+	ConfigMapNames []string `json:"configMapNames,omitempty"`
 }
 
 type RestorePVC struct {

--- a/pkg/types/node_agent.go
+++ b/pkg/types/node_agent.go
@@ -77,6 +77,18 @@ type BackupPVC struct {
 type RestorePVC struct {
 	// IgnoreDelayBinding indicates to ignore delay binding the restorePVC when it is in WaitForFirstConsumer mode
 	IgnoreDelayBinding bool `json:"ignoreDelayBinding,omitempty"`
+
+	// SecretNames is a list of secret names to copy from the target namespace to the
+	// Velero namespace before creating the restorePVC. The secrets are deleted after the
+	// DataDownload completes. This is needed for CSI drivers that require namespace-scoped
+	// secrets for volume provisioning (e.g., encrypted volumes).
+	SecretNames []string `json:"secretNames,omitempty"`
+
+	// ConfigMapNames is a list of configmap names to copy from the target namespace to the
+	// Velero namespace before creating the restorePVC. The configmaps are deleted after the
+	// DataDownload completes. This is needed for CSI drivers that require namespace-scoped
+	// configmaps for volume provisioning (e.g., tenant-specific Vault connection overrides).
+	ConfigMapNames []string `json:"configMapNames,omitempty"`
 }
 
 type CachePVC struct {

--- a/pkg/util/kube/secrets.go
+++ b/pkg/util/kube/secrets.go
@@ -66,9 +66,9 @@ const (
 var ErrSecretCollision = errors.New("secret collision: same name exists with different data")
 
 // CopySecret copies a secret from sourceNamespace to targetNamespace.
-// If a secret with the same name already exists in the target with identical data, it is a no-op.
-// If a secret with the same name exists with different data (collision from another DataUpload),
-// it returns ErrSecretCollision so the caller can requeue.
+// If a secret with the same name already exists in the target with identical data
+// and the same owner, it is a no-op. If the data matches but a different owner holds
+// it, or the data differs, it returns ErrSecretCollision.
 func CopySecret(ctx context.Context, client corev1client.CoreV1Interface, secretName, sourceNamespace, targetNamespace string, ownerName string, log logrus.FieldLogger) error {
 	srcSecret, err := client.Secrets(sourceNamespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
@@ -102,12 +102,12 @@ func CopySecret(ctx context.Context, client corev1client.CoreV1Interface, secret
 		return errors.Wrapf(err, "error getting existing secret %s/%s", targetNamespace, secretName)
 	}
 
-	if reflect.DeepEqual(existing.Data, srcSecret.Data) {
-		log.Infof("Secret %s already exists in %s with same data, skipping copy", secretName, targetNamespace)
+	if reflect.DeepEqual(existing.Data, srcSecret.Data) && existing.Labels[BackupPVCSecretLabel] == ownerName {
+		log.Infof("Secret %s already exists in %s with same data and owner, skipping copy", secretName, targetNamespace)
 		return nil
 	}
 
-	log.Infof("Secret %s already exists in %s with different data, collision detected", secretName, targetNamespace)
+	log.Infof("Secret %s already exists in %s owned by a different DataUpload, collision detected", secretName, targetNamespace)
 	return ErrSecretCollision
 }
 
@@ -124,6 +124,7 @@ func DeleteSecretIfAny(ctx context.Context, client corev1client.CoreV1Interface,
 }
 
 // DeleteSecretsWithLabel deletes all secrets in a namespace matching a label key=value pair.
+// Uses UID preconditions to avoid deleting a recreated object with the same name.
 func DeleteSecretsWithLabel(ctx context.Context, client corev1client.CoreV1Interface, namespace, labelKey, labelValue string, log logrus.FieldLogger) {
 	secrets, err := client.Secrets(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelKey + "=" + labelValue,
@@ -134,14 +135,20 @@ func DeleteSecretsWithLabel(ctx context.Context, client corev1client.CoreV1Inter
 	}
 
 	for i := range secrets.Items {
-		DeleteSecretIfAny(ctx, client, secrets.Items[i].Name, namespace, log)
+		uid := secrets.Items[i].UID
+		err := client.Secrets(namespace).Delete(ctx, secrets.Items[i].Name, metav1.DeleteOptions{
+			Preconditions: &metav1.Preconditions{UID: &uid},
+		})
+		if err != nil && !apierrors.IsNotFound(err) {
+			log.WithError(err).Errorf("Failed to delete secret %s/%s", namespace, secrets.Items[i].Name)
+		}
 	}
 }
 
 // CopyConfigMap copies a configmap from sourceNamespace to targetNamespace.
-// If a configmap with the same name already exists in the target with identical data, it is a no-op.
-// If a configmap with the same name exists with different data (collision from another DataUpload),
-// it returns ErrSecretCollision so the caller can requeue.
+// If a configmap with the same name already exists in the target with identical data
+// and the same owner, it is a no-op. If the data matches but a different owner holds
+// it, or the data differs, it returns ErrSecretCollision.
 func CopyConfigMap(ctx context.Context, client corev1client.CoreV1Interface, cmName, sourceNamespace, targetNamespace string, ownerName string, log logrus.FieldLogger) error {
 	srcCM, err := client.ConfigMaps(sourceNamespace).Get(ctx, cmName, metav1.GetOptions{})
 	if err != nil {
@@ -156,7 +163,8 @@ func CopyConfigMap(ctx context.Context, client corev1client.CoreV1Interface, cmN
 				BackupPVCSecretLabel: ownerName,
 			},
 		},
-		Data: srcCM.Data,
+		Data:       srcCM.Data,
+		BinaryData: srcCM.BinaryData,
 	}
 
 	_, err = client.ConfigMaps(targetNamespace).Create(ctx, newCM, metav1.CreateOptions{})
@@ -174,12 +182,14 @@ func CopyConfigMap(ctx context.Context, client corev1client.CoreV1Interface, cmN
 		return errors.Wrapf(err, "error getting existing configmap %s/%s", targetNamespace, cmName)
 	}
 
-	if reflect.DeepEqual(existing.Data, srcCM.Data) {
-		log.Infof("ConfigMap %s already exists in %s with same data, skipping copy", cmName, targetNamespace)
+	if reflect.DeepEqual(existing.Data, srcCM.Data) &&
+		reflect.DeepEqual(existing.BinaryData, srcCM.BinaryData) &&
+		existing.Labels[BackupPVCSecretLabel] == ownerName {
+		log.Infof("ConfigMap %s already exists in %s with same data and owner, skipping copy", cmName, targetNamespace)
 		return nil
 	}
 
-	log.Infof("ConfigMap %s already exists in %s with different data, collision detected", cmName, targetNamespace)
+	log.Infof("ConfigMap %s already exists in %s owned by a different DataUpload, collision detected", cmName, targetNamespace)
 	return ErrSecretCollision
 }
 
@@ -196,6 +206,7 @@ func DeleteConfigMapIfAny(ctx context.Context, client corev1client.CoreV1Interfa
 }
 
 // DeleteConfigMapsWithLabel deletes all configmaps in a namespace matching a label key=value pair.
+// Uses UID preconditions to avoid deleting a recreated object with the same name.
 func DeleteConfigMapsWithLabel(ctx context.Context, client corev1client.CoreV1Interface, namespace, labelKey, labelValue string, log logrus.FieldLogger) {
 	cms, err := client.ConfigMaps(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelKey + "=" + labelValue,
@@ -206,6 +217,12 @@ func DeleteConfigMapsWithLabel(ctx context.Context, client corev1client.CoreV1In
 	}
 
 	for i := range cms.Items {
-		DeleteConfigMapIfAny(ctx, client, cms.Items[i].Name, namespace, log)
+		uid := cms.Items[i].UID
+		err := client.ConfigMaps(namespace).Delete(ctx, cms.Items[i].Name, metav1.DeleteOptions{
+			Preconditions: &metav1.Preconditions{UID: &uid},
+		})
+		if err != nil && !apierrors.IsNotFound(err) {
+			log.WithError(err).Errorf("Failed to delete configmap %s/%s", namespace, cms.Items[i].Name)
+		}
 	}
 }

--- a/pkg/util/kube/secrets.go
+++ b/pkg/util/kube/secrets.go
@@ -18,9 +18,14 @@ package kube
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/cockroachdb/errors"
+	"github.com/sirupsen/logrus"
 	corev1api "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -48,4 +53,87 @@ func GetSecretKey(client kbclient.Client, namespace string, selector *corev1api.
 	}
 
 	return key, nil
+}
+
+const (
+	// BackupPVCSecretLabel is the label applied to secrets copied to the Velero namespace
+	// for backup PVC provisioning. The value is the owning DataUpload name.
+	BackupPVCSecretLabel = "velero.io/backup-pvc-secret"
+)
+
+// ErrSecretCollision is returned when a secret with the same name but different data
+// already exists in the target namespace, indicating another DataUpload is using it.
+var ErrSecretCollision = errors.New("secret collision: same name exists with different data")
+
+// CopySecret copies a secret from sourceNamespace to targetNamespace.
+// If a secret with the same name already exists in the target with identical data, it is a no-op.
+// If a secret with the same name exists with different data (collision from another DataUpload),
+// it returns ErrSecretCollision so the caller can requeue.
+func CopySecret(ctx context.Context, client corev1client.CoreV1Interface, secretName, sourceNamespace, targetNamespace string, ownerName string, log logrus.FieldLogger) error {
+	srcSecret, err := client.Secrets(sourceNamespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "error getting secret %s/%s", sourceNamespace, secretName)
+	}
+
+	newSecret := &corev1api.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: targetNamespace,
+			Labels: map[string]string{
+				BackupPVCSecretLabel: ownerName,
+			},
+		},
+		Type: srcSecret.Type,
+		Data: srcSecret.Data,
+	}
+
+	_, err = client.Secrets(targetNamespace).Create(ctx, newSecret, metav1.CreateOptions{})
+	if err == nil {
+		log.Infof("Copied secret %s from %s to %s", secretName, sourceNamespace, targetNamespace)
+		return nil
+	}
+
+	if !apierrors.IsAlreadyExists(err) {
+		return errors.Wrapf(err, "error creating secret %s in %s", secretName, targetNamespace)
+	}
+
+	existing, err := client.Secrets(targetNamespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "error getting existing secret %s/%s", targetNamespace, secretName)
+	}
+
+	if reflect.DeepEqual(existing.Data, srcSecret.Data) {
+		log.Infof("Secret %s already exists in %s with same data, skipping copy", secretName, targetNamespace)
+		return nil
+	}
+
+	log.Infof("Secret %s already exists in %s with different data, collision detected", secretName, targetNamespace)
+	return ErrSecretCollision
+}
+
+// DeleteSecretIfAny deletes a secret if it exists, logging but not returning errors.
+func DeleteSecretIfAny(ctx context.Context, client corev1client.CoreV1Interface, secretName, namespace string, log logrus.FieldLogger) {
+	err := client.Secrets(namespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debugf("Secret %s/%s not found, skipping delete", namespace, secretName)
+		} else {
+			log.WithError(err).Errorf("Failed to delete secret %s/%s", namespace, secretName)
+		}
+	}
+}
+
+// DeleteSecretsWithLabel deletes all secrets in a namespace matching a label key=value pair.
+func DeleteSecretsWithLabel(ctx context.Context, client corev1client.CoreV1Interface, namespace, labelKey, labelValue string, log logrus.FieldLogger) {
+	secrets, err := client.Secrets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelKey + "=" + labelValue,
+	})
+	if err != nil {
+		log.WithError(err).Errorf("Failed to list secrets with label %s=%s in %s", labelKey, labelValue, namespace)
+		return
+	}
+
+	for i := range secrets.Items {
+		DeleteSecretIfAny(ctx, client, secrets.Items[i].Name, namespace, log)
+	}
 }

--- a/pkg/util/kube/secrets.go
+++ b/pkg/util/kube/secrets.go
@@ -56,13 +56,13 @@ func GetSecretKey(client kbclient.Client, namespace string, selector *corev1api.
 }
 
 const (
-	// BackupPVCSecretLabel is the label applied to secrets copied to the Velero namespace
-	// for backup PVC provisioning. The value is the owning DataUpload name.
+	// BackupPVCSecretLabel is the label applied to secrets and configmaps copied to the
+	// Velero namespace for backup PVC provisioning. The value is the owning DataUpload name.
 	BackupPVCSecretLabel = "velero.io/backup-pvc-secret" //nolint:gosec // not a credential
 )
 
-// ErrSecretCollision is returned when a secret with the same name but different data
-// already exists in the target namespace, indicating another DataUpload is using it.
+// ErrSecretCollision is returned when a secret or configmap with the same name but different
+// data already exists in the target namespace, indicating another DataUpload is using it.
 var ErrSecretCollision = errors.New("secret collision: same name exists with different data")
 
 // CopySecret copies a secret from sourceNamespace to targetNamespace.
@@ -135,5 +135,77 @@ func DeleteSecretsWithLabel(ctx context.Context, client corev1client.CoreV1Inter
 
 	for i := range secrets.Items {
 		DeleteSecretIfAny(ctx, client, secrets.Items[i].Name, namespace, log)
+	}
+}
+
+// CopyConfigMap copies a configmap from sourceNamespace to targetNamespace.
+// If a configmap with the same name already exists in the target with identical data, it is a no-op.
+// If a configmap with the same name exists with different data (collision from another DataUpload),
+// it returns ErrSecretCollision so the caller can requeue.
+func CopyConfigMap(ctx context.Context, client corev1client.CoreV1Interface, cmName, sourceNamespace, targetNamespace string, ownerName string, log logrus.FieldLogger) error {
+	srcCM, err := client.ConfigMaps(sourceNamespace).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "error getting configmap %s/%s", sourceNamespace, cmName)
+	}
+
+	newCM := &corev1api.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: targetNamespace,
+			Labels: map[string]string{
+				BackupPVCSecretLabel: ownerName,
+			},
+		},
+		Data: srcCM.Data,
+	}
+
+	_, err = client.ConfigMaps(targetNamespace).Create(ctx, newCM, metav1.CreateOptions{})
+	if err == nil {
+		log.Infof("Copied configmap %s from %s to %s", cmName, sourceNamespace, targetNamespace)
+		return nil
+	}
+
+	if !apierrors.IsAlreadyExists(err) {
+		return errors.Wrapf(err, "error creating configmap %s in %s", cmName, targetNamespace)
+	}
+
+	existing, err := client.ConfigMaps(targetNamespace).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "error getting existing configmap %s/%s", targetNamespace, cmName)
+	}
+
+	if reflect.DeepEqual(existing.Data, srcCM.Data) {
+		log.Infof("ConfigMap %s already exists in %s with same data, skipping copy", cmName, targetNamespace)
+		return nil
+	}
+
+	log.Infof("ConfigMap %s already exists in %s with different data, collision detected", cmName, targetNamespace)
+	return ErrSecretCollision
+}
+
+// DeleteConfigMapIfAny deletes a configmap if it exists, logging but not returning errors.
+func DeleteConfigMapIfAny(ctx context.Context, client corev1client.CoreV1Interface, cmName, namespace string, log logrus.FieldLogger) {
+	err := client.ConfigMaps(namespace).Delete(ctx, cmName, metav1.DeleteOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debugf("ConfigMap %s/%s not found, skipping delete", namespace, cmName)
+		} else {
+			log.WithError(err).Errorf("Failed to delete configmap %s/%s", namespace, cmName)
+		}
+	}
+}
+
+// DeleteConfigMapsWithLabel deletes all configmaps in a namespace matching a label key=value pair.
+func DeleteConfigMapsWithLabel(ctx context.Context, client corev1client.CoreV1Interface, namespace, labelKey, labelValue string, log logrus.FieldLogger) {
+	cms, err := client.ConfigMaps(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelKey + "=" + labelValue,
+	})
+	if err != nil {
+		log.WithError(err).Errorf("Failed to list configmaps with label %s=%s in %s", labelKey, labelValue, namespace)
+		return
+	}
+
+	for i := range cms.Items {
+		DeleteConfigMapIfAny(ctx, client, cms.Items[i].Name, namespace, log)
 	}
 }

--- a/pkg/util/kube/secrets.go
+++ b/pkg/util/kube/secrets.go
@@ -58,7 +58,7 @@ func GetSecretKey(client kbclient.Client, namespace string, selector *corev1api.
 const (
 	// BackupPVCSecretLabel is the label applied to secrets copied to the Velero namespace
 	// for backup PVC provisioning. The value is the owning DataUpload name.
-	BackupPVCSecretLabel = "velero.io/backup-pvc-secret"
+	BackupPVCSecretLabel = "velero.io/backup-pvc-secret" //nolint:gosec // not a credential
 )
 
 // ErrSecretCollision is returned when a secret with the same name but different data

--- a/pkg/util/kube/secrets.go
+++ b/pkg/util/kube/secrets.go
@@ -113,18 +113,6 @@ func CopySecret(ctx context.Context, client corev1client.CoreV1Interface, secret
 	return ErrSecretCollision
 }
 
-// DeleteSecretIfAny deletes a secret if it exists, logging but not returning errors.
-func DeleteSecretIfAny(ctx context.Context, client corev1client.CoreV1Interface, secretName, namespace string, log logrus.FieldLogger) {
-	err := client.Secrets(namespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Debugf("Secret %s/%s not found, skipping delete", namespace, secretName)
-		} else {
-			log.WithError(err).Errorf("Failed to delete secret %s/%s", namespace, secretName)
-		}
-	}
-}
-
 // DeleteSecretsWithLabel deletes all secrets in a namespace matching a label key=value pair.
 // Uses UID preconditions to avoid deleting a recreated object with the same name.
 func DeleteSecretsWithLabel(ctx context.Context, client corev1client.CoreV1Interface, namespace, labelKey, labelValue string, log logrus.FieldLogger) {
@@ -191,18 +179,6 @@ func CopyConfigMap(ctx context.Context, client corev1client.CoreV1Interface, cmN
 
 	log.Infof("ConfigMap %s already exists in %s owned by a different owner, collision detected", cmName, targetNamespace)
 	return ErrSecretCollision
-}
-
-// DeleteConfigMapIfAny deletes a configmap if it exists, logging but not returning errors.
-func DeleteConfigMapIfAny(ctx context.Context, client corev1client.CoreV1Interface, cmName, namespace string, log logrus.FieldLogger) {
-	err := client.ConfigMaps(namespace).Delete(ctx, cmName, metav1.DeleteOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Debugf("ConfigMap %s/%s not found, skipping delete", namespace, cmName)
-		} else {
-			log.WithError(err).Errorf("Failed to delete configmap %s/%s", namespace, cmName)
-		}
-	}
 }
 
 // DeleteConfigMapsWithLabel deletes all configmaps in a namespace matching a label key=value pair.

--- a/pkg/util/kube/secrets.go
+++ b/pkg/util/kube/secrets.go
@@ -55,21 +55,25 @@ func GetSecretKey(client kbclient.Client, namespace string, selector *corev1api.
 	return key, nil
 }
 
-const (
-	// BackupPVCSecretLabel is the label applied to secrets and configmaps copied to the
-	// Velero namespace for backup PVC provisioning. The value is the owning DataUpload name.
-	BackupPVCSecretLabel = "velero.io/backup-pvc-secret" //nolint:gosec // not a credential
-)
-
 // ErrSecretCollision is returned when a secret or configmap with the same name but different
-// data already exists in the target namespace, indicating another DataUpload is using it.
+// data already exists in the target namespace, indicating another owner is using it.
 var ErrSecretCollision = errors.New("secret collision: same name exists with different data")
 
-// CopySecret copies a secret from sourceNamespace to targetNamespace.
-// If a secret with the same name already exists in the target with identical data
-// and the same owner, it is a no-op. If the data matches but a different owner holds
-// it, or the data differs, it returns ErrSecretCollision.
-func CopySecret(ctx context.Context, client corev1client.CoreV1Interface, secretName, sourceNamespace, targetNamespace string, ownerName string, log logrus.FieldLogger) error {
+// labelsMatch reports whether all entries in want are present in have with matching values.
+func labelsMatch(have, want map[string]string) bool {
+	for k, v := range want {
+		if have[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// CopySecret copies a secret from sourceNamespace to targetNamespace, applying the given labels.
+// If a secret with the same name already exists in the target with identical data and matching
+// labels, it is a no-op. If the data matches but the labels differ, or the data differs, it
+// returns ErrSecretCollision.
+func CopySecret(ctx context.Context, client corev1client.CoreV1Interface, secretName, sourceNamespace, targetNamespace string, labels map[string]string, log logrus.FieldLogger) error {
 	srcSecret, err := client.Secrets(sourceNamespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "error getting secret %s/%s", sourceNamespace, secretName)
@@ -79,9 +83,7 @@ func CopySecret(ctx context.Context, client corev1client.CoreV1Interface, secret
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: targetNamespace,
-			Labels: map[string]string{
-				BackupPVCSecretLabel: ownerName,
-			},
+			Labels:    labels,
 		},
 		Type: srcSecret.Type,
 		Data: srcSecret.Data,
@@ -102,12 +104,12 @@ func CopySecret(ctx context.Context, client corev1client.CoreV1Interface, secret
 		return errors.Wrapf(err, "error getting existing secret %s/%s", targetNamespace, secretName)
 	}
 
-	if reflect.DeepEqual(existing.Data, srcSecret.Data) && existing.Labels[BackupPVCSecretLabel] == ownerName {
-		log.Infof("Secret %s already exists in %s with same data and owner, skipping copy", secretName, targetNamespace)
+	if reflect.DeepEqual(existing.Data, srcSecret.Data) && labelsMatch(existing.Labels, labels) {
+		log.Infof("Secret %s already exists in %s with same data and labels, skipping copy", secretName, targetNamespace)
 		return nil
 	}
 
-	log.Infof("Secret %s already exists in %s owned by a different DataUpload, collision detected", secretName, targetNamespace)
+	log.Infof("Secret %s already exists in %s owned by a different owner, collision detected", secretName, targetNamespace)
 	return ErrSecretCollision
 }
 
@@ -145,11 +147,11 @@ func DeleteSecretsWithLabel(ctx context.Context, client corev1client.CoreV1Inter
 	}
 }
 
-// CopyConfigMap copies a configmap from sourceNamespace to targetNamespace.
-// If a configmap with the same name already exists in the target with identical data
-// and the same owner, it is a no-op. If the data matches but a different owner holds
-// it, or the data differs, it returns ErrSecretCollision.
-func CopyConfigMap(ctx context.Context, client corev1client.CoreV1Interface, cmName, sourceNamespace, targetNamespace string, ownerName string, log logrus.FieldLogger) error {
+// CopyConfigMap copies a configmap from sourceNamespace to targetNamespace, applying the given
+// labels. If a configmap with the same name already exists in the target with identical data and
+// matching labels, it is a no-op. If the data matches but the labels differ, or the data differs,
+// it returns ErrSecretCollision.
+func CopyConfigMap(ctx context.Context, client corev1client.CoreV1Interface, cmName, sourceNamespace, targetNamespace string, labels map[string]string, log logrus.FieldLogger) error {
 	srcCM, err := client.ConfigMaps(sourceNamespace).Get(ctx, cmName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "error getting configmap %s/%s", sourceNamespace, cmName)
@@ -159,9 +161,7 @@ func CopyConfigMap(ctx context.Context, client corev1client.CoreV1Interface, cmN
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
 			Namespace: targetNamespace,
-			Labels: map[string]string{
-				BackupPVCSecretLabel: ownerName,
-			},
+			Labels:    labels,
 		},
 		Data:       srcCM.Data,
 		BinaryData: srcCM.BinaryData,
@@ -184,12 +184,12 @@ func CopyConfigMap(ctx context.Context, client corev1client.CoreV1Interface, cmN
 
 	if reflect.DeepEqual(existing.Data, srcCM.Data) &&
 		reflect.DeepEqual(existing.BinaryData, srcCM.BinaryData) &&
-		existing.Labels[BackupPVCSecretLabel] == ownerName {
-		log.Infof("ConfigMap %s already exists in %s with same data and owner, skipping copy", cmName, targetNamespace)
+		labelsMatch(existing.Labels, labels) {
+		log.Infof("ConfigMap %s already exists in %s with same data and labels, skipping copy", cmName, targetNamespace)
 		return nil
 	}
 
-	log.Infof("ConfigMap %s already exists in %s owned by a different DataUpload, collision detected", cmName, targetNamespace)
+	log.Infof("ConfigMap %s already exists in %s owned by a different owner, collision detected", cmName, targetNamespace)
 	return ErrSecretCollision
 }
 

--- a/pkg/util/kube/secrets_copy_test.go
+++ b/pkg/util/kube/secrets_copy_test.go
@@ -89,11 +89,11 @@ func TestCopySecret(t *testing.T) {
 			},
 		},
 		{
-			name:        "returns collision when same data but different owner",
-			secretName:  "ceph-csi-kms-token",
-			sourceNS:    "app-ns",
-			targetNS:    "velero",
-			ownerName:   "du-456",
+			name:       "returns collision when same data but different owner",
+			secretName: "ceph-csi-kms-token",
+			sourceNS:   "app-ns",
+			targetNS:   "velero",
+			ownerName:  "du-456",
 			objects: []k8sruntime.Object{
 				&corev1api.Secret{
 					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-token", Namespace: "app-ns"},
@@ -269,11 +269,11 @@ func TestCopyConfigMap(t *testing.T) {
 			},
 		},
 		{
-			name:        "returns collision when same data but different owner",
-			cmName:      "ceph-csi-kms-config",
-			sourceNS:    "app-ns",
-			targetNS:    "velero",
-			ownerName:   "du-456",
+			name:      "returns collision when same data but different owner",
+			cmName:    "ceph-csi-kms-config",
+			sourceNS:  "app-ns",
+			targetNS:  "velero",
+			ownerName: "du-456",
 			objects: []k8sruntime.Object{
 				&corev1api.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-config", Namespace: "app-ns"},

--- a/pkg/util/kube/secrets_copy_test.go
+++ b/pkg/util/kube/secrets_copy_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestCopySecret(t *testing.T) {
+	log := logrus.New()
+
+	tests := []struct {
+		name        string
+		secretName  string
+		sourceNS    string
+		targetNS    string
+		ownerName   string
+		objects     []k8sruntime.Object
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:       "successfully copies secret to target namespace",
+			secretName: "ceph-csi-kms-token",
+			sourceNS:   "app-ns",
+			targetNS:   "velero",
+			ownerName:  "du-123",
+			objects: []k8sruntime.Object{
+				&corev1api.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-token", Namespace: "app-ns"},
+					Data:       map[string][]byte{"token": []byte("vault-token-a")},
+					Type:       corev1api.SecretTypeOpaque,
+				},
+			},
+		},
+		{
+			name:        "returns error when source secret does not exist",
+			secretName:  "missing-secret",
+			sourceNS:    "app-ns",
+			targetNS:    "velero",
+			ownerName:   "du-123",
+			objects:     []k8sruntime.Object{},
+			expectErr:   true,
+			errContains: "error getting secret",
+		},
+		{
+			name:       "no-op when target already has secret with same data",
+			secretName: "ceph-csi-kms-token",
+			sourceNS:   "app-ns",
+			targetNS:   "velero",
+			ownerName:  "du-123",
+			objects: []k8sruntime.Object{
+				&corev1api.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-token", Namespace: "app-ns"},
+					Data:       map[string][]byte{"token": []byte("same-token")},
+					Type:       corev1api.SecretTypeOpaque,
+				},
+				&corev1api.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-token", Namespace: "velero"},
+					Data:       map[string][]byte{"token": []byte("same-token")},
+					Type:       corev1api.SecretTypeOpaque,
+				},
+			},
+		},
+		{
+			name:       "returns collision error when target has secret with different data",
+			secretName: "ceph-csi-kms-token",
+			sourceNS:   "app-ns",
+			targetNS:   "velero",
+			ownerName:  "du-123",
+			objects: []k8sruntime.Object{
+				&corev1api.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-token", Namespace: "app-ns"},
+					Data:       map[string][]byte{"token": []byte("token-a")},
+					Type:       corev1api.SecretTypeOpaque,
+				},
+				&corev1api.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-token", Namespace: "velero"},
+					Data:       map[string][]byte{"token": []byte("token-b")},
+					Type:       corev1api.SecretTypeOpaque,
+				},
+			},
+			expectErr:   true,
+			errContains: "secret collision",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(tt.objects...)
+
+			err := CopySecret(context.Background(), fakeClient.CoreV1(),
+				tt.secretName, tt.sourceNS, tt.targetNS, tt.ownerName, log)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			copied, getErr := fakeClient.CoreV1().Secrets(tt.targetNS).Get(
+				context.Background(), tt.secretName, metav1.GetOptions{})
+			require.NoError(t, getErr)
+			assert.NotNil(t, copied)
+		})
+	}
+}
+
+func TestDeleteSecretIfAny(t *testing.T) {
+	log := logrus.New()
+
+	t.Run("deletes existing secret", func(t *testing.T) {
+		secret := &corev1api.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-secret", Namespace: "velero"},
+		}
+		fakeClient := fake.NewSimpleClientset(secret)
+
+		DeleteSecretIfAny(context.Background(), fakeClient.CoreV1(), "test-secret", "velero", log)
+
+		_, err := fakeClient.CoreV1().Secrets("velero").Get(
+			context.Background(), "test-secret", metav1.GetOptions{})
+		assert.True(t, err != nil)
+	})
+
+	t.Run("no error when secret does not exist", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+		DeleteSecretIfAny(context.Background(), fakeClient.CoreV1(), "missing", "velero", log)
+	})
+}
+
+func TestDeleteSecretsWithLabel(t *testing.T) {
+	log := logrus.New()
+
+	fakeClient := fake.NewSimpleClientset(
+		&corev1api.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "secret-1", Namespace: "velero",
+				Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+			},
+		},
+		&corev1api.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "secret-2", Namespace: "velero",
+				Labels: map[string]string{BackupPVCSecretLabel: "du-456"},
+			},
+		},
+	)
+
+	DeleteSecretsWithLabel(context.Background(), fakeClient.CoreV1(), "velero",
+		BackupPVCSecretLabel, "du-123", log)
+
+	_, err := fakeClient.CoreV1().Secrets("velero").Get(
+		context.Background(), "secret-1", metav1.GetOptions{})
+	assert.True(t, err != nil, "secret-1 should be deleted")
+
+	_, err = fakeClient.CoreV1().Secrets("velero").Get(
+		context.Background(), "secret-2", metav1.GetOptions{})
+	assert.NoError(t, err, "secret-2 should still exist")
+}

--- a/pkg/util/kube/secrets_copy_test.go
+++ b/pkg/util/kube/secrets_copy_test.go
@@ -67,7 +67,7 @@ func TestCopySecret(t *testing.T) {
 			errContains: "error getting secret",
 		},
 		{
-			name:       "no-op when target already has secret with same data",
+			name:       "no-op when target already has secret with same data and same owner",
 			secretName: "ceph-csi-kms-token",
 			sourceNS:   "app-ns",
 			targetNS:   "velero",
@@ -79,11 +79,38 @@ func TestCopySecret(t *testing.T) {
 					Type:       corev1api.SecretTypeOpaque,
 				},
 				&corev1api.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-token", Namespace: "velero"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ceph-csi-kms-token", Namespace: "velero",
+						Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+					},
+					Data: map[string][]byte{"token": []byte("same-token")},
+					Type: corev1api.SecretTypeOpaque,
+				},
+			},
+		},
+		{
+			name:        "returns collision when same data but different owner",
+			secretName:  "ceph-csi-kms-token",
+			sourceNS:    "app-ns",
+			targetNS:    "velero",
+			ownerName:   "du-456",
+			objects: []k8sruntime.Object{
+				&corev1api.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-token", Namespace: "app-ns"},
 					Data:       map[string][]byte{"token": []byte("same-token")},
 					Type:       corev1api.SecretTypeOpaque,
 				},
+				&corev1api.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ceph-csi-kms-token", Namespace: "velero",
+						Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+					},
+					Data: map[string][]byte{"token": []byte("same-token")},
+					Type: corev1api.SecretTypeOpaque,
+				},
 			},
+			expectErr:   true,
+			errContains: "collision",
 		},
 		{
 			name:       "returns collision error when target has secret with different data",
@@ -222,7 +249,7 @@ func TestCopyConfigMap(t *testing.T) {
 			errContains: "error getting configmap",
 		},
 		{
-			name:      "no-op when target already has configmap with same data",
+			name:      "no-op when target already has configmap with same data and same owner",
 			cmName:    "ceph-csi-kms-config",
 			sourceNS:  "app-ns",
 			targetNS:  "velero",
@@ -233,8 +260,46 @@ func TestCopyConfigMap(t *testing.T) {
 					Data:       map[string]string{"vaultAddress": "https://vault.example.com"},
 				},
 				&corev1api.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-config", Namespace: "velero"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ceph-csi-kms-config", Namespace: "velero",
+						Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+					},
+					Data: map[string]string{"vaultAddress": "https://vault.example.com"},
+				},
+			},
+		},
+		{
+			name:        "returns collision when same data but different owner",
+			cmName:      "ceph-csi-kms-config",
+			sourceNS:    "app-ns",
+			targetNS:    "velero",
+			ownerName:   "du-456",
+			objects: []k8sruntime.Object{
+				&corev1api.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-config", Namespace: "app-ns"},
 					Data:       map[string]string{"vaultAddress": "https://vault.example.com"},
+				},
+				&corev1api.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ceph-csi-kms-config", Namespace: "velero",
+						Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+					},
+					Data: map[string]string{"vaultAddress": "https://vault.example.com"},
+				},
+			},
+			expectErr:   true,
+			errContains: "collision",
+		},
+		{
+			name:      "copies configmap with BinaryData",
+			cmName:    "ceph-csi-kms-config",
+			sourceNS:  "app-ns",
+			targetNS:  "velero",
+			ownerName: "du-123",
+			objects: []k8sruntime.Object{
+				&corev1api.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-config", Namespace: "app-ns"},
+					BinaryData: map[string][]byte{"ca.crt": []byte("binary-ca-bundle")},
 				},
 			},
 		},

--- a/pkg/util/kube/secrets_copy_test.go
+++ b/pkg/util/kube/secrets_copy_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestCopySecret(t *testing.T) {
@@ -146,7 +146,7 @@ func TestDeleteSecretIfAny(t *testing.T) {
 
 		_, err := fakeClient.CoreV1().Secrets("velero").Get(
 			context.Background(), "test-secret", metav1.GetOptions{})
-		assert.True(t, err != nil)
+		assert.Error(t, err)
 	})
 
 	t.Run("no error when secret does not exist", func(t *testing.T) {
@@ -178,7 +178,7 @@ func TestDeleteSecretsWithLabel(t *testing.T) {
 
 	_, err := fakeClient.CoreV1().Secrets("velero").Get(
 		context.Background(), "secret-1", metav1.GetOptions{})
-	assert.True(t, err != nil, "secret-1 should be deleted")
+	require.Error(t, err, "secret-1 should be deleted")
 
 	_, err = fakeClient.CoreV1().Secrets("velero").Get(
 		context.Background(), "secret-2", metav1.GetOptions{})

--- a/pkg/util/kube/secrets_copy_test.go
+++ b/pkg/util/kube/secrets_copy_test.go
@@ -184,3 +184,154 @@ func TestDeleteSecretsWithLabel(t *testing.T) {
 		context.Background(), "secret-2", metav1.GetOptions{})
 	assert.NoError(t, err, "secret-2 should still exist")
 }
+
+func TestCopyConfigMap(t *testing.T) {
+	log := logrus.New()
+
+	tests := []struct {
+		name        string
+		cmName      string
+		sourceNS    string
+		targetNS    string
+		ownerName   string
+		objects     []k8sruntime.Object
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:      "successfully copies configmap to target namespace",
+			cmName:    "ceph-csi-kms-config",
+			sourceNS:  "app-ns",
+			targetNS:  "velero",
+			ownerName: "du-123",
+			objects: []k8sruntime.Object{
+				&corev1api.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-config", Namespace: "app-ns"},
+					Data:       map[string]string{"vaultAddress": "https://vault.example.com"},
+				},
+			},
+		},
+		{
+			name:        "returns error when source configmap does not exist",
+			cmName:      "missing-cm",
+			sourceNS:    "app-ns",
+			targetNS:    "velero",
+			ownerName:   "du-123",
+			objects:     []k8sruntime.Object{},
+			expectErr:   true,
+			errContains: "error getting configmap",
+		},
+		{
+			name:      "no-op when target already has configmap with same data",
+			cmName:    "ceph-csi-kms-config",
+			sourceNS:  "app-ns",
+			targetNS:  "velero",
+			ownerName: "du-123",
+			objects: []k8sruntime.Object{
+				&corev1api.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-config", Namespace: "app-ns"},
+					Data:       map[string]string{"vaultAddress": "https://vault.example.com"},
+				},
+				&corev1api.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-config", Namespace: "velero"},
+					Data:       map[string]string{"vaultAddress": "https://vault.example.com"},
+				},
+			},
+		},
+		{
+			name:      "returns collision error when target has configmap with different data",
+			cmName:    "ceph-csi-kms-config",
+			sourceNS:  "app-ns",
+			targetNS:  "velero",
+			ownerName: "du-123",
+			objects: []k8sruntime.Object{
+				&corev1api.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-config", Namespace: "app-ns"},
+					Data:       map[string]string{"vaultAddress": "https://vault-a.example.com"},
+				},
+				&corev1api.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "ceph-csi-kms-config", Namespace: "velero"},
+					Data:       map[string]string{"vaultAddress": "https://vault-b.example.com"},
+				},
+			},
+			expectErr:   true,
+			errContains: "secret collision",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(tt.objects...)
+
+			err := CopyConfigMap(context.Background(), fakeClient.CoreV1(),
+				tt.cmName, tt.sourceNS, tt.targetNS, tt.ownerName, log)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			copied, getErr := fakeClient.CoreV1().ConfigMaps(tt.targetNS).Get(
+				context.Background(), tt.cmName, metav1.GetOptions{})
+			require.NoError(t, getErr)
+			assert.NotNil(t, copied)
+		})
+	}
+}
+
+func TestDeleteConfigMapIfAny(t *testing.T) {
+	log := logrus.New()
+
+	t.Run("deletes existing configmap", func(t *testing.T) {
+		cm := &corev1api.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "velero"},
+		}
+		fakeClient := fake.NewSimpleClientset(cm)
+
+		DeleteConfigMapIfAny(context.Background(), fakeClient.CoreV1(), "test-cm", "velero", log)
+
+		_, err := fakeClient.CoreV1().ConfigMaps("velero").Get(
+			context.Background(), "test-cm", metav1.GetOptions{})
+		assert.Error(t, err)
+	})
+
+	t.Run("no error when configmap does not exist", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+		DeleteConfigMapIfAny(context.Background(), fakeClient.CoreV1(), "missing", "velero", log)
+	})
+}
+
+func TestDeleteConfigMapsWithLabel(t *testing.T) {
+	log := logrus.New()
+
+	fakeClient := fake.NewSimpleClientset(
+		&corev1api.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cm-1", Namespace: "velero",
+				Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+			},
+		},
+		&corev1api.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cm-2", Namespace: "velero",
+				Labels: map[string]string{BackupPVCSecretLabel: "du-456"},
+			},
+		},
+	)
+
+	DeleteConfigMapsWithLabel(context.Background(), fakeClient.CoreV1(), "velero",
+		BackupPVCSecretLabel, "du-123", log)
+
+	_, err := fakeClient.CoreV1().ConfigMaps("velero").Get(
+		context.Background(), "cm-1", metav1.GetOptions{})
+	require.Error(t, err, "cm-1 should be deleted")
+
+	_, err = fakeClient.CoreV1().ConfigMaps("velero").Get(
+		context.Background(), "cm-2", metav1.GetOptions{})
+	assert.NoError(t, err, "cm-2 should still exist")
+}

--- a/pkg/util/kube/secrets_copy_test.go
+++ b/pkg/util/kube/secrets_copy_test.go
@@ -163,28 +163,6 @@ func TestCopySecret(t *testing.T) {
 	}
 }
 
-func TestDeleteSecretIfAny(t *testing.T) {
-	log := logrus.New()
-
-	t.Run("deletes existing secret", func(t *testing.T) {
-		secret := &corev1api.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-secret", Namespace: "velero"},
-		}
-		fakeClient := fake.NewSimpleClientset(secret)
-
-		DeleteSecretIfAny(context.Background(), fakeClient.CoreV1(), "test-secret", "velero", log)
-
-		_, err := fakeClient.CoreV1().Secrets("velero").Get(
-			context.Background(), "test-secret", metav1.GetOptions{})
-		assert.Error(t, err)
-	})
-
-	t.Run("no error when secret does not exist", func(t *testing.T) {
-		fakeClient := fake.NewSimpleClientset()
-		DeleteSecretIfAny(context.Background(), fakeClient.CoreV1(), "missing", "velero", log)
-	})
-}
-
 func TestDeleteSecretsWithLabel(t *testing.T) {
 	log := logrus.New()
 
@@ -351,28 +329,6 @@ func TestCopyConfigMap(t *testing.T) {
 			assert.NotNil(t, copied)
 		})
 	}
-}
-
-func TestDeleteConfigMapIfAny(t *testing.T) {
-	log := logrus.New()
-
-	t.Run("deletes existing configmap", func(t *testing.T) {
-		cm := &corev1api.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "velero"},
-		}
-		fakeClient := fake.NewSimpleClientset(cm)
-
-		DeleteConfigMapIfAny(context.Background(), fakeClient.CoreV1(), "test-cm", "velero", log)
-
-		_, err := fakeClient.CoreV1().ConfigMaps("velero").Get(
-			context.Background(), "test-cm", metav1.GetOptions{})
-		assert.Error(t, err)
-	})
-
-	t.Run("no error when configmap does not exist", func(t *testing.T) {
-		fakeClient := fake.NewSimpleClientset()
-		DeleteConfigMapIfAny(context.Background(), fakeClient.CoreV1(), "missing", "velero", log)
-	})
 }
 
 func TestDeleteConfigMapsWithLabel(t *testing.T) {

--- a/pkg/util/kube/secrets_copy_test.go
+++ b/pkg/util/kube/secrets_copy_test.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+const testCopyLabel = "velero.io/backup-pvc-secret"
+
 func TestCopySecret(t *testing.T) {
 	log := logrus.New()
 
@@ -81,7 +83,7 @@ func TestCopySecret(t *testing.T) {
 				&corev1api.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "ceph-csi-kms-token", Namespace: "velero",
-						Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+						Labels: map[string]string{testCopyLabel: "du-123"},
 					},
 					Data: map[string][]byte{"token": []byte("same-token")},
 					Type: corev1api.SecretTypeOpaque,
@@ -103,7 +105,7 @@ func TestCopySecret(t *testing.T) {
 				&corev1api.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "ceph-csi-kms-token", Namespace: "velero",
-						Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+						Labels: map[string]string{testCopyLabel: "du-123"},
 					},
 					Data: map[string][]byte{"token": []byte("same-token")},
 					Type: corev1api.SecretTypeOpaque,
@@ -140,7 +142,8 @@ func TestCopySecret(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(tt.objects...)
 
 			err := CopySecret(context.Background(), fakeClient.CoreV1(),
-				tt.secretName, tt.sourceNS, tt.targetNS, tt.ownerName, log)
+				tt.secretName, tt.sourceNS, tt.targetNS,
+				map[string]string{testCopyLabel: tt.ownerName}, log)
 
 			if tt.expectErr {
 				require.Error(t, err)
@@ -189,19 +192,19 @@ func TestDeleteSecretsWithLabel(t *testing.T) {
 		&corev1api.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "secret-1", Namespace: "velero",
-				Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+				Labels: map[string]string{testCopyLabel: "du-123"},
 			},
 		},
 		&corev1api.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "secret-2", Namespace: "velero",
-				Labels: map[string]string{BackupPVCSecretLabel: "du-456"},
+				Labels: map[string]string{testCopyLabel: "du-456"},
 			},
 		},
 	)
 
 	DeleteSecretsWithLabel(context.Background(), fakeClient.CoreV1(), "velero",
-		BackupPVCSecretLabel, "du-123", log)
+		testCopyLabel, "du-123", log)
 
 	_, err := fakeClient.CoreV1().Secrets("velero").Get(
 		context.Background(), "secret-1", metav1.GetOptions{})
@@ -262,7 +265,7 @@ func TestCopyConfigMap(t *testing.T) {
 				&corev1api.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "ceph-csi-kms-config", Namespace: "velero",
-						Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+						Labels: map[string]string{testCopyLabel: "du-123"},
 					},
 					Data: map[string]string{"vaultAddress": "https://vault.example.com"},
 				},
@@ -282,7 +285,7 @@ func TestCopyConfigMap(t *testing.T) {
 				&corev1api.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "ceph-csi-kms-config", Namespace: "velero",
-						Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+						Labels: map[string]string{testCopyLabel: "du-123"},
 					},
 					Data: map[string]string{"vaultAddress": "https://vault.example.com"},
 				},
@@ -329,7 +332,8 @@ func TestCopyConfigMap(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(tt.objects...)
 
 			err := CopyConfigMap(context.Background(), fakeClient.CoreV1(),
-				tt.cmName, tt.sourceNS, tt.targetNS, tt.ownerName, log)
+				tt.cmName, tt.sourceNS, tt.targetNS,
+				map[string]string{testCopyLabel: tt.ownerName}, log)
 
 			if tt.expectErr {
 				require.Error(t, err)
@@ -378,19 +382,19 @@ func TestDeleteConfigMapsWithLabel(t *testing.T) {
 		&corev1api.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cm-1", Namespace: "velero",
-				Labels: map[string]string{BackupPVCSecretLabel: "du-123"},
+				Labels: map[string]string{testCopyLabel: "du-123"},
 			},
 		},
 		&corev1api.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cm-2", Namespace: "velero",
-				Labels: map[string]string{BackupPVCSecretLabel: "du-456"},
+				Labels: map[string]string{testCopyLabel: "du-456"},
 			},
 		},
 	)
 
 	DeleteConfigMapsWithLabel(context.Background(), fakeClient.CoreV1(), "velero",
-		BackupPVCSecretLabel, "du-123", log)
+		testCopyLabel, "du-123", log)
 
 	_, err := fakeClient.CoreV1().ConfigMaps("velero").Get(
 		context.Background(), "cm-1", metav1.GetOptions{})


### PR DESCRIPTION
# Summary

Add support for copying namespace-scoped secrets and configmaps to the Velero namespace during datamover backup and restore, so CSI volumes that require namespace-scoped resources for provisioning (e.g., ODF/ceph-csi encrypted volumes with Vault KMS) can be backed up and restored.

The datamover creates an intermediate PVC in the Velero namespace using the source/target volume's StorageClass. For encrypted volumes, ceph-csi looks up the KMS token secret (`ceph-csi-kms-token`) in the PVC's namespace (the Velero namespace), where it doesn't exist, so provisioning fails.

New `secretNames`/`configMapNames` fields let users configure which resources to copy:

```json
{
  "backupPVC": {
    "ocs-storagecluster-ceph-rbd-encrypted": {
      "secretNames": ["ceph-csi-kms-token"],
      "configMapNames": ["ceph-csi-kms-config"]
    }
  },
  "restorePVC": {
    "secretNames": ["ceph-csi-kms-token"],
    "configMapNames": ["ceph-csi-kms-config"]
  }
}
```

## How it works

**Backup** (`pkg/exposer/csi_snapshot.go`): after the volume snapshot is ready and before creating the backup PVC, copy the configured secrets/configmaps from the source namespace to the Velero namespace (labeled `velero.io/backup-pvc-secret`). Clean up in `CleanUp()`.

**Restore** (`pkg/exposer/generic_restore.go`): before creating the restore PVC, copy the configured secrets/configmaps from the target namespace to the Velero namespace. Clean up in `CleanUp()`.

- **Collision handling**: if a resource with the same name but different data already exists (another DataUpload/DataDownload), return `ErrSecretCollision`. Same data + matching labels is a no-op.
- **Cleanup**: label-based deletion with UID preconditions to avoid deleting a recreated object.

## Testing

Unit tests for the copy/delete helpers and both exposers. Also validated end to end on an OpenShift + ODF 4.22 cluster with Vault KMS (`vaulttokens`) encrypted RBD volumes:
- Backup: secret+configmap copied, encrypted backup PVC provisioned and bound, DataUpload completed, resources cleaned up.
- Restore: secret+configmap copied, encrypted restore PVC provisioned and bound (previously stuck Pending with `ceph-csi-kms-token not found`), DataDownload completed, data verified, resources cleaned up.

## Which issue(s) this PR fixes

Fixes #9879

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.