### PR TITLE
fix: periodically enqueue DataUpload tasks in Prepared phase

### DIFF
--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -640,28 +640,38 @@ func (r *DataUploadReconciler) OnDataUploadProgress(ctx context.Context, namespa
 	}
 }
 
+func duGenericEventPredicate(object client.Object) bool {
+	du, ok := object.(*velerov2alpha1api.DataUpload)
+	if !ok {
+		return false
+	}
+
+	if du.Status.Phase == velerov2alpha1api.DataUploadPhaseAccepted {
+		return true
+	}
+
+	if du.Status.Phase == velerov2alpha1api.DataUploadPhasePrepared {
+		return true
+	}
+
+	if du.Spec.Cancel && !isDataUploadInFinalState(du) {
+		return true
+	}
+
+	if isDataUploadInFinalState(du) && !du.DeletionTimestamp.IsZero() {
+		return true
+	}
+
+	return false
+}
+
 // SetupWithManager registers the DataUpload controller.
 // The fresh new DataUpload CR first created will trigger to create one pod (long time, maybe failure or unknown status) by one of the dataupload controllers
 // then the request will get out of the Reconcile queue immediately by not blocking others' CR handling, in order to finish the rest data upload process we need to
 // re-enqueue the previous related request once the related pod is in running status to keep going on the rest logic. and below logic will avoid handling the unwanted
 // pod status and also avoid block others CR handling
 func (r *DataUploadReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	gp := kube.NewGenericEventPredicate(func(object client.Object) bool {
-		du := object.(*velerov2alpha1api.DataUpload)
-		if du.Status.Phase == velerov2alpha1api.DataUploadPhaseAccepted {
-			return true
-		}
-
-		if du.Spec.Cancel && !isDataUploadInFinalState(du) {
-			return true
-		}
-
-		if isDataUploadInFinalState(du) && !du.DeletionTimestamp.IsZero() {
-			return true
-		}
-
-		return false
-	})
+	gp := kube.NewGenericEventPredicate(duGenericEventPredicate)
 	s := kube.NewPeriodicalEnqueueSource(r.logger.WithField("controller", constant.ControllerDataUpload), r.client, &velerov2alpha1api.DataUploadList{}, preparingMonitorFrequency, kube.PeriodicalEnqueueSourceOption{
 		Predicates: []predicate.Predicate{gp},
 	})

--- a/pkg/controller/data_upload_controller_test.go
+++ b/pkg/controller/data_upload_controller_test.go
@@ -1561,3 +1561,84 @@ func TestDataUploadSetupExposeParam(t *testing.T) {
 		})
 	}
 }
+
+func TestDUGenericEventPredicate(t *testing.T) {
+	tests := []struct {
+		name     string
+		object   kbclient.Object
+		expected bool
+	}{
+		{
+			name:     "invalid object type",
+			object:   &corev1api.Pod{},
+			expected: false,
+		},
+		{
+			name: "accepted phase",
+			object: &velerov2alpha1api.DataUpload{
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhaseAccepted,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "prepared phase",
+			object: &velerov2alpha1api.DataUpload{
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhasePrepared,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "in progress phase not canceled",
+			object: &velerov2alpha1api.DataUpload{
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhaseInProgress,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "canceled and not in final state",
+			object: &velerov2alpha1api.DataUpload{
+				Spec: velerov2alpha1api.DataUploadSpec{
+					Cancel: true,
+				},
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhaseInProgress,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "completed with deletion timestamp",
+			object: &velerov2alpha1api.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhaseCompleted,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "completed without deletion timestamp",
+			object: &velerov2alpha1api.DataUpload{
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhaseCompleted,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := duGenericEventPredicate(tt.object)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Please add a summary of your change

While reviewing the `DataUploadReconciler`, I noticed that `DataUpload` tasks can occasionally get permanently stuck in the `Prepared` phase. 

The root cause is that the `GenericEventPredicate` used for the `PeriodicalEnqueueSource` in `SetupWithManager` explicitly checks for `DataUploadPhaseAccepted`, but it omits `DataUploadPhasePrepared`. Because of this omission, if a task enters the `Prepared` phase and a subsequent watch event is dropped or delayed, the controller never periodically re-queues it, leaving it stuck indefinitely without any timeout enforcement.

This PR simply adds `DataUploadPhasePrepared` to the predicate so that prepared tasks are also periodically checked by the controller, allowing them to recover from missed events or correctly time out.

# Does your change fix a particular issue?

Fixes #10178

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
