### PR TITLE
Enable TLS for MinIO in the kind E2E workflow

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -137,9 +137,37 @@ jobs:
         run: |
           echo "Loading MinIO image..."
           docker load < ./minio-image.tar
+      # Serve MinIO over TLS so the E2E suite exercises Velero's HTTPS object
+      # store path (BSL caCert / plugin TLS handshake) instead of plain HTTP.
+      - name: Generate MinIO TLS certificate
+        run: |
+          set -euo pipefail
+          # hostname -i can return several addresses; the certificate SAN needs exactly one.
+          MINIO_HOST_IP=$(hostname -i | awk '{print $1}')
+          echo "MINIO_HOST_IP=${MINIO_HOST_IP}" >> $GITHUB_ENV
+          mkdir -p /tmp/minio-certs
+          openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+            -keyout /tmp/minio-certs/private.key \
+            -out /tmp/minio-certs/public.crt \
+            -subj "/CN=${MINIO_HOST_IP}" \
+            -addext "subjectAltName=IP:${MINIO_HOST_IP},IP:127.0.0.1,DNS:localhost"
+          # The MinIO container runs as a non-root user and must be able to read both files.
+          chmod 644 /tmp/minio-certs/private.key /tmp/minio-certs/public.crt
       - name: Install MinIO
         run: |
-          docker run -d --rm -p 9000:9000 -e "MINIO_ROOT_USER=minio" -e "MINIO_ROOT_PASSWORD=minio123" -e "MINIO_DEFAULT_BUCKETS=bucket,additional-bucket" bitnami/minio:local
+          set -euo pipefail
+          # SSL_CERT_FILE / CURL_CA_BUNDLE let the container's own readiness probe
+          # (curl) and bucket bootstrap (mc) trust the self-signed certificate.
+          docker run -d --rm -p 9000:9000 \
+            -e "MINIO_ROOT_USER=minio" \
+            -e "MINIO_ROOT_PASSWORD=minio123" \
+            -e "MINIO_DEFAULT_BUCKETS=bucket,additional-bucket" \
+            -e "MINIO_SCHEME=https" \
+            -e "MINIO_SERVER_URL=https://${MINIO_HOST_IP}:9000" \
+            -e "SSL_CERT_FILE=/certs/public.crt" \
+            -e "CURL_CA_BUNDLE=/certs/public.crt" \
+            -v /tmp/minio-certs:/certs:ro \
+            bitnami/minio:local
       - uses: helm/kind-action@v1
         with:
           cluster_name: "kind"
@@ -180,11 +208,13 @@ jobs:
           GOPATH=~/go \
               CLOUD_PROVIDER=kind \
               OBJECT_STORE_PROVIDER=aws \
-              BSL_CONFIG=region=minio,s3ForcePathStyle="true",s3Url=http://$(hostname -i):9000 \
+              BSL_CONFIG=region=minio,s3ForcePathStyle="true",s3Url=https://${MINIO_HOST_IP}:9000 \
+              BSL_CA_CERT_FILE=/tmp/minio-certs/public.crt \
               CREDS_FILE=/tmp/credential \
               BSL_BUCKET=bucket \
               ADDITIONAL_OBJECT_STORE_PROVIDER=aws \
-              ADDITIONAL_BSL_CONFIG=region=minio,s3ForcePathStyle="true",s3Url=http://$(hostname -i):9000 \
+              ADDITIONAL_BSL_CONFIG=region=minio,s3ForcePathStyle="true",s3Url=https://${MINIO_HOST_IP}:9000 \
+              ADDITIONAL_BSL_CA_CERT_FILE=/tmp/minio-certs/public.crt \
               ADDITIONAL_CREDS_FILE=/tmp/credential \
               ADDITIONAL_BSL_BUCKET=additional-bucket \
               VELERO_IMAGE=velero:pr-test-linux-amd64 \

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -151,8 +151,12 @@ jobs:
             -out /tmp/minio-certs/public.crt \
             -subj "/CN=${MINIO_HOST_IP}" \
             -addext "subjectAltName=IP:${MINIO_HOST_IP},IP:127.0.0.1,DNS:localhost"
