### PR TITLE
[e2e][repro] NFSOwnership test: fs-backup restore silently loses file ownership on root-squashing NFS (#10040)

### DIFF
--- a/.github/workflows/e2e-nfs-ownership.yaml
+++ b/.github/workflows/e2e-nfs-ownership.yaml
@@ -1,0 +1,102 @@
+# Reproduces https://github.com/velero-io/velero/issues/10040 in CI:
+# fs-backup (kopia) restore silently loses file ownership on NFS exports that
+# squash root, while the restore reports Completed.
+#
+# The NFSOwnership e2e asserts ownership is preserved, so this workflow is
+# EXPECTED TO FAIL on current main — the failure is the reproduction. It goes
+# green once the swallowed chown EPERM (IgnorePermissionErrors hardcoded true
+# in pkg/uploader/kopia/snapshot.go) is surfaced or ownership restore works.
+#
+# Scoped triggers: only runs when the test itself (or this workflow) changes,
+# or on manual dispatch — so the intentional red does not affect other PRs.
+name: "[EXPECTED FAIL until #10040 fixed] NFS ownership-preservation E2E on kind"
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "test/e2e/nfs-ownership/**"
+      - "test/testdata/nfs-ownership/**"
+      - "pkg/uploader/kopia/snapshot.go"
+      - ".github/workflows/e2e-nfs-ownership.yaml"
+  pull_request:
+    paths:
+      - "test/e2e/nfs-ownership/**"
+      - "test/testdata/nfs-ownership/**"
+      - "pkg/uploader/kopia/snapshot.go"
+      - ".github/workflows/e2e-nfs-ownership.yaml"
+permissions:
+  contents: read
+jobs:
+  get-go-version:
+    uses: ./.github/workflows/get-go-version.yaml
+    with:
+      ref: ${{ github.event.pull_request.base.ref || github.ref_name }}
+
+  run-nfs-ownership-e2e:
+    name: "run-nfs-ownership-e2e (expected to fail — reproduces #10040)"
+    needs: get-go-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go version
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ needs.get-go-version.outputs.version }}
+
+      - name: Build Velero CLI
+        run: |
+          make local
+
+      - name: Build Velero Image
+        run: |
+          IMAGE=velero VERSION=pr-test BUILD_OUTPUT_TYPE=docker make container
+
+      - name: Install MinIO
+        run: |
+          docker run -d --rm --name minio -p 9000:9000 -e "MINIO_ROOT_USER=minio" -e "MINIO_ROOT_PASSWORD=minio123" quay.io/minio/minio:latest server /data
+          for i in $(seq 1 30); do
+            curl -sf http://127.0.0.1:9000/minio/health/ready && break
+            sleep 2
+          done
+          docker run --rm --network host --entrypoint sh quay.io/minio/mc:latest -c \
+            "mc alias set m http://127.0.0.1:9000 minio minio123 && mc mb -p m/bucket"
+
+      - uses: helm/kind-action@7a97ed793754775518f9db3a8151ee7461dc9c31 # v1 + fix: add curl retry flags (https://github.com/helm/kind-action/pull/165) + node24
+        with:
+          cluster_name: "kind"
+          version: "v0.32.0"
+
+      - name: Load Velero Image
+        run: |
+          kind load docker-image velero:pr-test-linux-amd64
+
+      - name: Run NFSOwnership E2E test
+        run: |
+          cat << EOF > /tmp/credential
+          [default]
+          aws_access_key_id=minio
+          aws_secret_access_key=minio123
+          EOF
+
+          GOPATH=~/go \
+              CLOUD_PROVIDER=kind \
+              OBJECT_STORE_PROVIDER=aws \
+              BSL_CONFIG=region=minio,s3ForcePathStyle="true",s3Url=http://$(hostname -i):9000 \
+              CREDS_FILE=/tmp/credential \
+              BSL_BUCKET=bucket \
+              VELERO_IMAGE=velero:pr-test-linux-amd64 \
+              PLUGINS=velero/velero-plugin-for-aws:latest \
+              GINKGO_LABELS="NFSOwnership" \
+              make -C test/ run-e2e
+        timeout-minutes: 30
+
+      - name: Upload debug bundle
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: DebugBundle-nfs-ownership
+          path: /home/runner/work/velero/velero/test/e2e/debug-bundle*

