### PR TITLE
Guard nil VolumeSnapshotContent.Status when building volume info

### DIFF
--- a/changelogs/unreleased/10148-somanchi004-code
+++ b/changelogs/unreleased/10148-somanchi004-code
@@ -1,0 +1,1 @@
+Guard nil VolumeSnapshotContent.Status in generateVolumeInfoForCSIVolumeSnapshot to avoid a panic during backup finalization when the snapshot controller has not yet written the content status

--- a/internal/volume/volumes_information.go
+++ b/internal/volume/volumes_information.go
@@ -457,7 +457,7 @@ func (v *BackupVolumesInformation) generateVolumeInfoForCSIVolumeSnapshot() {
 			size = volumeSnapshot.Status.RestoreSize.Value()
 		}
 		snapshotHandle := ""
-		if volumeSnapshotContent.Status.SnapshotHandle != nil {
+		if volumeSnapshotContent.Status != nil && volumeSnapshotContent.Status.SnapshotHandle != nil {
 			snapshotHandle = *volumeSnapshotContent.Status.SnapshotHandle
 		}
 		volumeGroupSnapshotHandle := ""

--- a/internal/volume/volumes_information_test.go
+++ b/internal/volume/volumes_information_test.go
@@ -1262,3 +1262,49 @@ func TestGetVolumeSnapshotClasses(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []snapshotv1api.VolumeSnapshotClass{*class}, result)
 }
+
+func TestGenerateVolumeInfoForCSIVolumeSnapshotNilVSCStatus(t *testing.T) {
+	// VolumeSnapshotContent.Status is optional and is not written until the
+	// snapshot controller reconciles the content. Velero labels and collects
+	// the VSC before that happens, so generateVolumeInfoForCSIVolumeSnapshot
+	// must tolerate a nil Status.
+	now := metav1.Now()
+	restoreSize := resource.MustParse("100Gi")
+	vscName := "testContent"
+	pvcName := "testPVC"
+	className := "testClass"
+
+	volumesInfo := BackupVolumesInformation{}
+	volumesInfo.Init()
+	volumesInfo.logger = logging.DefaultLogger(logrus.DebugLevel, logging.FormatJSON)
+
+	volumesInfo.volumeSnapshots = []snapshotv1api.VolumeSnapshot{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "testVS", Namespace: "velero"},
+			Spec: snapshotv1api.VolumeSnapshotSpec{
+				Source:                  snapshotv1api.VolumeSnapshotSource{PersistentVolumeClaimName: &pvcName},
+				VolumeSnapshotClassName: &className,
+			},
+			Status: &snapshotv1api.VolumeSnapshotStatus{
+				BoundVolumeSnapshotContentName: &vscName,
+				CreationTime:                   &now,
+				RestoreSize:                    &restoreSize,
+			},
+		},
+	}
+	volumesInfo.volumeSnapshotContents = []snapshotv1api.VolumeSnapshotContent{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: vscName},
+			Spec:       snapshotv1api.VolumeSnapshotContentSpec{Driver: "pd.csi.storage.gke.io"},
+			// Status intentionally nil.
+		},
+	}
+	volumesInfo.volumeSnapshotClasses = []snapshotv1api.VolumeSnapshotClass{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: className},
+			Driver:     "pd.csi.storage.gke.io",
+		},
+	}
+
+	require.NotPanics(t, volumesInfo.generateVolumeInfoForCSIVolumeSnapshot)
+}


### PR DESCRIPTION
## Thank you for contributing to Velero!

**Please add a summary of your change**

`generateVolumeInfoForCSIVolumeSnapshot` dereferences `volumeSnapshotContent.Status` without a nil check when reading `SnapshotHandle`:

```go
snapshotHandle := ""
if volumeSnapshotContent.Status.SnapshotHandle != nil {            // no nil check on .Status
    snapshotHandle = *volumeSnapshotContent.Status.SnapshotHandle
}
volumeGroupSnapshotHandle := ""
if volumeSnapshotContent.Status != nil && volumeSnapshotContent.Status.VolumeGroupSnapshotHandle != nil {
    volumeGroupSnapshotHandle = *volumeSnapshotContent.Status.VolumeGroupSnapshotHandle
}
```

`Status` is `// +optional` on `VolumeSnapshotContent` and is not written until the snapshot controller reconciles the content. The guard four lines below — added with VolumeGroupSnapshot support in #9516 — checks it; the line above was not backfilled. `pkg/backup/actions/csi/volumesnapshot_action.go` also wraps the same field on the same type in `if vsc.Status != nil`.

The path is reachable: `volumesnapshot_action.go` labels the VSC while explicitly not awaiting reconciliation ("we will not await VolumeSnapshot reconciliation"), and `GetBackupCSIResources` collects VSCs by label selector with no status filtering. So a content with no status reaches this function.

**Does your change fix a particular issue?**

No existing issue — I found this while reading the CSI backup path.

**Please indicate you've done the following:**

- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Created a [changelog file](https://velero.io/docs/main/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [x] Updated the corresponding documentation in `site/content/docs/main`. *(not applicable — no user-facing docs change)*

---

**Reproduction**

A unit test with a bound VolumeSnapshot and a VolumeSnapshotContent whose `Status` is nil panics on the current code:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0]
  ...internal/volume.(*BackupVolumesInformation).generateVolumeInfoForCSIVolumeSnapshot
      internal/volume/volumes_information.go:460
```

The call site is `persistBackup` in the backup controller, so the panic surfaces as a recovered panic and a failed reconcile — the backup's volume info, tarball and result are never uploaded and the backup does not finalize.

All six existing `TestGenerateVolumeInfoForCSIVolumeSnapshot` subtests supply a non-nil `Status`, which is why this path was untested. The new test covers a content with no status; it panics without the change and passes with it.

**What I verified and what I did not**

Verified: the nil dereference, the panic and its stack, that the fix resolves it, that the existing tests still pass, and the collection path that allows a statusless VSC to reach this function.

Not verified: I have not observed a real CSI driver leaving a statusless VolumeSnapshotContent at the exact moment `persistBackup` runs. That the code can panic on a nil `Status` stands on its own, but I want to be clear I have not reproduced it end to end on a live cluster.

*Disclosure: an AI assistant helped me trace the call path and draft the test. The panic output above is from a test I ran against this tree, and I checked the referenced code paths myself.*
