### PR TITLE
fix: use request-scoped ctx in backup storage location reconciler

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -613,7 +613,6 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 
 	// Enable BSL controller. No need to check whether it's enabled or not.
 	bslr := controller.NewBackupStorageLocationReconciler(
-		s.ctx,
 		s.mgr.GetClient(),
 		storage.DefaultBackupLocationInfo{
 			StorageLocation:           s.config.DefaultBackupLocation,

--- a/pkg/controller/backup_storage_location_controller.go
+++ b/pkg/controller/backup_storage_location_controller.go
@@ -147,7 +147,6 @@ func sanitizeStorageError(err error) string {
 
 // BackupStorageLocationReconciler reconciles a BackupStorageLocation object
 type backupStorageLocationReconciler struct {
-	ctx                       context.Context
 	client                    client.Client
 	defaultBackupLocationInfo storage.DefaultBackupLocationInfo
 	// use variables to refer to these functions so they can be
@@ -160,7 +159,6 @@ type backupStorageLocationReconciler struct {
 
 // NewBackupStorageLocationReconciler initialize and return a backupStorageLocationReconciler struct
 func NewBackupStorageLocationReconciler(
-	ctx context.Context,
 	client client.Client,
 	defaultBackupLocationInfo storage.DefaultBackupLocationInfo,
 	newPluginManager func(logrus.FieldLogger) clientmgmt.Manager,
@@ -168,7 +166,6 @@ func NewBackupStorageLocationReconciler(
 	metrics *metrics.ServerMetrics,
 	log logrus.FieldLogger) *backupStorageLocationReconciler {
 	return &backupStorageLocationReconciler{
-		ctx:                       ctx,
 		client:                    client,
 		defaultBackupLocationInfo: defaultBackupLocationInfo,
 		newPluginManager:          newPluginManager,
@@ -188,7 +185,7 @@ func (r *backupStorageLocationReconciler) Reconcile(ctx context.Context, req ctr
 	log := r.log.WithField("controller", constant.ControllerBackupStorageLocation).WithField(constant.ControllerBackupStorageLocation, req.NamespacedName.String())
 	log.Debug("Validating availability of BackupStorageLocation")
 
-	locationList, err := storage.ListBackupStorageLocations(r.ctx, r.client, req.Namespace)
+	locationList, err := storage.ListBackupStorageLocations(ctx, r.client, req.Namespace)
 	if err != nil {
 		log.WithError(err).Error("No BackupStorageLocations found, at least one is required")
 		return ctrl.Result{}, nil
@@ -210,7 +207,7 @@ func (r *backupStorageLocationReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// decide the default BSL
-	defaultFound, err := r.ensureSingleDefaultBSL(locationList)
+	defaultFound, err := r.ensureSingleDefaultBSL(ctx, locationList)
 	if err != nil {
 		log.WithError(err).Error("failed to ensure single default bsl")
 		return ctrl.Result{}, nil
@@ -232,7 +229,7 @@ func (r *backupStorageLocationReconciler) Reconcile(ctx context.Context, req ctr
 				location.Status.Phase = velerov1api.BackupStorageLocationPhaseAvailable
 				location.Status.Message = ""
 			}
-			if err := r.client.Patch(r.ctx, &location, client.MergeFrom(original)); err != nil {
+			if err := r.client.Patch(ctx, &location, client.MergeFrom(original)); err != nil {
 				log.WithError(err).Error("Error updating BackupStorageLocation phase")
 			}
 		}()
@@ -328,7 +325,7 @@ func (r *backupStorageLocationReconciler) SetupWithManager(mgr ctrl.Manager) err
 // the default BSL priority is as follows:
 // 1. follow the user's setting (the most recent validation BSL is the default BSL)
 // 2. follow the server's setting ("velero server --default-backup-storage-location")
-func (r *backupStorageLocationReconciler) ensureSingleDefaultBSL(locationList velerov1api.BackupStorageLocationList) (bool, error) {
+func (r *backupStorageLocationReconciler) ensureSingleDefaultBSL(ctx context.Context, locationList velerov1api.BackupStorageLocationList) (bool, error) {
 	// get all default BSLs
 	var defaultBSLs []*velerov1api.BackupStorageLocation
 	var defaultFound bool
@@ -360,7 +357,7 @@ func (r *backupStorageLocationReconciler) ensureSingleDefaultBSL(locationList ve
 		for _, bsl := range defaultBSLs {
 			if bsl.Name != mostRecentCreatedBSL.Name {
 				bsl.Spec.Default = false
-				if err := r.client.Update(r.ctx, bsl); err != nil {
+				if err := r.client.Update(ctx, bsl); err != nil {
 					return defaultFound, errors.Wrapf(err, "failed to unset default backup storage location %q", bsl.Name)
 				}
 				r.log.Debugf("update default backup storage location %q to false", bsl.Name)

--- a/pkg/controller/backup_storage_location_controller_test.go
+++ b/pkg/controller/backup_storage_location_controller_test.go
@@ -85,7 +85,6 @@ var _ = Describe("Backup Storage Location Reconciler", func() {
 		// Setup reconciler
 		Expect(velerov1api.AddToScheme(scheme.Scheme)).To(Succeed())
 		r := backupStorageLocationReconciler{
-			ctx:    ctx,
 			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(locations).Build(),
 			defaultBackupLocationInfo: storage.DefaultBackupLocationInfo{
 				StorageLocation:           "location-1",
@@ -151,7 +150,6 @@ var _ = Describe("Backup Storage Location Reconciler", func() {
 		// Setup reconciler
 		Expect(velerov1api.AddToScheme(scheme.Scheme)).To(Succeed())
 		r := backupStorageLocationReconciler{
-			ctx:    ctx,
 			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(locations).Build(),
 			defaultBackupLocationInfo: storage.DefaultBackupLocationInfo{
 				StorageLocation:           "default",
@@ -245,13 +243,12 @@ func TestEnsureSingleDefaultBSL(t *testing.T) {
 		require.NoError(t, velerov1api.AddToScheme(scheme.Scheme))
 		t.Run(test.name, func(t *testing.T) {
 			r := &backupStorageLocationReconciler{
-				ctx:                       t.Context(),
 				client:                    fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(&test.locations).Build(),
 				defaultBackupLocationInfo: test.defaultBackupInfo,
 				metrics:                   metrics.NewServerMetrics(),
 				log:                       velerotest.NewLogger(),
 			}
-			defaultFound, err := r.ensureSingleDefaultBSL(test.locations)
+			defaultFound, err := r.ensureSingleDefaultBSL(t.Context(), test.locations)
 
 			assert.Equal(t, test.expectedDefaultSet, defaultFound)
 			assert.Equal(t, test.expectedError, err)
@@ -290,7 +287,6 @@ func TestBSLReconcile(t *testing.T) {
 		require.NoError(t, velerov1api.AddToScheme(scheme.Scheme))
 		t.Run(test.name, func(t *testing.T) {
 			r := &backupStorageLocationReconciler{
-				ctx:              t.Context(),
 				client:           fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(&test.locationList).Build(),
 				newPluginManager: func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager },
 				metrics:          metrics.NewServerMetrics(),


### PR DESCRIPTION
## Please add a summary of your change

`backupStorageLocationReconciler` stored a `ctx context.Context` field on the struct that was initialized once when the server started. Because of this, several API calls inside `Reconcile` were using `r.ctx` instead of the request-scoped `ctx` passed into the reconciliation function:

- `storage.ListBackupStorageLocations(r.ctx, ...)`
- `r.client.Patch(r.ctx, ...)`
- `r.client.Update(r.ctx, ...)` inside `ensureSingleDefaultBSL`

This prevented these operations from respecting request-level timeouts or cancellations (such as during manager shutdown or leader transitions).

This PR:
- Removes the `ctx` field from `backupStorageLocationReconciler` and its constructor `NewBackupStorageLocationReconciler`.
- Updates all calls within `Reconcile` to use the request-scoped `ctx`.
- Passes `ctx` into `ensureSingleDefaultBSL`.
- Updates the call site in `pkg/cmd/server/server.go` and unit tests in `backup_storage_location_controller_test.go`.

## Does your change fix a particular issue?

Fixes #10171

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
