### PR TITLE
fix: correct typos in log messages and status strings

### DIFF
--- a/pkg/controller/data_download_controller.go
+++ b/pkg/controller/data_download_controller.go
@@ -693,11 +693,11 @@ func (r *DataDownloadReconciler) findSnapshotRestoreForPod(ctx context.Context, 
 				r.prepareDataDownload(dd)
 				return true
 			}); err != nil {
-			log.WithError(err).Warn("failed to update dataudownload, prepare will halt for this dataudownload")
+			log.WithError(err).Warn("failed to update datadownload, prepare will halt for this datadownload")
 			return []reconcile.Request{}
 		}
 	} else if unrecoverable, reason := kube.IsPodUnrecoverable(pod, log); unrecoverable {
-		err := UpdateDataDownloadWithRetry(context.Background(), r.client, types.NamespacedName{Namespace: dd.Namespace, Name: dd.Name}, r.logger.WithField("datadownlad", dd.Name),
+		err := UpdateDataDownloadWithRetry(context.Background(), r.client, types.NamespacedName{Namespace: dd.Namespace, Name: dd.Name}, r.logger.WithField("datadownload", dd.Name),
 			func(dataDownload *velerov2alpha1api.DataDownload) bool {
 				if dataDownload.Spec.Cancel {
 					return false

--- a/pkg/repository/maintenance/maintenance.go
+++ b/pkg/repository/maintenance/maintenance.go
@@ -351,7 +351,7 @@ func WaitJobComplete(cli client.Client, ctx context.Context, jobName, ns string,
 	if maintenanceJob.Status.Failed > 0 {
 		if r, err := getResultFromJob(cli, maintenanceJob); err != nil {
 			log.WithError(err).Warn("Failed to get maintenance job result")
-			result = "Repo maintenance failed but result is not retrieveable"
+			result = "Repo maintenance failed but result is not retrievable"
 		} else {
 			result = r
 		}
@@ -414,7 +414,7 @@ func WaitAllJobsComplete(ctx context.Context, cli client.Client, repo *velerov1a
 		if job.Status.Failed > 0 {
 			if msg, err := getResultFromJob(cli, job); err != nil {
 				log.WithError(err).Warnf("Failed to get result of maintenance job %s", job.Name)
-				message = fmt.Sprintf("Repo maintenance failed but result is not retrieveable, err: %v", err)
+				message = fmt.Sprintf("Repo maintenance failed but result is not retrievable, err: %v", err)
 			} else {
 				message = msg
 			}

--- a/pkg/repository/maintenance/maintenance_test.go
+++ b/pkg/repository/maintenance/maintenance_test.go
@@ -789,7 +789,7 @@ func TestWaitAllJobsComplete(t *testing.T) {
 				{
 					Result:         velerov1api.BackupRepositoryMaintenanceFailed,
 					StartTimestamp: &metav1.Time{Time: now.Add(time.Hour)},
-					Message:        "Repo maintenance failed but result is not retrieveable, err: no pod found for job job2",
+					Message:        "Repo maintenance failed but result is not retrievable, err: no pod found for job job2",
 				},
 			},
 		},


### PR DESCRIPTION
Fix typos in log messages and status strings

Fix dataudownload in DataDownload warning log message (data_download_controller.go:696)
Fix datadownlad misspelled structured log field key → datadownload (data_download_controller.go:700) — this caused the field to be unqueryable by the correct key name
Fix retrieveable → retrievable in BackupRepository maintenance status messages (maintenance.go:354, 417)
Update corresponding test assertion to match corrected string (maintenance_test.go:792)
Summary
Found a few typos in log messages and status strings while reading through the codebase. The datadownlad one is slightly more than cosmetic — it's a structured log field key, so querying logs by datadownload silently returns nothing for entries coming from that code path. The others are spelling corrections in user-visible status messages. No logic changes anywhere.

Does your change fix a particular issue?
Fixes #10191 

Please indicate you've done the following:
 [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
 [Created a changelog file (make new-changelog)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment /kind changelog-not-required on this PR.
