### PR TITLE
add curl --fail flag to kubectl download in e2e kind workflow

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -169,7 +169,7 @@ jobs:
           EOF
 
           # Match kubectl version to k8s server version
-          curl -LO https://dl.k8s.io/release/v${{ matrix.k8s }}/bin/linux/amd64/kubectl
+          curl -fLO https://dl.k8s.io/release/v${{ matrix.k8s }}/bin/linux/amd64/kubectl
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
           git init -q /tmp/kibishii

--- a/changelogs/unreleased/10174-samay43
+++ b/changelogs/unreleased/10174-samay43
@@ -1,0 +1,1 @@
+Add curl --fail flag to kubectl download in e2e kind workflow


### PR DESCRIPTION
Fixes #10172 

Adds the `-f` (`--fail`) flag to the `curl -LO` command that downloads kubectl in the Kind E2E workflow. Without it, curl treats HTTP error responses (e.g. an invalid k8s version, or a temporary dl.k8s.io outage) as a "successful" download, silently saving the error page as if it were the kubectl binary.

Verified locally: without `-f`, a bad URL saved a 251-byte XML error response as "kubectl" with exit code 0. With `-f`, the same request now fails immediately with exit code 22 and no file is created.

# Please indicate you've done the following:
- [x] Accepted the DCO
- [x] Created a changelog file (`make new-changelog`) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.