### PR TITLE
Add set-based label selector test and docs coverage for restore

### DIFF
--- a/pkg/cmd/util/flag/label_selector_test.go
+++ b/pkg/cmd/util/flag/label_selector_test.go
@@ -24,6 +24,28 @@ func TestSetOfLabelSelector(t *testing.T) {
 	assert.True(t, str == "k1=v1,k2=v2" || str == "k2=v2,k2=v2")
 }
 
+func TestSetOfSetBasedLabelSelector(t *testing.T) {
+	selector := &LabelSelector{}
+	require.NoError(t, selector.Set("pr-label notin (1)"))
+	require.NotNil(t, selector.LabelSelector)
+	require.Len(t, selector.LabelSelector.MatchExpressions, 1)
+	req := selector.LabelSelector.MatchExpressions[0]
+	assert.Equal(t, "pr-label", req.Key)
+	assert.Equal(t, metav1.LabelSelectorOpNotIn, req.Operator)
+	assert.Equal(t, []string{"1"}, req.Values)
+}
+
+func TestSetOfDoesNotExistLabelSelector(t *testing.T) {
+	selector := &LabelSelector{}
+	require.NoError(t, selector.Set("!pr-label"))
+	require.NotNil(t, selector.LabelSelector)
+	require.Len(t, selector.LabelSelector.MatchExpressions, 1)
+	req := selector.LabelSelector.MatchExpressions[0]
+	assert.Equal(t, "pr-label", req.Key)
+	assert.Equal(t, metav1.LabelSelectorOpDoesNotExist, req.Operator)
+	assert.Empty(t, req.Values)
+}
+
 func TestTypeOfLabelSelector(t *testing.T) {
 	selector := &LabelSelector{}
 	assert.Equal(t, "labelSelector", selector.Type())

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -452,6 +452,99 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			},
 		},
 		{
+			name: "notin label selector excludes matching resources",
+			restore: defaultRestore().LabelSelector(&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "pr-label", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"1"}},
+			}}).Result(),
+			backup: defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				AddItems("deployments.apps",
+					builder.ForDeployment("ns-1", "deploy-1").Result(),
+					builder.ForDeployment("ns-2", "deploy-2").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+					builder.ForPersistentVolume("pv-2").ObjectMeta(builder.WithLabels("pr-label", "2")).Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Pods(),
+				test.Deployments(),
+				test.PVs(),
+			},
+			want: map[*test.APIResource][]string{
+				test.Pods():        {"ns-2/pod-2"},
+				test.Deployments(): {"ns-1/deploy-1"},
+				test.PVs():         {"/pv-2"},
+			},
+		},
+		{
+			name: "in label selector only restores matching resources",
+			restore: defaultRestore().LabelSelector(&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "pr-label", Operator: metav1.LabelSelectorOpIn, Values: []string{"1", "2"}},
+			}}).Result(),
+			backup: defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+					builder.ForPod("ns-2", "pod-2").ObjectMeta(builder.WithLabels("pr-label", "3")).Result(),
+				).
+				AddItems("deployments.apps",
+					builder.ForDeployment("ns-1", "deploy-1").Result(),
+					builder.ForDeployment("ns-2", "deploy-2").ObjectMeta(builder.WithLabels("pr-label", "2")).Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels("pr-label", "2")).Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Pods(),
+				test.Deployments(),
+				test.PVs(),
+			},
+			want: map[*test.APIResource][]string{
+				test.Pods():        {"ns-1/pod-1"},
+				test.Deployments(): {"ns-2/deploy-2"},
+				test.PVs():         {"/pv-1"},
+			},
+		},
+		{
+			name: "doesnotexist label selector only restores resources without the label key",
+			restore: defaultRestore().LabelSelector(&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "pr-label", Operator: metav1.LabelSelectorOpDoesNotExist},
+			}}).Result(),
+			backup: defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				AddItems("deployments.apps",
+					builder.ForDeployment("ns-1", "deploy-1").Result(),
+					builder.ForDeployment("ns-2", "deploy-2").ObjectMeta(builder.WithLabels("pr-label", "2")).Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels("other-label", "x")).Result(),
+					builder.ForPersistentVolume("pv-2").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Pods(),
+				test.Deployments(),
+				test.PVs(),
+			},
+			want: map[*test.APIResource][]string{
+				test.Pods():        {"ns-2/pod-2"},
+				test.Deployments(): {"ns-1/deploy-1"},
+				test.PVs():         {"/pv-1"},
+			},
+		},
+		{
 			name: "OrLabelSelectors only restores matching resources",
 			restore: defaultRestore().OrLabelSelector([]*metav1.LabelSelector{{MatchLabels: map[string]string{"a1": "b1"}}, {MatchLabels: map[string]string{"a2": "b2"}},
 				{MatchLabels: map[string]string{"a3": "b3"}}, {MatchLabels: map[string]string{"a4": "b4"}}}).Result(),

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -454,6 +454,99 @@ func TestRestoreResourceFiltering(t *testing.T) {
 			},
 		},
 		{
+			name: "notin label selector excludes matching resources",
+			restore: defaultRestore().LabelSelector(&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "pr-label", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"1"}},
+			}}).Result(),
+			backup: defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				AddItems("deployments.apps",
+					builder.ForDeployment("ns-1", "deploy-1").Result(),
+					builder.ForDeployment("ns-2", "deploy-2").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+					builder.ForPersistentVolume("pv-2").ObjectMeta(builder.WithLabels("pr-label", "2")).Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Pods(),
+				test.Deployments(),
+				test.PVs(),
+			},
+			want: map[*test.APIResource][]string{
+				test.Pods():        {"ns-2/pod-2"},
+				test.Deployments(): {"ns-1/deploy-1"},
+				test.PVs():         {"/pv-2"},
+			},
+		},
+		{
+			name: "in label selector only restores matching resources",
+			restore: defaultRestore().LabelSelector(&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "pr-label", Operator: metav1.LabelSelectorOpIn, Values: []string{"1", "2"}},
+			}}).Result(),
+			backup: defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+					builder.ForPod("ns-2", "pod-2").ObjectMeta(builder.WithLabels("pr-label", "3")).Result(),
+				).
+				AddItems("deployments.apps",
+					builder.ForDeployment("ns-1", "deploy-1").Result(),
+					builder.ForDeployment("ns-2", "deploy-2").ObjectMeta(builder.WithLabels("pr-label", "2")).Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels("pr-label", "2")).Result(),
+					builder.ForPersistentVolume("pv-2").Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Pods(),
+				test.Deployments(),
+				test.PVs(),
+			},
+			want: map[*test.APIResource][]string{
+				test.Pods():        {"ns-1/pod-1"},
+				test.Deployments(): {"ns-2/deploy-2"},
+				test.PVs():         {"/pv-1"},
+			},
+		},
+		{
+			name: "doesnotexist label selector only restores resources without the label key",
+			restore: defaultRestore().LabelSelector(&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "pr-label", Operator: metav1.LabelSelectorOpDoesNotExist},
+			}}).Result(),
+			backup: defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("pods",
+					builder.ForPod("ns-1", "pod-1").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+				).
+				AddItems("deployments.apps",
+					builder.ForDeployment("ns-1", "deploy-1").Result(),
+					builder.ForDeployment("ns-2", "deploy-2").ObjectMeta(builder.WithLabels("pr-label", "2")).Result(),
+				).
+				AddItems("persistentvolumes",
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels("other-label", "x")).Result(),
+					builder.ForPersistentVolume("pv-2").ObjectMeta(builder.WithLabels("pr-label", "1")).Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.Pods(),
+				test.Deployments(),
+				test.PVs(),
+			},
+			want: map[*test.APIResource][]string{
+				test.Pods():        {"ns-2/pod-2"},
+				test.Deployments(): {"ns-1/deploy-1"},
+				test.PVs():         {"/pv-1"},
+			},
+		},
+		{
 			name: "OrLabelSelectors only restores matching resources",
 			restore: defaultRestore().OrLabelSelector([]*metav1.LabelSelector{{MatchLabels: map[string]string{"a1": "b1"}}, {MatchLabels: map[string]string{"a2": "b2"}},
 				{MatchLabels: map[string]string{"a3": "b3"}}, {MatchLabels: map[string]string{"a4": "b4"}}}).Result(),

--- a/site/content/docs/main/resource-filtering.md
+++ b/site/content/docs/main/resource-filtering.md
@@ -103,6 +103,30 @@ Includes cluster-scoped resources. Cannot work with `--include-cluster-scoped-re
   velero backup create <backup-name> --selector "<key> notin (<value>)"
   ```
 
+The same selector syntax works on restore. Set-based selectors are useful for phased restores: restore labeled resources first, then everything else.
+
+* Restore only resources matching the label selector.
+
+  ```bash
+  velero restore create --from-backup <backup-name> --selector <key>=<value>
+  ```
+
+* Restore everything in the backup except resources matching the selector.
+
+  ```bash
+  velero restore create --from-backup <backup-name> --selector "<key> notin (<value>)"
+  ```
+
+  `notin` also matches resources that don't have the `<key>` label at all: this restores resources whose `<key>` label has any other value, as well as resources without the `<key>` label.
+
+* Restore only resources that do not have a particular label key.
+
+  ```bash
+  velero restore create --from-backup <backup-name> --selector '!<key>'
+  ```
+
+Note: resources pulled in as dependencies of selected items by restore item actions (for example, a restored pod's service account or persistent volume claims) are restored even if the label selector would exclude them.
+
 For more information read the [Kubernetes label selector documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)
 
 ### --or-selector


### PR DESCRIPTION
# Please add a summary of your change

Adds test and docs coverage for set-based label selectors (`notin`/`in`/`!key`) on restore — previously only equality-based selectors (`MatchLabels`) were tested anywhere in the repo, so `velero restore create --selector 'key notin (value)'` worked purely by inheritance from apimachinery with no velero-side coverage.

- `pkg/restore/restore_test.go`: three new `TestRestoreResourceFiltering` cases — `notin` excludes labeled items (matches items with a different value or no label), `in` restores only items whose value is in the set, `doesnotexist` (`!key`) restores only items without the label key
- `pkg/cmd/util/flag/label_selector_test.go`: verifies the `--selector` flag parses set-based syntax into `MatchExpressions` (`NotIn`, `DoesNotExist`)
- `site/content/docs/main/resource-filtering.md`: the `--selector` section only showed `backup create` examples — added restore examples: the `notin` phased-restore scenario (with a note that `notin` also matches resources without the label key), restoring only unlabeled resources via `--selector '!<key>'`, and a caveat that dependencies pulled in by restore item actions (e.g. a pod's service account or PVCs) bypass label selectors

Context: coverage gap found while verifying the two-phase-restore workaround discussed in https://github.com/velero-io/velero/issues/9381#issuecomment-3739285865 (`--selector "pr-label notin (1)"`). The behavior is correct on main and every release branch back through 1.12 — this pins it.

No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Does your change fix a particular issue?

No — test and docs coverage only.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.