### PR TITLE
Fix switch case ordering bug in `filterBackupOwnerReferences`

### DIFF
--- a/changelogs/unreleased/10161-AftAb-25
+++ b/changelogs/unreleased/10161-AftAb-25
@@ -1,0 +1,1 @@
+Fixed a bug in the backup sync controller where transient API errors could cause backups to incorrectly lose their schedule owner references.

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -271,11 +271,11 @@ func (b *backupSyncReconciler) filterBackupOwnerReferences(ctx context.Context, 
 			case err != nil && apierrors.IsNotFound(err):
 				log.Warnf("Removing missing schedule ownership reference %s/%s from backup", backup.Namespace, v.Name)
 				continue
+			case err != nil && !apierrors.IsNotFound(err):
+				log.WithError(errors.WithStack(err)).Error("Error finding schedule ownership reference, keeping schedule on backup")
 			case schedule.UID != v.UID:
 				log.Warnf("Removing schedule ownership reference with mismatched UIDs. Expected %s, got %s", v.UID, schedule.UID)
 				continue
-			case err != nil && !apierrors.IsNotFound(err):
-				log.WithError(errors.WithStack(err)).Error("Error finding schedule ownership reference, keeping schedule on backup")
 			}
 		default:
 			log.Warnf("Unable to check ownership reference for unknown kind, %s", v.Kind)

--- a/pkg/controller/backup_sync_controller_test.go
+++ b/pkg/controller/backup_sync_controller_test.go
@@ -36,6 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/builder"
@@ -913,5 +914,48 @@ var _ = Describe("Backup Sync Reconciler", func() {
 				Expect(references).To(BeEquivalentTo(test.expectedReferences))
 			})
 		}
+	})
+
+	It("filterBackupOwnerReferences preserves owner reference on transient API error", func() {
+		// This test verifies the fix for the switch case ordering bug:
+		// When client.Get returns a non-NotFound error (e.g. transient API failure),
+		// the owner reference must be kept on the backup rather than silently dropped
+		// due to an incorrect UID comparison against a zero-value struct.
+		scheduleUID := types.UID("schedule-uid-1")
+		backup := &velerov1api.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-backup",
+				Namespace: "test-namespace",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: "Schedule",
+						Name: "my-schedule",
+						UID:  scheduleUID,
+					},
+				},
+			},
+		}
+
+		// Build a fake client that returns a generic (non-NotFound) error on Get,
+		// simulating a transient API server failure.
+		transientErr := fmt.Errorf("transient connection error")
+		fakeClient := ctrlfake.NewClientBuilder().
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, c ctrlClient.WithWatch, key ctrlClient.ObjectKey, obj ctrlClient.Object, opts ...ctrlClient.GetOption) error {
+					return transientErr
+				},
+			}).
+			Build()
+
+		b := backupSyncReconciler{
+			client: fakeClient,
+		}
+
+		logger := velerotest.NewLogger()
+		references := b.filterBackupOwnerReferences(context.Background(), backup, logger)
+
+		// The owner reference must be preserved when a transient error occurs.
+		Expect(references).To(HaveLen(1))
+		Expect(references[0].UID).To(Equal(scheduleUID))
 	})
 })


### PR DESCRIPTION


## PR Description
**What this PR does / why we need it**:
This PR fixes a subtle logic bug in `backup_sync_controller.go` where a transient API error during a schedule lookup would incorrectly trigger a "UID mismatch" warning and drop the schedule owner reference from the backup. 

Because Go evaluates `switch` cases in order, a non-NotFound error (like a timeout) would leave the `schedule` struct empty. The code would then hit the `schedule.UID != v.UID` case *before* the general error handler, evaluating `"" != "actual-uid"` (which is true) and silently dropping the owner reference instead of correctly logging the error and keeping it.

I've reordered the switch cases so the general error handler is evaluated before the UID mismatch check, ensuring the UID comparison only happens when the `Schedule` object is successfully fetched (`err == nil`).

**Which issue(s) this PR fixes**:
Fixes #10160 

**Special notes for reviewer**:
* Moved the `err != nil && !apierrors.IsNotFound(err)` case up.
* Added a new test `filterBackupOwnerReferences preserves owner reference on transient API error` in `backup_sync_controller_test.go`. The test uses a fake client interceptor to simulate a generic `client.Get` error and verifies the owner reference is correctly preserved.

**Does this PR introduce a user-facing change?**:
Fixed a bug in the backup sync controller where transient API errors could cause backups to incorrectly lose their schedule owner references.