-          # The MinIO container runs as a non-root user and must be able to read both files.
-          chmod 644 /tmp/minio-certs/private.key /tmp/minio-certs/public.crt
+          # The certificate is public, but the key must not be world-readable.
+          # The bitnami/minio image runs as uid 1001, so give that uid ownership
+          # of the key; 0600 is then still readable inside the container.
+          chmod 600 /tmp/minio-certs/private.key
+          chmod 644 /tmp/minio-certs/public.crt
+          sudo chown 1001:1001 /tmp/minio-certs/private.key
       - name: Install MinIO
         run: |
           set -euo pipefail

--- a/changelogs/unreleased/10204-Smallfu666
+++ b/changelogs/unreleased/10204-Smallfu666
@@ -1,0 +1,1 @@
+Run the kind E2E object store (MinIO) over TLS and plumb a CA bundle through the E2E test framework to `velero install --cacert`.

--- a/test/Makefile
+++ b/test/Makefile
@@ -96,6 +96,10 @@ STANDBY_CLS_SERVICE_ACCOUNT_NAME ?=
 BSL_BUCKET ?=
 BSL_PREFIX ?=
 BSL_CONFIG ?=
+# Path to a PEM certificate bundle used to verify TLS connections to the object
+# store. Required when the object store (e.g. MinIO) serves HTTPS with a
+# certificate that is not signed by a publicly trusted CA.
+BSL_CA_CERT_FILE ?=
 VSL_CONFIG ?=
 CLOUD_PROVIDER ?=
 STANDBY_CLUSTER_CLOUD_PROVIDER ?=
@@ -118,6 +122,7 @@ ADDITIONAL_CREDS_FILE ?=
 ADDITIONAL_BSL_BUCKET ?=
 ADDITIONAL_BSL_PREFIX ?=
 ADDITIONAL_BSL_CONFIG ?=
+ADDITIONAL_BSL_CA_CERT_FILE ?=
 
 FEATURES ?=
 DEBUG_VELERO_POD_RESTART ?= false
@@ -215,6 +220,7 @@ run-e2e: ginkgo
 		--additional-bsl-bucket=$(ADDITIONAL_BSL_BUCKET) \
 		--additional-bsl-prefix=$(ADDITIONAL_BSL_PREFIX) \
 		--additional-bsl-config=$(ADDITIONAL_BSL_CONFIG) \
+		--additional-bsl-ca-cert-file=$(ADDITIONAL_BSL_CA_CERT_FILE) \
 		--default-cluster-context=$(DEFAULT_CLUSTER) \
 		--standby-cluster-context=$(STANDBY_CLUSTER) \
 		--snapshot-move-data=$(SNAPSHOT_MOVE_DATA) \
@@ -232,7 +238,8 @@ run-e2e: ginkgo
 		--image-registry-proxy=$(IMAGE_REGISTRY_PROXY) \
 		--worker-os=$(WORKER_OS) \
 		--pod-labels=$(POD_LABELS) \
-		--sa-annotations=$(SA_ANNOTATIONS)
+		--sa-annotations=$(SA_ANNOTATIONS) \
+		--bsl-ca-cert-file=$(BSL_CA_CERT_FILE)
 
 .PHONY: run-perf
 run-perf: ginkgo

--- a/test/e2e/backup/backup.go
+++ b/test/e2e/backup/backup.go
@@ -205,6 +205,7 @@ func BackupRestoreTest(backupRestoreTestConfig BackupRestoreTestConfig) {
 				veleroCfg.AdditionalBSLConfig,
 				secretName,
 				secretKey,
+				veleroCfg.AdditionalBSLCACertFile,
 			)).To(Succeed())
 
 			// We limit the length of backup name here to avoid the issue of vsphere plugin