--- a/changelogs/unreleased/10041-kaovilai
+++ b/changelogs/unreleased/10041-kaovilai
@@ -1,0 +1,1 @@
+Add NFSOwnership e2e test reproducing silent file ownership loss on NFS fs-backup restore (issue #10040)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -39,6 +39,7 @@ import (
 	. "github.com/vmware-tanzu/velero/test/e2e/basic/resources-check"
 	. "github.com/vmware-tanzu/velero/test/e2e/bsl-mgmt"
 	. "github.com/vmware-tanzu/velero/test/e2e/migration"
+	. "github.com/vmware-tanzu/velero/test/e2e/nfs-ownership"
 	. "github.com/vmware-tanzu/velero/test/e2e/nodeagentconfig"
 	. "github.com/vmware-tanzu/velero/test/e2e/parallelfilesdownload"
 	. "github.com/vmware-tanzu/velero/test/e2e/parallelfilesupload"
@@ -652,6 +653,12 @@ var _ = Describe(
 	"Backup resources should follow the specific order in schedule",
 	Label("PVBackup", "OptOut", "FSB"),
 	OptOutPVBackupTest,
+)
+
+var _ = Describe(
+	"Restore of fs-backup preserves file ownership on root-squashing NFS",
+	Label("NFSOwnership", "FSB"),
+	NFSOwnershipTest,
 )
 
 var _ = Describe(

--- a/test/e2e/nfs-ownership/nfs_ownership.go
+++ b/test/e2e/nfs-ownership/nfs_ownership.go
@@ -1,0 +1,239 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package nfsownership reproduces https://github.com/velero-io/velero/issues/10040:
+// fs-backup (kopia) restore silently loses file ownership on NFS exports that
+// squash root. The node-agent data path runs as root, the export squashes it to
+// the anonymous uid, so kopia's post-create os.Chown to the original UID fails
+// with EPERM — which is silently swallowed because pkg/uploader/kopia/snapshot.go
+// hardcodes IgnorePermissionErrors: true. The restore reports Completed while
+// every restored file is owned by the anonymous uid instead of the original one.
+//
+// This test asserts that ownership IS preserved, so it fails on current main by
+// design; it goes green once the swallowed permission errors are surfaced or
+// ownership restore is made to work/fail loudly.
+package nfsownership
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
+	. "github.com/vmware-tanzu/velero/test/e2e/test"
+	. "github.com/vmware-tanzu/velero/test/util/k8s"
+)
+
+const (
+	// The UID the workload writes files as. Must differ from the NFS anonymous
+	// uid (65534) that root gets squashed to, or the bug would be masked.
+	workloadUID = 1001
+
+	ganeshaManifest = "../testdata/nfs-ownership/nfs-ganesha.yaml"
+	ganeshaNS       = "nfs-ownership-ganesha"
+	storageClass    = "nfs-rootsquash-e2e"
+	podName         = "writer"
+	pvcName         = "data"
+)
+
+// Files created by the workload before backup; ownership of each is verified
+// after restore.
+var dataFiles = []string{"/data/apps/a.txt", "/data/caslibs/b.txt"}
+
+type NFSOwnership struct {
+	TestCase
+}
+
+var NFSOwnershipTest func() = TestFunc(&NFSOwnership{})
+
+func (n *NFSOwnership) Init() error {
+	n.TestCase.Init()
+	n.CaseBaseName = "nfs-ownership-" + n.UUIDgen
+	n.BackupName = "backup-" + n.CaseBaseName
+	n.RestoreName = "restore-" + n.CaseBaseName
+	n.VeleroCfg.UseVolumeSnapshots = false
+	n.VeleroCfg.UseNodeAgent = true
+	n.NSIncluded = &[]string{n.CaseBaseName}
+
+	n.TestMsg = &TestMSG{
+		Desc:      "Restore of fs-backup preserves file ownership on root-squashing NFS",
+		FailedMSG: "Restored files lost their original ownership (see https://github.com/velero-io/velero/issues/10040)",
+		Text:      fmt.Sprintf("Files owned by uid %d should keep that ownership after fs-backup restore from a root-squashing NFS volume", workloadUID),
+	}
+
+	n.BackupArgs = []string{
+		"create", "--namespace", n.VeleroCfg.VeleroNamespace, "backup", n.BackupName,
+		"--include-namespaces", n.CaseBaseName,
+		"--snapshot-volumes=false", "--default-volumes-to-fs-backup", "--wait",
+	}
+	n.RestoreArgs = []string{
+		"create", "--namespace", n.VeleroCfg.VeleroNamespace, "restore", n.RestoreName,
+		"--from-backup", n.BackupName, "--wait",
+	}
+	return nil
+}
+
+func (n *NFSOwnership) CreateResources() error {
+	workloadNS := n.CaseBaseName
+
+	By("Deploy in-cluster NFS-Ganesha server with a root-squashing StorageClass", func() {
+		Expect(KubectlApplyByFile(n.Ctx, ganeshaManifest)).To(Succeed())
+		Expect(waitDeploymentAvailable(n.Ctx, ganeshaNS, "nfs-provisioner")).To(Succeed())
+	})
+
+	By(fmt.Sprintf("Create workload namespace %s with a uid-%d writer pod on the NFS PVC", workloadNS, workloadUID), func() {
+		Expect(CreateNamespace(n.Ctx, n.Client, workloadNS)).To(Succeed())
+		Expect(n.applyWorkload(workloadNS)).To(Succeed())
+		Expect(WaitForPods(n.Ctx, n.Client, workloadNS, []string{podName})).To(Succeed())
+	})
+
+	By(fmt.Sprintf("Verify pre-backup ownership of %v is uid %d", dataFiles, workloadUID), func() {
+		for _, f := range dataFiles {
+			uid, err := fileUID(n.Ctx, workloadNS, podName, f)
+			Expect(err).To(Succeed())
+			Expect(uid).To(Equal(strconv.Itoa(workloadUID)),
+				"pre-backup file %s should be owned by the workload uid; test setup is broken otherwise", f)
+		}
+	})
+	return nil
+}
+
+func (n *NFSOwnership) Verify() error {
+	workloadNS := n.CaseBaseName
+
+	By("Wait for the restored workload pod to be ready", func() {
+		Expect(WaitForPods(n.Ctx, n.Client, workloadNS, []string{podName})).To(Succeed())
+	})
+
+	By(fmt.Sprintf("Verify restored files kept ownership uid %d", workloadUID), func() {
+		for _, f := range dataFiles {
+			uid, err := fileUID(n.Ctx, workloadNS, podName, f)
+			Expect(err).To(Succeed())
+			Expect(uid).To(Equal(strconv.Itoa(workloadUID)),
+				"restored file %s is owned by uid %s instead of the original uid %d: "+
+					"the kopia restore's chown failed on the root-squashing NFS export and the "+
+					"EPERM was silently swallowed (IgnorePermissionErrors is hardcoded true in "+
+					"pkg/uploader/kopia/snapshot.go) while the restore reported success — "+
+					"https://github.com/velero-io/velero/issues/10040", f, uid, workloadUID)
+		}
+	})
+	return nil
+}
+
+func (n *NFSOwnership) Clean() error {
+	cleanErr := n.TestCase.Clean()
+	var ganeshaErr error
+	By("Remove the NFS-Ganesha server and StorageClass", func() {
+		ganeshaErr = KubectlDeleteByFile(n.Ctx, ganeshaManifest)
+	})
+	if cleanErr != nil || ganeshaErr != nil {
+		return errors.Join(cleanErr, ganeshaErr)
+	}
+	return nil
+}
+
+// applyWorkload creates the PVC and the uid-1001 writer pod. The framework's
+// CreatePod helper is unusable here: it hardcodes RunAsUser/FSGroup 65534,
+// which is exactly the anonymous uid root gets squashed to and would mask the
+// bug.
+func (n *NFSOwnership) applyWorkload(ns string) error {
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  accessModes:
+  - ReadWriteMany
+  storageClassName: %[3]s
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %[4]s
+  namespace: %[2]s
+spec:
+  securityContext:
+    runAsUser: %[5]d
+    runAsGroup: %[5]d
+    fsGroup: %[5]d
+  containers:
+  - name: app
+    image: busybox:1.36
+    command:
+    - sh
+    - -c
+    - |
+      mkdir -p /data/apps /data/caslibs
+      echo hello-apps > /data/apps/a.txt
+      echo hello-caslibs > /data/caslibs/b.txt
+      ls -lnR /data
+      sleep 3600
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: %[1]s
+`, pvcName, ns, storageClass, podName, workloadUID)
+
+	file, err := os.CreateTemp("", "nfs-ownership-workload-*.yaml")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temp workload manifest")
+	}
+	defer os.Remove(file.Name())
+	if _, err := file.WriteString(manifest); err != nil {
+		file.Close()
+		return errors.Wrap(err, "failed to write workload manifest")
+	}
+	file.Close()
+	return KubectlApplyByFile(n.Ctx, filepath.Clean(file.Name()))
+}
+
+// fileUID returns the numeric owner uid of path inside the pod.
+func fileUID(ctx context.Context, namespace, pod, path string) (string, error) {
+	cmd := exec.CommandContext(ctx, "kubectl",
+		"exec", "-n", namespace, "-c", "app", pod, "--", "stat", "-c", "%u", path)
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to stat %s in %s/%s: %s", path, namespace, pod, stderr)
+	}
+	return strings.TrimSpace(stdout), nil
+}
+
+// waitDeploymentAvailable blocks until the named deployment reports Available.
+func waitDeploymentAvailable(ctx context.Context, namespace, name string) error {
+	cmd := exec.CommandContext(ctx, "kubectl",
+		"wait", "--for=condition=Available", "-n", namespace,
+		"deployment/"+name, "--timeout=180s")
+	_, stderr, err := veleroexec.RunCommand(cmd)
+	if err != nil {
+		return errors.Wrapf(err, "deployment %s/%s not available: %s", namespace, name, stderr)
+	}
+	return nil
+}

--- a/test/testdata/nfs-ownership/nfs-ganesha.yaml
+++ b/test/testdata/nfs-ownership/nfs-ganesha.yaml
@@ -1,0 +1,206 @@
+# Deploys an in-cluster userspace NFS server (NFS-Ganesha) with a dynamic
+# provisioner and a StorageClass whose exports squash root
+# (rootSquash: "true" -> ganesha root_id_squash). Used by the NFSOwnership
+# e2e test to reproduce silent file-ownership loss on fs-backup restore:
+# the node-agent/data-mover runs as root, the export squashes root to the
+# anonymous uid, kopia's post-create chown fails with EPERM, and the error
+# is silently swallowed (IgnorePermissionErrors hardcoded true).
+# See https://github.com/velero-io/velero/issues/10040
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nfs-ownership-ganesha
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfs-provisioner
+  namespace: nfs-ownership-ganesha
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nfs-ownership-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nfs-ownership-run-nfs-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: nfs-provisioner
+    namespace: nfs-ownership-ganesha
+roleRef:
+  kind: ClusterRole
+  name: nfs-ownership-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-nfs-provisioner
+  namespace: nfs-ownership-ganesha
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-nfs-provisioner
+  namespace: nfs-ownership-ganesha
+subjects:
+  - kind: ServiceAccount
+    name: nfs-provisioner
+    namespace: nfs-ownership-ganesha
+roleRef:
+  kind: Role
+  name: leader-locking-nfs-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nfs-provisioner
+  namespace: nfs-ownership-ganesha
+  labels:
+    app: nfs-provisioner
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+    - name: nfs-udp
+      port: 2049
+      protocol: UDP
+    - name: nlockmgr
+      port: 32803
+    - name: nlockmgr-udp
+      port: 32803
+      protocol: UDP
+    - name: mountd
+      port: 20048
+    - name: mountd-udp
+      port: 20048
+      protocol: UDP
+    - name: rquotad
+      port: 875
+    - name: rquotad-udp
+      port: 875
+      protocol: UDP
+    - name: rpcbind
+      port: 111
+    - name: rpcbind-udp
+      port: 111
+      protocol: UDP
+    - name: statd
+      port: 662
+    - name: statd-udp
+      port: 662
+      protocol: UDP
+  selector:
+    app: nfs-provisioner
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nfs-provisioner
+  namespace: nfs-ownership-ganesha
+spec:
+  selector:
+    matchLabels:
+      app: nfs-provisioner
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: nfs-provisioner
+    spec:
+      serviceAccountName: nfs-provisioner
+      containers:
+        - name: nfs-provisioner
+          image: registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8
+          ports:
+            - name: nfs
+              containerPort: 2049
+            - name: nfs-udp
+              containerPort: 2049
+              protocol: UDP
+            - name: nlockmgr
+              containerPort: 32803
+            - name: nlockmgr-udp
+              containerPort: 32803
+              protocol: UDP
+            - name: mountd
+              containerPort: 20048
+            - name: mountd-udp
+              containerPort: 20048
+              protocol: UDP
+            - name: rquotad
+              containerPort: 875
+            - name: rquotad-udp
+              containerPort: 875
+              protocol: UDP
+            - name: rpcbind
+              containerPort: 111
+            - name: rpcbind-udp
+              containerPort: 111
+              protocol: UDP
+            - name: statd
+              containerPort: 662
+            - name: statd-udp
+              containerPort: 662
+              protocol: UDP
+          securityContext:
+            capabilities:
+              add:
+                - DAC_READ_SEARCH
+                - SYS_RESOURCE
+          args:
+            - "-provisioner=nfs-ownership.velero.io/nfs"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVICE_NAME
+              value: nfs-provisioner
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: export-volume
+              mountPath: /export
+      volumes:
+        - name: export-volume
+          emptyDir: {}
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: nfs-rootsquash-e2e
+provisioner: nfs-ownership.velero.io/nfs
+parameters:
+  rootSquash: "true"
+mountOptions:
+  - vers=4.1


### PR DESCRIPTION
> [!Note]
> Responses generated with Claude

## Thank you for contributing to Velero!

## Please add a summary of your change

This draft PR adds an e2e test (`NFSOwnership` label) that reproduces #10040 in kind on GitHub Actions: fs-backup (kopia) restore silently loses file ownership on NFS exports that squash root, while the restore reports Completed.

**This test is EXPECTED TO FAIL on current main — the red run is the reproduction.** It will go green once the swallowed chown permission errors are surfaced (or ownership restore is made to work / fail loudly). Fix directions are being discussed in #10040.

### What the test does

1. Deploys an in-cluster **userspace NFS-Ganesha** server + dynamic provisioner (`registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8`) with a StorageClass setting `rootSquash: "true"` — no kernel `nfsd` module needed on the runner, works in kind out of the box.
2. Creates a workload pod running as **uid 1001** writing files to the NFS PVC, and verifies pre-backup ownership is 1001.
3. Runs an fs-backup (`--default-volumes-to-fs-backup`), destroys the namespace, restores.
4. Asserts every restored file is still owned by uid 1001. On current main the files come back owned by the NFS anonymous uid (65534 / 4294967294) because the node-agent data path runs as root, the export squashes root, kopia's post-create `os.Chown` gets EPERM, and `IgnorePermissionErrors: true` (hardcoded in `pkg/uploader/kopia/snapshot.go`) silently swallows it.

The mechanism was confirmed on a real EKS cluster with a one-line instrumented build (`IgnorePermissionErrors: false`), which turned the silent success into:

```
Failed to run kopia restore: ... error setting attributes: could not change owner/group for
/<pvc-uid>/apps/a.txt: chown ...: operation not permitted
```

Full evidence in #10040.

### Notes

- The framework's `CreatePod` helper hardcodes `RunAsUser/FSGroup: 65534` — exactly the anonymous uid root gets squashed to, which would mask the bug; the test uses its own uid-1001 workload manifest instead.
- The new workflow `.github/workflows/e2e-nfs-ownership.yaml` only triggers on changes to the test's own paths (plus `workflow_dispatch`), so the intentional red does not affect other PRs.
- The `NFSOwnership` label is not added to the default kind e2e matrix for the same reason.

## Does your change fix a particular issue?

Reproduces (does not yet fix) #10040. Related closed reports: #9398, #9399.

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/main/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`. (N/A — test-only change)