### PR TITLE
Do not assume a port name is a string when clearing node ports

### DIFF
--- a/changelogs/unreleased/10132-arpitjain099
+++ b/changelogs/unreleased/10132-arpitjain099
@@ -1,0 +1,1 @@
+Fix a panic when a port name in the last-applied-configuration annotation is not a string

--- a/pkg/restore/actions/service_action.go
+++ b/pkg/restore/actions/service_action.go
@@ -193,8 +193,8 @@ func deleteNodePorts(service *corev1api.Service) error {
 						if !ok {
 							// unnamed port
 							unnamedPortInts.Insert(nodePortInt)
-						} else {
-							explicitNodePorts.Insert(portName.(string))
+						} else if name, ok := portName.(string); ok {
+							explicitNodePorts.Insert(name)
 						}
 					}
 				}

--- a/pkg/restore/actions/service_action_test.go
+++ b/pkg/restore/actions/service_action_test.go
@@ -674,6 +674,44 @@ func TestServiceActionExecute(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "If a port name in last-applied-configuration is not a string, it should not crash.",
+			obj: corev1api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "svc-1",
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": `{"spec":{"ports":[{"nodePort":30001,"name":123}]}}`,
+					},
+				},
+				Spec: corev1api.ServiceSpec{
+					Type: corev1api.ServiceTypeNodePort,
+					Ports: []corev1api.ServicePort{
+						{
+							Name:     "http",
+							NodePort: 30001,
+						},
+					},
+				},
+			},
+			restore: builder.ForRestore(api.DefaultNamespace, "").PreserveNodePorts(false).Result(),
+			expectedRes: corev1api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "svc-1",
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": `{"spec":{"ports":[{"nodePort":30001,"name":123}]}}`,
+					},
+				},
+				Spec: corev1api.ServiceSpec{
+					Type: corev1api.ServiceTypeNodePort,
+					Ports: []corev1api.ServicePort{
+						{
+							Name:     "http",
+							NodePort: 0,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
`ServiceAction` runs on every Service during restore unless `--preserve-nodeports` is set. To work out which node ports were explicitly requested, `deleteNodePorts` reads the `kubectl.kubernetes.io/last-applied-configuration` annotation, unmarshals it, and walks `spec.ports`:

```go
portName, ok := p["name"]
if !ok {
    unnamedPortInts.Insert(nodePortInt)
} else {
    explicitNodePorts.Insert(portName.(string))
}
```

That annotation is free-form JSON carried in the backup, so its contents are whatever produced the backup. A port entry whose `name` is not a string, for instance `{"nodePort":30001,"name":123}`, panics:

```
panic: interface conversion: interface {} is float64, not string
```

Everything else in the same loop already guards: `port.(map[string]any)` uses comma-ok, the `nodePort` value goes through a type switch, and the presence of `name` is checked. This one cast is the odd one out, so this makes it comma-ok too and skips the entry when the name is not a string, which lines up with how an unusable value is treated elsewhere in the function.

Noticed while reading the area that #9653 recently hardened: that PR tightened the parsing of the same annotation for `healthCheckNodePort`, but did not touch this cast.

Test added to the existing `TestServiceActionExecute` table with a numeric port name. It panics on main and passes with the change; the other 20 subtests are unaffected.