### PR TITLE
docs: fix restore logs command name in self-signed-certificates

### DIFF
--- a/site/content/docs/main/self-signed-certificates.md
+++ b/site/content/docs/main/self-signed-certificates.md
@@ -150,7 +150,7 @@ Velero provides a way for you to skip TLS verification on the object store when 
 * velero backup download
 * velero backup logs
 * velero restore describe
-* velero restore log
+* velero restore logs
 
 If true, the object store's TLS certificate will not be checked for validity before Velero or backup repository connects to the object storage. You can permanently skip TLS verification for an object store by setting `Spec.Config.InsecureSkipTLSVerify` to true in the [BackupStorageLocation](api-types/backupstoragelocation.md) CRD.
 


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Fixes a one-character typo in the list of commands that support `--insecure-skip-tls-verify` in `site/content/docs/main/self-signed-certificates.md`: `velero restore log` → `velero restore logs`.

The registered command is `logs` ([`pkg/cmd/cli/restore/logs.go`](https://github.com/velero-io/velero/blob/main/pkg/cmd/cli/restore/logs.go#L48) declares `Use: "logs RESTORE"`), and there is no `log` alias. Following the docs verbatim produces no error, which is what makes the typo mildly annoying — `velero restore log` silently falls through to the parent command's help text and exits 0, so the user gets no logs and no indication they mistyped anything:

```
$ velero restore log
Work with restores

Usage:
   ...
$ echo $?
0
```

I verified against a binary built from `main` that the rest of the list is accurate and only this entry was wrong — all five correctly-spelled commands do register the flag:

```
  OK      : velero backup describe
  OK      : velero backup download
  OK      : velero backup logs
  OK      : velero restore describe
  OK      : velero restore logs
```

**Note on scope:** the same typo exists in the versioned copies for v1.9–v1.18. I've deliberately limited this PR to `site/content/docs/main/` on the assumption that archived versioned docs are left as published. Happy to extend it to all 11 files if you'd prefer — just say so and I'll push the additional change here.

# Does your change fix a particular issue?

Fixes #10183

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR. — docs-only change, commented `/kind changelog-not-required`
- [x] Updated the corresponding documentation in `site/content/docs/main`. — this PR *is* the `site/content/docs/main` change
