### PR TITLE
Add make test-e2e-kind: self-contained e2e run in a single container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,6 +489,15 @@ gen-docs:
 test-e2e: local
 	$(MAKE) -e VERSION=$(VERSION) -C test/ run-e2e
 
+# Runs the e2e suite against a kind cluster and MinIO that live entirely inside a
+# single privileged wrapper container (nested dockerd). The kind cluster, its
+# kubeconfig, and MinIO never exist on the host - only the wrapper image/container
+# touch the host engine. See hack/e2e-kind.sh and test/e2e/README.md for details
+# and prerequisites.
+.PHONY: test-e2e-kind
+test-e2e-kind:
+	./hack/e2e-kind.sh
+
 .PHONY: test-perf
 test-perf: local
 	$(MAKE) -e VERSION=$(VERSION) -C test/ run-perf

--- a/Makefile
+++ b/Makefile
@@ -509,6 +509,15 @@ gen-docs: ## Generate a new versioned docs directory
 test-e2e: local ## Run end-to-end tests
 	$(MAKE) -e VERSION=$(VERSION) -C test/ run-e2e
 
+# Runs the e2e suite against a kind cluster and MinIO that live entirely inside a
+# single privileged wrapper container (nested dockerd). The kind cluster, its
+# kubeconfig, and MinIO never exist on the host - only the wrapper image/container
+# touch the host engine. See hack/e2e-kind.sh and test/e2e/README.md for details
+# and prerequisites.
+.PHONY: test-e2e-kind
+test-e2e-kind:
+	./hack/e2e-kind.sh
+
 .PHONY: test-perf
 test-perf: local ## Run performance tests
 	$(MAKE) -e VERSION=$(VERSION) -C test/ run-perf

