### PR TITLE
fix: return errors correctly in block restore validation and BatchForget

### DIFF
--- a/changelogs/unreleased/10138-Jay2006sawant
+++ b/changelogs/unreleased/10138-Jay2006sawant
@@ -1,0 +1,1 @@
+Fix block uploader restore validation and BatchForget error handling

--- a/changelogs/unreleased/fix-error-handling-Jay2006sawant
+++ b/changelogs/unreleased/fix-error-handling-Jay2006sawant
@@ -1,0 +1,9 @@
+fix: return errors correctly in block restore validation and BatchForget
+
+Block uploader Restore used errors.Wrapf with a stale nil err after
+successful getSourceSize, causing size validation failures to return
+(0, nil). flushZeroBlocks had the same pattern on short writes.
+
+BatchForget dropped delete errors when flush also failed.
+
+Signed-off-by: Jay2006sawant <jay242902@gmail.com>

--- a/changelogs/unreleased/fix-error-handling-Jay2006sawant
+++ b/changelogs/unreleased/fix-error-handling-Jay2006sawant
@@ -1,9 +1,0 @@
-fix: return errors correctly in block restore validation and BatchForget
-
-Block uploader Restore used errors.Wrapf with a stale nil err after
-successful getSourceSize, causing size validation failures to return
-(0, nil). flushZeroBlocks had the same pattern on short writes.
-
-BatchForget dropped delete errors when flush also failed.
-
-Signed-off-by: Jay2006sawant <jay242902@gmail.com>

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -384,7 +384,7 @@ func (urp *unifiedRepoProvider) BatchForget(ctx context.Context, snapshotIDs []s
 
 	err = bkRepo.Flush(ctx)
 	if err != nil {
-		errs = append(errs, errors.Wrap(err, "error to flush repo"))
+		return append(errs, errors.Wrap(err, "error to flush repo"))
 	}
 
 	log.Debug("Forget snapshot complete")

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -384,7 +384,7 @@ func (urp *unifiedRepoProvider) BatchForget(ctx context.Context, snapshotIDs []s
 
 	err = bkRepo.Flush(ctx)
 	if err != nil {
-		return []error{errors.Wrap(err, "error to flush repo")}
+		errs = append(errs, errors.Wrap(err, "error to flush repo"))
 	}
 
 	log.Debug("Forget snapshot complete")

--- a/pkg/repository/provider/unified_repo_test.go
+++ b/pkg/repository/provider/unified_repo_test.go
@@ -1062,6 +1062,41 @@ func TestBatchForget(t *testing.T) {
 			},
 			expectedErr: []string{"error to flush repo: fake-error-4"},
 		},
+		{
+			name:            "delete and flush fail",
+			getter:          new(credmock.SecretStore),
+			credStoreReturn: "fake-password",
+			funcTable: localFuncTable{
+				getStorageVariables: func(*velerov1api.BackupStorageLocation, string, string, map[string]string, velerocredentials.CredentialGetter) (map[string]string, error) {
+					return map[string]string{}, nil
+				},
+				getStorageCredentials: func(*velerov1api.BackupStorageLocation, velerocredentials.FileStore) (map[string]string, error) {
+					return map[string]string{}, nil
+				},
+			},
+			repoService: new(reposervicenmocks.BackupRepoService),
+			backupRepo:  new(reposervicenmocks.BackupRepo),
+			retFuncOpen: []any{
+				func(context.Context, udmrepo.RepoOptions) udmrepo.BackupRepo {
+					return backupRepo
+				},
+
+				func(context.Context, udmrepo.RepoOptions) error {
+					return nil
+				},
+			},
+			retFuncDelete: func(context.Context, udmrepo.ID) error {
+				return errors.New("fake-delete-error")
+			},
+			retFuncFlush: func(context.Context) error {
+				return errors.New("fake-flush-error")
+			},
+			snapshots: []string{"snapshot-1"},
+			expectedErr: []string{
+				"error to delete manifest snapshot-1: fake-delete-error",
+				"error to flush repo: fake-flush-error",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/uploader/block/uploader.go
+++ b/pkg/uploader/block/uploader.go
@@ -169,11 +169,11 @@ func (blkup *blockUploader) Restore(snapshot udmrepo.Snapshot, dest destInfo, bi
 	}
 
 	if sourceSize > meta.SubObjects[0].Size {
-		return 0, errors.Wrapf(err, "unexpected size (%v vs. %v) for bdev object %s", meta.SubObjects[0].Size, sourceSize, meta.SubObjects[0].Name)
+		return 0, errors.Errorf("unexpected size (%v vs. %v) for bdev object %s", meta.SubObjects[0].Size, sourceSize, meta.SubObjects[0].Name)
 	}
 
 	if sourceSize > dest.size {
-		return 0, errors.Wrapf(err, "dest dev(%s) size is too small (%v vs. %v)", dest.path, dest.size, sourceSize)
+		return 0, errors.Errorf("dest dev(%s) size is too small (%v vs. %v)", dest.path, dest.size, sourceSize)
 	}
 
 	reader, err := blkup.repoWriter.OpenObject(blkup.ctx, meta.SubObjects[0].ID)
@@ -616,7 +616,7 @@ func flushZeroBlocks(dest *os.File, start int64, length int64, zeroBlock []byte,
 		}
 
 		if writeSize != n {
-			return errors.Wrapf(err, "short write zero buffer at %v, length %v", start+written, writeSize)
+			return errors.Errorf("short write zero buffer at %v, length %v", start+written, writeSize)
 		}
 
 		written += int64(writeSize)

--- a/pkg/uploader/block/uploader_test.go
+++ b/pkg/uploader/block/uploader_test.go
@@ -689,4 +689,52 @@ func TestBlockUploaderRestore(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(1048576), written)
 	})
+
+	t.Run("source size tag larger than object size", func(t *testing.T) {
+		ctx := context.Background()
+		repoWriter := udmrepomocks.NewBackupRepo(t)
+		blkup := NewUploader(ctx, repoWriter, nil, logrus.New())
+
+		meta := &udmrepo.Metadata{
+			SubObjects: []udmrepo.ObjectMetadata{
+				{ID: "data-id", Name: "bdev", Size: 1048576},
+			},
+		}
+		repoWriter.On("ReadMetadata", mock.Anything, udmrepo.ID("root-id")).Return(meta, nil)
+
+		snap := udmrepo.Snapshot{
+			RootObject: udmrepo.ObjectMetadata{ID: "root-id"},
+			Tags:       map[string]string{bdevSourceSizeTag: "2097152"},
+		}
+		dest := destInfo{size: 4194304, path: "/dev/target"}
+		iterMock := cbtmocks.NewIterator(t)
+
+		_, err := blkup.Restore(snap, dest, iterMock, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected size (1048576 vs. 2097152) for bdev object bdev")
+	})
+
+	t.Run("destination smaller than source size", func(t *testing.T) {
+		ctx := context.Background()
+		repoWriter := udmrepomocks.NewBackupRepo(t)
+		blkup := NewUploader(ctx, repoWriter, nil, logrus.New())
+
+		meta := &udmrepo.Metadata{
+			SubObjects: []udmrepo.ObjectMetadata{
+				{ID: "data-id", Name: "bdev", Size: 1048576},
+			},
+		}
+		repoWriter.On("ReadMetadata", mock.Anything, udmrepo.ID("root-id")).Return(meta, nil)
+
+		snap := udmrepo.Snapshot{
+			RootObject: udmrepo.ObjectMetadata{ID: "root-id"},
+			Tags:       map[string]string{bdevSourceSizeTag: "1048576"},
+		}
+		dest := destInfo{size: 512, path: "/dev/small"}
+		iterMock := cbtmocks.NewIterator(t)
+
+		_, err := blkup.Restore(snap, dest, iterMock, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "dest dev(/dev/small) size is too small")
+	})
 }


### PR DESCRIPTION

Thank you for contributing to Velero!

## Please add a summary of your change

This PR fixes three related error-handling bugs where failures were silently ignored instead of being returned to callers.

**1. Block uploader `Restore()` size validation returns `(0, nil)`**

In `pkg/uploader/block/uploader.go`, when `getSourceSize()` succeeds, `err` is `nil`. The size checks for oversized source tags and too-small destination devices use `errors.Wrapf(err, ...)`. In Go, wrapping a nil error returns `nil`, so validation failures appear as a successful restore with 0 bytes written.

**2. `flushZeroBlocks()` short-write fallback returns nil**

On the conservative zero-fill fallback path, when `WriteAt` returns fewer bytes than requested with `err == nil`, the code used `errors.Wrapf(err, ...)`, which again returns `nil` instead of reporting the short write.

**3. `BatchForget()` drops delete errors when flush fails**

In `pkg/repository/provider/unified_repo.go`, delete failures are collected in an `errs` slice. If `Flush()` also fails, the function returned only the flush error and discarded any delete errors already collected.

**What this PR changes**

- Use `errors.Errorf(...)` for block uploader restore size validation messages
- Use `errors.Errorf(...)` for `flushZeroBlocks` short-write detection
- Append flush errors to `errs` in `BatchForget` instead of replacing the slice

**Tests added**

- `TestBlockUploaderRestore/source_size_tag_larger_than_object_size`
- `TestBlockUploaderRestore/destination_smaller_than_source_size`
- `TestBatchForget/delete_and_flush_fail`

These tests fail on `main` without the fix and pass with it.

```
go test ./pkg/uploader/block/... -count=1
go test ./pkg/repository/provider/... -count=1
golangci-lint run ./pkg/uploader/block/... ./pkg/repository/provider/...
```

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

### Fixes #10139 