--- a/test/e2e/bsl-mgmt/deletion.go
+++ b/test/e2e/bsl-mgmt/deletion.go
@@ -130,6 +130,7 @@ func BslDeletionTest(useVolumeSnapshots bool) {
 					veleroCfg.AdditionalBSLConfig,
 					secretName,
 					secretKey,
+					veleroCfg.AdditionalBSLCACertFile,
 				)).To(Succeed())
 			})
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -147,6 +147,12 @@ func init() {
 		"bsl-config",
 		"", "configuration to use for the backup storage location. Format is key1=value1,key2=value2")
 	flag.StringVar(
+		&test.VeleroCfg.CACertFile,
+		"bsl-ca-cert-file",
+		"",
+		"file containing a certificate bundle to use when verifying TLS connections to the object store. Optional.",
+	)
+	flag.StringVar(
 		&test.VeleroCfg.BSLPrefix,
 		"prefix",
 		"",
@@ -225,6 +231,12 @@ func init() {
 		"additional-bsl-credentials-file",
 		"",
 		"file containing credentials for additional backup storage location provider. Required if testing multiple credentials support.",
+	)
+	flag.StringVar(
+		&test.VeleroCfg.AdditionalBSLCACertFile,
+		"additional-bsl-ca-cert-file",
+		"",
+		"file containing a certificate bundle to use when verifying TLS connections to the additional backup storage location's object store. Optional.",
 	)
 	flag.StringVar(
 		&test.VeleroCfg.Features,

--- a/test/types.go
+++ b/test/types.go
@@ -96,6 +96,7 @@ type VeleroConfig struct {
 	AdditionalBSLPrefix               string
 	AdditionalBSLConfig               string
 	AdditionalBSLCredentials          string
+	AdditionalBSLCACertFile           string
 	RegistryCredentialFile            string
 	RestoreHelperImage                string
 	UpgradeFromVeleroVersion          string

--- a/test/util/velero/install.go
+++ b/test/util/velero/install.go
@@ -438,6 +438,9 @@ func installVeleroServer(
 	if len(options.Prefix) > 0 {
 		args = append(args, "--prefix", options.Prefix)
 	}
+	if len(options.CACertFile) > 0 {
+		args = append(args, "--cacert", options.CACertFile)
+	}
 	//Treat ServiceAccountName priority higher than SecretFile
 	if len(options.ServiceAccountName) > 0 {
 		args = append(args, "--service-account-name", options.ServiceAccountName)

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -269,6 +269,17 @@ func getProviderVeleroInstallOptions(veleroCfg *VeleroConfig,
 	io.BackupStorageConfig = flag.NewMap()
 	io.BackupStorageConfig.Set(veleroCfg.BSLConfig)
 
+	// CACertFile is the CA bundle used to verify TLS connections to the object
+	// store. It is passed through to `velero install --cacert`, which stores it
+	// in the BSL's spec.objectStorage.caCert.
+	if veleroCfg.CACertFile != "" {
+		realPath, err := filepath.Abs(veleroCfg.CACertFile)
+		if err != nil {
+			return nil, err
+		}
+		io.CACertFile = realPath
+	}
+
 	io.VolumeSnapshotConfig = flag.NewMap()
 	io.VolumeSnapshotConfig.Set(veleroCfg.VSLConfig)
 
@@ -651,7 +662,8 @@ func VeleroCreateBackupLocation(ctx context.Context,
 	prefix,
 	config,
 	secretName,
-	secretKey string,
+	secretKey,
+	caCertFile string,
 ) error {
 	args := []string{
 		"--namespace", veleroNamespace,
@@ -666,6 +678,10 @@ func VeleroCreateBackupLocation(ctx context.Context,
 
 	if config != "" {
 		args = append(args, "--config", config)
+	}
+
+	if caCertFile != "" {
+		args = append(args, "--cacert", caCertFile)
 	}
 
 	if secretName != "" && secretKey != "" {

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -665,6 +665,40 @@ func VeleroCreateBackupLocation(ctx context.Context,
 	secretKey,
 	caCertFile string,
 ) error {
+	args := createBackupLocationArgs(
+		veleroNamespace,
+		name,
+		objectStoreProvider,
+		bucket,
+		prefix,
+		config,
+		secretName,
+		secretKey,
+		caCertFile,
+	)
+
+	if err := VeleroCmdExec(ctx, veleroCLI, args); err != nil {
+		return err
+	}
+
+	return CheckBSL(ctx, veleroNamespace, name)
+}
+
+// createBackupLocationArgs builds the argument list for
+// `velero backup-location create`. It is separated from
+// VeleroCreateBackupLocation so that the argument construction can be verified
+// without invoking the Velero CLI.
+func createBackupLocationArgs(
+	veleroNamespace,
+	name,
+	objectStoreProvider,
+	bucket,
+	prefix,
+	config,
+	secretName,
+	secretKey,
+	caCertFile string,
+) []string {
 	args := []string{
 		"--namespace", veleroNamespace,
 		"create", "backup-location", name,
@@ -688,11 +722,7 @@ func VeleroCreateBackupLocation(ctx context.Context,
 		args = append(args, "--credential", fmt.Sprintf("%s=%s", secretName, secretKey))
 	}
 
-	if err := VeleroCmdExec(ctx, veleroCLI, args); err != nil {
-		return err
-	}
-
-	return CheckBSL(ctx, veleroNamespace, name)
+	return args
 }
 
 func VeleroVersion(ctx context.Context, veleroCLI, veleroNamespace string) error {

--- a/test/util/velero/velero_utils_test.go
+++ b/test/util/velero/velero_utils_test.go
@@ -52,3 +52,52 @@ func Test_getVersionWithoutPatch(t *testing.T) {
 		})
 	}
 }
+
+func Test_createBackupLocationArgs(t *testing.T) {
+	// argValue returns the value following flag, and whether flag was present.
+	argValue := func(args []string, flag string) (string, bool) {
+		for i, a := range args {
+			if a == flag && i+1 < len(args) {
+				return args[i+1], true
+			}
+		}
+		return "", false
+	}
+
+	const (
+		namespace = "velero"
+		bslName   = "additional-bsl"
+		provider  = "aws"
+		bucket    = "additional-bucket"
+		config    = "region=minio,s3ForcePathStyle=\"true\",s3Url=https://minio.example.com:9000"
+		caCert    = "/tmp/minio-certs/public.crt"
+	)
+
+	t.Run("emits --cacert when a CA bundle is configured", func(t *testing.T) {
+		args := createBackupLocationArgs(
+			namespace, bslName, provider, bucket, "", config,
+			"bsl-credentials", "creds-aws", caCert,
+		)
+
+		require.Equal(t, []string{
+			"--namespace", namespace,
+			"create", "backup-location", bslName,
+			"--provider", provider,
+			"--bucket", bucket,
+		}, args[:9], "leading subcommand shape changed")
+
+		value, found := argValue(args, "--cacert")
+		require.True(t, found, "expected --cacert to be emitted, got %v", args)
+		require.Equal(t, caCert, value, "--cacert must be followed by the bundle path")
+	})
+
+	t.Run("omits --cacert when no CA bundle is configured", func(t *testing.T) {
+		args := createBackupLocationArgs(
+			namespace, bslName, provider, bucket, "", config,
+			"bsl-credentials", "creds-aws", "",
+		)
+
+		_, found := argValue(args, "--cacert")
+		require.False(t, found, "did not expect --cacert, got %v", args)
+	})
+}


### PR DESCRIPTION

Fixes #7728

### What this does

The kind E2E workflow runs MinIO over plain HTTP, so no E2E test currently
exercises Velero's HTTPS object-store path. #7728 was opened off #7696, where a
backup against a MinIO instance behind a self-signed certificate failed in a way
CI could not have caught.

This change serves the E2E MinIO over TLS and gives the test framework a way to
pass the corresponding CA bundle to Velero.

**Test framework (`test/`)**

The framework had no way to express "verify TLS against this CA". `velero install`
already supports `--cacert`, and `test.VeleroConfig` already embeds
`install.Options` (so `CACertFile` existed but was never populated or emitted).

Default BSL:

- `test/e2e/e2e_suite_test.go` — new `--bsl-ca-cert-file` flag.
- `test/Makefile` — new `BSL_CA_CERT_FILE` variable, passed to the `run-e2e`
  target only. It is deliberately *not* added to `COMMON_ARGS`, because
  `COMMON_ARGS` is shared with `run-perf` and the perf suite registers its own
  flag set.
- `test/util/velero/velero_utils.go` — resolve the path and set
  `io.CACertFile` in `getProviderVeleroInstallOptions`.
- `test/util/velero/install.go` — emit `--cacert` when set.

Additional BSL — `velero backup-location create` has its own `--cacert`, and the
framework had no way to pass one. The two call sites are the "additional
BackupStorageLocation with unique credentials" spec and the BSL deletion specs:

- `test/types.go` — new `AdditionalBSLCACertFile`.
- `test/e2e/e2e_suite_test.go` / `test/Makefile` —
  `--additional-bsl-ca-cert-file` / `ADDITIONAL_BSL_CA_CERT_FILE`.
- `test/util/velero/velero_utils.go` — `VeleroCreateBackupLocation` takes a
  `caCertFile` and emits `--cacert`; both call sites updated
  (`test/e2e/backup/backup.go`, `test/e2e/bsl-mgmt/deletion.go`).

To be precise about what this workflow covers: **the kind matrix does not
currently exercise the additional-BSL path.** Those specs are all labelled
`AdditionalBSL`, and none of the four label groups here select them — group 3
selects `Backups && BackupsSync`, which is `BackupsSyncTest`, and that test uses
the default BSL (`BackupCfg.BackupLocation = ""`) and never calls
`VeleroCreateBackupLocation`. The additional-BSL plumbing is included so the
second location stays consistent with the now-HTTPS `ADDITIONAL_BSL_CONFIG` this
workflow sets, and so the path is correct for suites that do run the
`AdditionalBSL` label. The **default** BSL `--cacert` path, by contrast, is
exercised by every matrix entry, because every entry installs Velero.

**Workflow (`.github/workflows/e2e-test-kind.yaml`)**

- Generate a self-signed certificate whose SAN covers the runner IP.
- Start the MinIO container with `MINIO_SCHEME=https` and the certificate mounted
  at `/certs`.
- Switch `BSL_CONFIG` / `ADDITIONAL_BSL_CONFIG` to `https://` and pass
  `BSL_CA_CERT_FILE`.

One detail worth calling out for reviewers: the Bitnami MinIO container
bootstraps its default buckets with `mc` and waits for readiness with `curl`,
both against its own endpoint. Once the endpoint is HTTPS with a private CA, both
fail unless they trust it. Rather than patch the image, the container gets
`SSL_CERT_FILE` (honoured by `mc`, a Go binary) and `CURL_CA_BUNDLE` (honoured by
`curl`) pointing at the mounted certificate. Without these two variables the
container never finishes `Creating default buckets...`.

### Scope note

The framework's own S3 verification client (`test/util/providers/aws_utils.go`)
already tolerates HTTPS: for `region == "minio"` it constructs its AWS config
with `insecureSkipTLSVerify=true`, so it needs no change here. Tightening that
client to verify against the same CA is a reasonable follow-up but is kept out of
this PR to keep the diff reviewable. (`caCertKey` in that file is currently a
declared-but-unused constant, which is where such a follow-up would start.)

### Verification

Reproduced the full workflow locally on a single-node kind cluster with the
MinIO image built from the same pinned Bitnami commit the workflow uses:

- MinIO came up on `https://<host>:9000` with the generated certificate, and
  `Creating default buckets...` completed (`bucket`, `additional-bucket`).
- `curl --cacert <ca> https://<host>:9000/minio/health/live` → `200`.
- Same request without the CA → curl exit `60` (certificate verify failed),
  confirming TLS is genuinely enforced rather than falling back.
- Plain `http://` against the same port → `400`, i.e. the old plaintext path is
  really gone.
- `go vet ./test/...` clean; `test/e2e` test binary compiles; `gofmt` clean.
- `go test ./test/util/velero/` — the new `Test_createBackupLocationArgs`
  asserts `velero backup-location create` emits `--cacert <path>` when a bundle
  is configured and omits the flag when it is not. Checked that it is
  load-bearing: dropping the `--cacert` append makes it fail.
- The generated private key is `0600`, owned by the uid the bitnami/minio image
  runs as, rather than world-readable. Re-ran MinIO startup with those
  permissions: default buckets bootstrap, no permission or TLS errors in the
  container log, and the health checks below still behave the same.

Then the E2E label subset `Basic && ClusterResource` was run against that MinIO,
twice, to check that the new plumbing is actually load-bearing rather than
incidentally passing:

| | `BSL_CA_CERT_FILE` set | Result |
|---|---|---|
| A | no | `Ran 0 of 68 Specs in 81.862s` — **FAIL**, BeforeSuite failed, exit 2. Velero log: `x509: certificate signed by unknown authority`, BSL `phase:Unavailable` |
| B | yes | `Ran 3 of 68 Specs in 49.554s` — **SUCCESS! 3 Passed \| 0 Failed**, exit 0, `--cacert <path>` present in the generated `velero install` command, zero x509 errors |

Arm A is the important one: it confirms the endpoint really is TLS-only and that
without the CA bundle the suite cannot even reach BeforeSuite — so the flag is
doing real work, not decorating a run that would have passed anyway.


