### PR TITLE
docs: fix grammar and typos in customize-installation

### DIFF
--- a/site/content/docs/main/customize-installation.md
+++ b/site/content/docs/main/customize-installation.md
@@ -40,7 +40,7 @@ When installing with the `--use-node-agent` flag, the node-agent will mount the 
 
 By default, `velero install` does not enable the use of File System Backup (FSB) to take backups of all pod volumes. You must apply an [annotation](file-system-backup.md/#using-opt-in-pod-volume-backup) to every pod which contains volumes for Velero to use FSB for the backup.
 
-If you are planning to only use FSB for volume backups, you can run the `velero install` command with the `--default-volumes-to-fs-backup` flag. This will default all pod volumes backups to use FSB without having to apply annotations to pods. Note that when this flag is set during install, Velero will always try to use FSB to perform the backup, even want an individual backup to use volume snapshots, by setting the `--snapshot-volumes` flag in the `backup create` command. Alternatively, you can set the  `--default-volumes-to-fs-backup` on an individual backup to to make sure Velero uses FSB for each volume being backed up.
+If you are planning to only use FSB for volume backups, you can run the `velero install` command with the `--default-volumes-to-fs-backup` flag. This will default all pod volume backups to use FSB without having to apply annotations to pods. Note that when this flag is set during install, Velero will always try to use FSB to perform the backup. If you want an individual backup to use volume snapshots instead, set the `--snapshot-volumes` flag in the `backup create` command. Alternatively, you can set the `--default-volumes-to-fs-backup` flag on an individual backup to make sure Velero uses FSB for each volume being backed up.
 
 ## Update an existing installation
 
@@ -219,7 +219,7 @@ kubectl patch daemonset node-agent -n velero --patch \
 '{"spec":{"template":{"spec":{"containers":[{"name": "node-agent", "resources": {"limits":{"cpu": "1", "memory": "1024Mi"}, "requests": {"cpu": "1", "memory": "512Mi"}}}]}}}}'
 ```
 
-Additionally, you may want to update the the default File System Backup operation timeout (default 240 minutes) to allow larger backups more time to complete. You can adjust this timeout by adding the `- --fs-backup-timeout` argument to the Velero Deployment spec.
+Additionally, you may want to update the default File System Backup operation timeout (default 240 minutes) to allow larger backups more time to complete. You can adjust this timeout by adding the `- --fs-backup-timeout` argument to the Velero Deployment spec.
 
 **NOTE:** Changes made to this timeout value will revert back to the default value if you re-run the Velero install command.
 


### PR DESCRIPTION
## Summary
- Fix broken grammar in the Default Pod Volume backup to FSB section (`even want` → clear override instructions; remove duplicated `to to`; fix `pod volumes backups`)
- Remove duplicated word (`the the`) in the File System Backup timeout guidance

## Test plan
- [x] Confirmed the incorrect phrases exist on current `upstream/main` in `site/content/docs/main/customize-installation.md`
- [x] Re-read the corrected paragraphs for clarity against `--default-volumes-to-fs-backup` / `--snapshot-volumes` CLI flags
- [x] Verified the bad patterns no longer appear in `docs/main`