### PR TITLE
Fix e2e cache miss on force push by saving build artifacts explicitly

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -33,14 +33,14 @@ jobs:
       # Look for a CLI that's made for this PR
       - name: Fetch built CLI
         id: cli-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./_output/bin/linux/amd64/velero
           # The cache key a combination of the current PR number and the commit SHA
           key: velero-cli-${{ github.event.pull_request.number }}-${{ github.sha }}
       - name: Fetch built image
         id: image-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./velero.tar
           # The cache key a combination of the current PR number and the commit SHA
@@ -63,7 +63,7 @@ jobs:
           DOCKERFILE_SHA=$(curl -s https://api.github.com/repos/bitnami/containers/commits?path=bitnami/minio/2026/debian-12/Dockerfile\&per_page=1 | jq -r '.[0].sha')
           echo "dockerfile_sha=${DOCKERFILE_SHA}" >> $GITHUB_OUTPUT
       - name: Cache MinIO Image
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         id: minio-cache
         with:
           path: ./minio-image.tar
@@ -76,6 +76,29 @@ jobs:
           cd /tmp/bitnami-containers/bitnami/minio/2026/debian-12
           docker build -t bitnami/minio:local .
           docker save bitnami/minio:local > ${{ github.workspace }}/minio-image.tar
+      # Save the freshly built artifacts to the cache explicitly, before this
+      # job reports completion. actions/cache@v4 saves in a post-job hook that
+      # runs *after* the job finishes, so the dependent run-e2e-test jobs (which
+      # start as soon as build completes) would race the save and miss the cache
+      # on a force push. See #9927.
+      - name: Save built CLI to cache
+        if: steps.cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ./_output/bin/linux/amd64/velero
+          key: velero-cli-${{ github.event.pull_request.number }}-${{ github.sha }}
+      - name: Save built image to cache
+        if: steps.image-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ./velero.tar
+          key: velero-image-${{ github.event.pull_request.number }}-${{ github.sha }}
+      - name: Save MinIO image to cache
+        if: steps.minio-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ./minio-image.tar
+          key: minio-bitnami-${{ steps.minio-version.outputs.dockerfile_sha }}
   # Create json of k8s versions to test
   # from guide: https://stackoverflow.com/a/65094398/4590470
   setup-test-matrix:
@@ -123,7 +146,7 @@ jobs:
 
       # Fetch the pre-built MinIO image from the build job
       - name: Fetch built MinIO Image
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         id: minio-cache
         with:
           path: ./minio-image.tar
@@ -142,13 +165,13 @@ jobs:
           node_image: "kindest/node:v${{ matrix.k8s }}"
       - name: Fetch built CLI
         id: cli-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./_output/bin/linux/amd64/velero
           key: velero-cli-${{ github.event.pull_request.number }}-${{ github.sha }}
       - name: Fetch built Image
         id: image-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./velero.tar
           key: velero-image-${{ github.event.pull_request.number }}-${{ github.sha }}

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -39,14 +39,14 @@ jobs:
       # Look for a CLI that's made for this PR
       - name: Fetch built CLI
         id: cli-cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ./_output/bin/linux/amd64/velero
           # The cache key a combination of the current PR number and the commit SHA
           key: velero-cli-${{ github.event.pull_request.number }}-${{ github.sha }}
       - name: Fetch built image
         id: image-cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ./velero.tar
           # The cache key a combination of the current PR number and the commit SHA
@@ -64,7 +64,7 @@ jobs:
           docker save velero:pr-test-linux-amd64 -o ./velero.tar
       # Build the MinIO image once for all e2e tests, from the reviewed bitnami/containers commit.
       - name: Cache MinIO Image
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         id: minio-cache
         with:
           path: ./minio-image.tar
@@ -81,6 +81,29 @@ jobs:
           cd /tmp/bitnami-containers/bitnami/minio/2026/debian-12
           docker build -t bitnami/minio:local .
           docker save bitnami/minio:local > ${{ github.workspace }}/minio-image.tar
+      # Save the freshly built artifacts to the cache explicitly, before this
+      # job reports completion. actions/cache saves in a post-job hook that
+      # runs *after* the job finishes, so the dependent run-e2e-test jobs (which
+      # start as soon as build completes) would race the save and miss the cache
+      # on a force push. See #9927.
+      - name: Save built CLI to cache
+        if: steps.cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ./_output/bin/linux/amd64/velero
+          key: velero-cli-${{ github.event.pull_request.number }}-${{ github.sha }}
+      - name: Save built image to cache
+        if: steps.image-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ./velero.tar
+          key: velero-image-${{ github.event.pull_request.number }}-${{ github.sha }}
+      - name: Save MinIO image to cache
+        if: steps.minio-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ./minio-image.tar
+          key: minio-bitnami-${{ steps.minio-version.outputs.dockerfile_sha }}
   # Create json of k8s versions to test
   # from guide: https://stackoverflow.com/a/65094398/4590470
   setup-test-matrix:
@@ -157,7 +180,7 @@ jobs:
 
       # Fetch the pre-built MinIO image from the build job
       - name: Fetch built MinIO Image
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         id: minio-cache
         with:
           path: ./minio-image.tar
@@ -176,13 +199,13 @@ jobs:
           node_image: "kindest/node:v${{ matrix.k8s }}"
       - name: Fetch built CLI
         id: cli-cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ./_output/bin/linux/amd64/velero
           key: velero-cli-${{ github.event.pull_request.number }}-${{ github.sha }}
       - name: Fetch built Image
         id: image-cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ./velero.tar
           key: velero-image-${{ github.event.pull_request.number }}-${{ github.sha }}

--- a/changelogs/unreleased/9952-alliasgher
+++ b/changelogs/unreleased/9952-alliasgher
@@ -1,0 +1,1 @@
+Fix e2e-test-kind workflow cache miss on force push by saving build artifacts explicitly instead of relying on the actions/cache post-job hook


### PR DESCRIPTION
# Please add a summary of your change

The `e2e-test-kind.yaml` workflow passes build artifacts (`velero.tar`, the CLI binary, and the MinIO image) from the `build` job to the `run-e2e-test` jobs using `actions/cache@v4`.

`actions/cache@v4` saves the cache in a **post-job hook** that runs *after* the job reports completion. The `run-e2e-test` jobs have `needs: build`, so they start as soon as `build` completes — before the post-hook has written the cache. Because the CLI/image cache keys include `github.sha`, a force push (e.g. after a rebase) has no pre-existing cache entry, so every e2e job deterministically misses the cache and fails at "Load Velero Image" with `ERROR: stat velero.tar: no such file or directory`. Re-running the failed jobs works only because the build job's post-hook has since populated the cache.

This change makes the save explicit and in-job:

- `build` job: switch the lookups to `actions/cache/restore`, and add `actions/cache/save` steps at the end of the job for the CLI, image, and MinIO artifacts (guarded on a cache miss). The cache is now written before `build` reports completion.
- `run-e2e-test` jobs: switch the reads to `actions/cache/restore`.

The MinIO image is keyed on a content SHA rather than `github.sha`, but it shares the same post-hook-save race on the first build of a new Dockerfile revision, so it's converted for consistency.

# Does your change fix a particular issue?

Fixes #9927

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] Created a changelog file (`make new-changelog`) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main` (N/A — CI workflow only).