### PR TITLE
Site: add conference talks to resources and LinkedIn to community page

### DIFF
--- a/site/content/community/_index.md
+++ b/site/content/community/_index.md
@@ -12,6 +12,7 @@ If you are ready to jump in and test, add code, or help with documentation, foll
 You can follow the work we do via our [GitHub milestones](https://github.com/velero-io/velero/milestones) and the project [Roadmap](https://github.com/velero-io/velero/wiki/Roadmap).
 
 * Follow us on Twitter at [@projectvelero](https://twitter.com/projectvelero)
+* Follow us on LinkedIn at [Project Velero](https://www.linkedin.com/company/project-velero)
 * Join our Kubernetes Slack channel and talk to over 800 other community members: [#velero-users](https://kubernetes.slack.com/messages/velero-users)
 * Join the Velero community meetings 
 Bi-weekly  community meeting alternating every week between Beijing Friendly timezone and EST/Europe Friendly Timezone  

--- a/site/content/resources/_index.md
+++ b/site/content/resources/_index.md
@@ -21,6 +21,12 @@ Here you will find external resources about Velero, including conference talks, 
 
     {{< youtube oPQW99NiV_0 >}}
 
+### Open Source Summit
+
+* **Open Source Summit NA 2022 (Austin)** - [Velero - The Cloud Native Backup for Kubernetes](https://ossna2022.sched.com/event/11Nu9) - Orlin Vasilev, VMware & Scott Seago, Red Hat
+
+    {{< youtube DKMW69OSI7c >}}
+
 ### DevConf
 
 * **DevConf.IN 2025** - From Chaos to Control: Mastering Kubernetes Backups and Restore with Velero - Aziza Karol & Prasad Joshi

--- a/site/content/resources/_index.md
+++ b/site/content/resources/_index.md
@@ -3,7 +3,29 @@ title: Resources
 description: Velero Resources
 id: resources
 ---
-Here you will find external resources about Velero, such as videos, podcasts, and community articles.
+Here you will find external resources about Velero, including conference talks, videos, podcasts, and community articles.
+
+## Conference Talks
+
+### KubeCon + CloudNativeCon
+
+* **KubeCon EU 2026 (Amsterdam)** - [Snapshots Gone Wild: Taming Multi-PVC Chaos with VolumeGroupSnapshot](https://kccnceu2026.sched.com/event/2CW53/snapshots-gone-wild-taming-multi-pvc-chaos-with-volumegroupsnapshot-shubham-pampattiwar-scott-seago-red-hat) - Shubham Pampattiwar & Scott Seago, Red Hat
+
+    {{< youtube pLmRkRO6O6E >}}
+
+* **KubeCon India 2026 (Mumbai)** - [Sponsored Demo: Cloud Native AI: Model Management with Harbor & Velero](https://kccncind2026.sched.com/event/2OdTx/sponsored-demo-cloud-native-ai-model-management-with-harbor-velero-dhruv-tyagi-broadcom) - Dhruv Tyagi, Broadcom
+
+* **KubeCon China 2024 (Hong Kong)** - [The Challenges of Kubernetes Data Protection - Real Examples and Solutions with Velero](https://kccncossaidevchn2024.sched.com/event/1eYb8/the-challenges-of-kubernetes-data-protection-real-examples-and-solutions-with-velero-kuberneteszha-velerozha-kang-reji-wenkai-yin-broadcom-bruce-zou-shanghai-jibu-tech) - Wenkai Yin, Broadcom & Bruce Zou, Shanghai Jibu Tech
+
+* **KubeCon EU 2023 (Amsterdam)** - [Disaster Recovery: Bringing Back Production from Scratch in Under 1 Hour Using KOps, ArgoCD and Velero](https://kccnceu2023.sched.com/event/1Hye8/disaster-recovery-bringing-back-production-from-scratch-in-under-1-hour-using-kops-argocd-and-velero-andre-jay-marcelo-tanner-ada-support) - Andre Jay Marcelo-Tanner, Ada Support
+
+    {{< youtube oPQW99NiV_0 >}}
+
+### DevConf
+
+* **DevConf.IN 2025** - From Chaos to Control: Mastering Kubernetes Backups and Restore with Velero - Aziza Karol & Prasad Joshi
+
+    {{< youtube Bo4lSle0J7k >}}
 
 ## All community meetings
 


### PR DESCRIPTION
# Summary

Two updates to the velero.io site:

1. **Resources page**: Add a new "Conference Talks" section with Velero-related talks from recent conferences, including YouTube embeds and sched.com links:
   - KubeCon EU 2026 -- Snapshots Gone Wild: VolumeGroupSnapshot (Pampattiwar & Seago)
   - KubeCon India 2026 -- Cloud Native AI: Harbor & Velero (Tyagi)
   - KubeCon China 2024 -- Challenges of Kubernetes Data Protection (Yin & Zou)
   - KubeCon EU 2023 -- Disaster Recovery in Under 1 Hour (Marcelo-Tanner)
   - DevConf.IN 2025 -- Mastering Kubernetes Backups with Velero (Karol & Joshi)

2. **Community page**: Add LinkedIn page link alongside existing Twitter and Slack links.

# Does your change fix a particular issue?

Part of the Velero web presence improvement effort. Related to #10080.

/kind changelog-not-required

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.