--- a/hack/e2e-kind.sh
+++ b/hack/e2e-kind.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Driver for `make test-e2e-kind`. Builds the wrapper image (see hack/e2e-kind/)
+# and runs it --privileged --rm: the nested dockerd, the kind cluster, MinIO, the
+# velero build, and the e2e test run all happen inside that one container. The
+# kind cluster, its kubeconfig, and MinIO never exist on the host; the host
+# engine only ever sees the wrapper image and, while the run is active, the
+# wrapper container itself. Nothing is written to the host filesystem outside
+# this repo checkout (which a native `make test-e2e` run would also write build
+# output into).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTAINER_TOOL="${CONTAINER_TOOL:-docker}"
+
+for tool in "${CONTAINER_TOOL}" git; do
+	command -v "${tool}" >/dev/null 2>&1 || {
+		echo "error: ${tool} is required on PATH to run test-e2e-kind" >&2
+		exit 1
+	}
+done
+
+case "$(uname -m)" in
+	x86_64) TARGETARCH=amd64 ;;
+	aarch64 | arm64) TARGETARCH=arm64 ;;
+	*)
+		echo "error: unsupported host architecture $(uname -m)" >&2
+		exit 1
+		;;
+esac
+
+WRAPPER_IMAGE="velero-e2e-kind:local"
+
+# If this checkout is a git worktree, its .git is a pointer file to the real
+# repo's git dir elsewhere on the host (e.g. /path/to/main-clone/.git/worktrees/x)
+# - bind-mount that too, or every git invocation inside the container fails to
+# resolve it. For a plain (non-worktree) clone this just re-mounts a path already
+# under REPO_ROOT, which is a harmless no-op.
+GIT_COMMON_DIR="$(cd "${REPO_ROOT}" && git rev-parse --path-format=absolute --git-common-dir)"
+
+EXTRA_MOUNTS=()
+if [[ "${GIT_COMMON_DIR}" != "${REPO_ROOT}"/* ]]; then
+	EXTRA_MOUNTS+=(-v "${GIT_COMMON_DIR}:${GIT_COMMON_DIR}")
+fi
+
+# buildx-backed docker needs --load to land the image in the local store; other
+# tools (podman) load locally by default and may not accept the flag.
+BUILD_FLAGS=()
+if "${CONTAINER_TOOL}" build --help 2>&1 | grep -q -- '--load'; then
+	BUILD_FLAGS+=(--load)
+fi
+
+echo "==> building wrapper image (${WRAPPER_IMAGE})"
+"${CONTAINER_TOOL}" build \
+	"${BUILD_FLAGS[@]}" \
+	--build-arg "TARGETARCH=${TARGETARCH}" \
+	-t "${WRAPPER_IMAGE}" \
+	"${REPO_ROOT}/hack/e2e-kind"
+
+# Run by immutable image ID, not tag, so a concurrent invocation re-tagging
+# velero-e2e-kind:local can't swap the image out from under this run.
+WRAPPER_IMAGE_ID="$("${CONTAINER_TOOL}" image inspect --format '{{.Id}}' "${WRAPPER_IMAGE}")"
+
+echo "==> running e2e tests in a self-contained container (kind + MinIO + build, all inside)"
+exec "${CONTAINER_TOOL}" run --rm --privileged \
+	-v "${REPO_ROOT}:${REPO_ROOT}" \
+	"${EXTRA_MOUNTS[@]}" \
+	-w "${REPO_ROOT}" \
+	-e "BSL_BUCKET=${BSL_BUCKET:-velero}" \
+	-e "PLUGINS=${PLUGINS:-velero/velero-plugin-for-aws:main}" \
+	-e "GINKGO_LABELS=${GINKGO_LABELS:-}" \
+	-e "HOST_UID=$(id -u)" \
+	-e "HOST_GID=$(id -g)" \
+	"${WRAPPER_IMAGE_ID}" "$@"

--- a/hack/e2e-kind/Dockerfile
+++ b/hack/e2e-kind/Dockerfile
@@ -1,0 +1,63 @@
+# Wrapper image for `make test-e2e-kind`: runs a nested dockerd, builds Velero
+# from the mounted repo source, creates a kind cluster, runs MinIO, and drives the
+# existing test/Makefile e2e target — all entirely inside one container.
+# See hack/e2e-kind.sh (driver) and test/e2e/README.md for usage.
+#
+# Each tool is fetched in its own stage so layer caching is per-tool: bumping one
+# version only re-downloads that tool, editing entrypoint.sh re-downloads nothing,
+# and cold builds fetch all three in parallel.
+#
+# Future investigation: a podman-in-podman base (quay.io/podman/stable) could
+# replace docker:dind, but two things block it today: kind's podman provider is
+# still experimental (KIND_EXPERIMENTAL_PROVIDER=podman, with a known rootless
+# log-driver issue that breaks kind's boot detection), and the root Makefile's
+# `container` target hard-requires docker buildx (errors on CONTAINER_TOOL=podman),
+# so the inner Velero image build would need a separate podman build path.
+
+# KIND_VERSION and KUBECTL_VERSION must be bumped together: kubectl should match
+# the Kubernetes version of this kind release's default node image.
+ARG KIND_VERSION=v0.27.0
+ARG KUBECTL_VERSION=v1.32.2
+ARG GO_VERSION=1.26.0
+
+FROM alpine:3.21 AS fetch-kind
+ARG KIND_VERSION
+ARG TARGETARCH
+RUN apk add --no-cache curl \
+	&& curl -fsSLo /kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${TARGETARCH}" \
+	&& curl -fsSLo /kind.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${TARGETARCH}.sha256sum" \
+	&& echo "$(cut -d' ' -f1 /kind.sha256sum)  /kind" | sha256sum -c - \
+	&& chmod +x /kind
+
+FROM alpine:3.21 AS fetch-kubectl
+ARG KUBECTL_VERSION
+ARG TARGETARCH
+RUN apk add --no-cache curl \
+	&& curl -fsSLo /kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+	&& curl -fsSLo /kubectl.sha256 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl.sha256" \
+	&& echo "$(cat /kubectl.sha256)  /kubectl" | sha256sum -c - \
+	&& chmod +x /kubectl
+
+FROM alpine:3.21 AS fetch-go
+ARG GO_VERSION
+ARG TARGETARCH
+RUN apk add --no-cache curl \
+	&& curl -fsSLo /tmp/go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
+	&& curl -fsSLo /tmp/go.tar.gz.sha256 "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz.sha256" \
+	&& echo "$(cat /tmp/go.tar.gz.sha256)  /tmp/go.tar.gz" | sha256sum -c - \
+	&& tar -C /usr/local -xzf /tmp/go.tar.gz
+
+FROM docker:dind
+
+RUN apk add --no-cache bash git make ca-certificates
+
+COPY --from=fetch-kind /kind /usr/local/bin/kind
+COPY --from=fetch-kubectl /kubectl /usr/local/bin/kubectl
+COPY --from=fetch-go /usr/local/go /usr/local/go
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/hack/e2e-kind/entrypoint.sh
+++ b/hack/e2e-kind/entrypoint.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Runs entirely inside this one container: nested dockerd, the repo's own build
+# targets, a kind cluster, MinIO, and test/Makefile's run-e2e target. The
+# kubeconfig, the kind cluster, and MinIO live only in this container's own
+# filesystem/engine and disappear when the container is removed. The repo is
+# bind-mounted read-write at the same path it lives at on the host (see
+# hack/e2e-kind.sh) purely so build caches/output behave exactly like a native
+# `make local`/`make test-e2e` run would.
+set -euo pipefail
+
+CLUSTER_NAME="velero-e2e"
+KUBECONFIG_PATH="/root/.kube/config"
+CREDS_PATH="/root/minio-credentials"
+BUCKET="${BSL_BUCKET:-velero}"
+PLUGINS="${PLUGINS:-velero/velero-plugin-for-aws:main}"
+GINKGO_LABELS="${GINKGO_LABELS:-}"
+
+# On native-Linux hosts this container runs as root against the bind-mounted
+# repo, which would leave root-owned build artifacts behind (the repo's own
+# `make shell` avoids this with -u). Hand everything we may have written back to
+# the host user on the way out. On macOS engines (Docker Desktop/podman machine)
+# the mount is UID-mapped and this is a no-op that may not even be permitted,
+# hence the blanket error suppression.
+cleanup_ownership() {
+	if [ -n "${HOST_UID:-}" ] && [ "${HOST_UID}" != "0" ]; then
+		chown -R "${HOST_UID}:${HOST_GID:-${HOST_UID}}" \
+			_output .go test/e2e/report.xml 2>/dev/null || true
+	fi
+}
+trap cleanup_ownership EXIT
+
+echo "==> starting inner dockerd"
+# cgroup v2: delegate all available controllers to child cgroups before dockerd
+# starts. Without this, dockerd's own cgroup has an empty cgroup.subtree_control
+# (nothing delegated down), so the kind node's nested systemd fails outright
+# ("Structure needs cleaning" on /init.scope) or, one layer deeper, kubelet's own
+# startup script hits the same wall ("this script needs cgroup.procs to be empty").
+# This is normally handled by docker:dind's own default entrypoint, which our
+# custom ENTRYPOINT bypasses, so it's reproduced here (same shape as upstream's
+# dind script). The procs move must happen before subtree_control is written
+# ("no internal processes" rule); errors moving individual PIDs are ignored like
+# upstream does (a process may exit mid-move), but a failed delegation write is
+# fatal and reported.
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+	mkdir -p /sys/fs/cgroup/init
+	xargs -rn1 </sys/fs/cgroup/cgroup.procs >/sys/fs/cgroup/init/cgroup.procs 2>/dev/null || true
+	sed -e 's/^/+/' -e 's/ / +/g' </sys/fs/cgroup/cgroup.controllers >/sys/fs/cgroup/cgroup.subtree_control || {
+		echo "failed to delegate cgroup v2 controllers; nested kind will not boot" >&2
+		exit 1
+	}
+fi
+
+dockerd >/var/log/dockerd.log 2>&1 &
+for _ in $(seq 1 30); do
+	docker info >/dev/null 2>&1 && break
+	sleep 1
+done
+docker info >/dev/null 2>&1 || {
+	echo "inner dockerd did not come up; last log lines:" >&2
+	tail -n 50 /var/log/dockerd.log >&2
+	exit 1
+}
+
+# The repo is bind-mounted from the host, owned by the host user's UID; git
+# refuses to operate on a repo it doesn't own unless told it's safe. Optional
+# locks are disabled so read-only commands (git status in the Makefile) don't
+# opportunistically rewrite the host repo's index as root.
+git config --global --add safe.directory '*'
+export GIT_OPTIONAL_LOCKS=0
+
+# Create the cluster before the heavy build steps so the timing-sensitive
+# systemd boot inside the kind node isn't competing with the Go compile and
+# BuildKit for CPU/IO.
+echo "==> creating kind cluster ${CLUSTER_NAME}"
+kind create cluster --name "${CLUSTER_NAME}" --kubeconfig "${KUBECONFIG_PATH}"
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+echo "==> building velero CLI (make local)"
+make local CONTAINER_TOOL=docker
+
+echo "==> building velero server image (make container)"
+docker buildx inspect --bootstrap >/dev/null
+make container CONTAINER_TOOL=docker BUILD_OUTPUT_TYPE=docker IMAGE=velero VERSION=e2e-kind-local
+
+ARCH="$(go env GOARCH)"
+VELERO_IMAGE="velero:e2e-kind-local-linux-${ARCH}"
+
+echo "==> loading ${VELERO_IMAGE} into kind"
+kind load docker-image "${VELERO_IMAGE}" --name "${CLUSTER_NAME}"
+
+echo "==> starting MinIO"
+docker run -d --name minio --network kind \
+	-e MINIO_ACCESS_KEY=minio -e MINIO_SECRET_KEY=minio123 \
+	minio/minio:latest server /data >/dev/null
+minio_ready=false
+for _ in $(seq 1 30); do
+	if docker run --rm --network kind curlimages/curl:latest -sf -o /dev/null \
+		http://minio:9000/minio/health/live; then
+		minio_ready=true
+		break
+	fi
+	sleep 1
+done
+if [ "${minio_ready}" != "true" ]; then
+	echo "MinIO did not become healthy in time; container logs:" >&2
+	docker logs minio 2>&1 | tail -n 50 >&2
+	exit 1
+fi
+
+echo "==> creating bucket ${BUCKET}"
+docker run --rm --network kind \
+	--entrypoint /bin/sh minio/mc:latest -c "
+		mc alias set local http://minio:9000 minio minio123 >/dev/null &&
+		mc mb -p local/${BUCKET} >/dev/null
+	"
+
+cat >"${CREDS_PATH}" <<-EOF
+	[default]
+	aws_access_key_id = minio
+	aws_secret_access_key = minio123
+EOF
+
+echo "==> running e2e tests (make -C test run-e2e)"
+set +e
+make -C test run-e2e \
+	CREDS_FILE="${CREDS_PATH}" \
+	BSL_BUCKET="${BUCKET}" \
+	CLOUD_PROVIDER=kind \
+	OBJECT_STORE_PROVIDER=aws \
+	BSL_CONFIG="region=minio,s3ForcePathStyle=true,s3Url=http://minio:9000" \
+	VELERO_IMAGE="${VELERO_IMAGE}" \
+	PLUGINS="${PLUGINS}" \
+	GINKGO_LABELS="${GINKGO_LABELS}" \
+	"$@"
+code=$?
+set -e
+
+echo "==> e2e tests exited with code ${code}"
+exit "${code}"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -89,6 +89,36 @@ a specified object store type.  Currently supported cloud provider types are _aw
 
 ## 4. Running tests
 
+### Quick start: fully self-contained `kind` run
+
+`make test-e2e-kind` runs the suite against a `kind` cluster and MinIO with no
+manual setup at all - no `kind create cluster`, no MinIO deployment, no credentials
+file to write by hand, and no risk to your current kubectl context.
+
+The kind cluster, MinIO, the Velero build, and the test run all happen inside a
+single privileged wrapper container (a nested `dockerd`, similar to how kind's own
+node containers already run a nested container runtime). The kind cluster, its
+kubeconfig, and MinIO never exist on the host - your `~/.kube/config`, current
+kubectl context, and `kind get clusters` are untouched. The host engine only sees
+the wrapper image and, while the run is active, the wrapper container itself; the
+host filesystem is only written inside this repo checkout (build output, same as a
+native `make test-e2e`). When the container exits, the inner cluster, MinIO, and
+kubeconfig all disappear with it.
+
+Prerequisites: `docker` (or `podman`, via `CONTAINER_TOOL=podman`) and `git` on
+`PATH`. That's it - `kind`, `kubectl`, `go`, MinIO, and the Velero image are all
+handled inside the wrapper.
+
+```bash
+make test-e2e-kind
+# narrow to a subset, same as GINKGO_LABELS for make test-e2e:
+GINKGO_LABELS="Basic" make test-e2e-kind
+```
+
+See `hack/e2e-kind.sh` and `hack/e2e-kind/` for how it's assembled. This target
+always builds Velero from your local checkout (not a published image), so it
+exercises whatever you have checked out, including uncommitted changes.
+
 ### Parameters for `make`
 
 E2E tests can be run from the Velero repository root by running `make test-e2e`. While running E2E tests using `make` the E2E test configuration values are passed using `make` variables.


### PR DESCRIPTION
# Please add a summary of your change

Adds `make test-e2e-kind`: a zero-setup way to run the e2e suite against a `kind` cluster and MinIO that never touches the developer's kube context, host kind clusters, or credentials files.

The kind cluster, MinIO, the Velero build (CLI + server image from the local checkout), and the test run all happen inside a single privileged wrapper container running a nested `dockerd`. When the container exits (`--rm`), the inner cluster, MinIO, and kubeconfig all disappear with it — nothing to clean up, pass or fail. Host prerequisites are only `docker` (or `podman`) and `git`; `kind`, `kubectl`, and Go are baked into the wrapper image (fetched in per-tool multistage stages with sha256 verification).

Highlights:
- `hack/e2e-kind/entrypoint.sh` reproduces docker:dind's cgroup v2 controller delegation, without which the kind node's nested systemd fails with `Failed to create /init.scope control group: Structure needs cleaning`
- `hack/e2e-kind.sh` handles git-worktree checkouts (bind-mounts the resolved `--git-common-dir`), runs the wrapper by immutable image ID to avoid concurrent-run tag races, and hands build-artifact ownership back to the host user on native-Linux hosts
- `GINKGO_LABELS` and the other e2e make variables pass through unchanged: `GINKGO_LABELS="Basic" make test-e2e-kind`

Verified end-to-end on macOS (Docker CLI → Podman Desktop compatibility socket): `GINKGO_LABELS="Basic" make test-e2e-kind` → 6 passed / 0 failed, host `~/.kube/config`, `docker ps`, and `kind get clusters` untouched throughout.

# Does your change fix a particular issue?

N/A — developer-experience improvement for running e2e locally.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`. (docs live in `test/e2e/README.md`, which is where the e2e workflow is documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)