### PR TITLE
surface error when restoring PV reclaim policy fails in rebindVolumeSameMode

### DIFF
--- a/changelogs/unreleased/10217-samay43
+++ b/changelogs/unreleased/10217-samay43
@@ -1,0 +1,1 @@
+Surface error when restoring PV reclaim policy fails in rebindVolumeSameMode

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -585,14 +585,11 @@ func (e *genericRestoreExposer) rebindVolumeSameMode(ctx context.Context, ownerO
 	curLog.WithField("restore PV", restorePV.Name).Info("Restore PV is ready")
 
 	retained = nil
-
 	_, err = kube.SetPVReclaimPolicy(ctx, e.kubeClient.CoreV1(), restorePV, orgReclaim)
 	if err != nil {
-		curLog.WithField("restore PV", restorePV.Name).WithError(err).Warn("Restore PV's reclaim policy is not restored")
-	} else {
-		curLog.WithField("restore PV", restorePV.Name).Info("Restore PV's reclaim policy is restored")
+		return errors.Wrapf(err, "error restoring reclaim policy for restore PV %s", restorePV.Name)
 	}
-
+	curLog.WithField("restore PV", restorePV.Name).Info("Restore PV's reclaim policy is restored")
 	return nil
 }
 

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -409,6 +409,19 @@ func TestRebindVolume(t *testing.T) {
 		},
 	}
 
+	restorePVObjBound := &corev1api.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fake-restore-pv",
+		},
+		Spec: corev1api.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: corev1api.PersistentVolumeReclaimDelete,
+			VolumeMode:                    &modeFilesystem,
+		},
+		Status: corev1api.PersistentVolumeStatus{
+			Phase: corev1api.VolumeBound,
+		},
+	}
+
 	restorePod := &corev1api.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: velerov1.DefaultNamespace,
@@ -761,6 +774,35 @@ func TestRebindVolume(t *testing.T) {
 				restorePod,
 			},
 			err: "error to wait restore PV bound, restore PV fake-restore-pv: error to wait for bound of PV: context deadline exceeded",
+		},
+		{
+			name:            "[same mode] restore reclaim policy fail",
+			targetPVCName:   "fake-target-pvc",
+			targetNamespace: "fake-ns",
+			ownerRestore:    restore,
+			kubeClientObj: []runtime.Object{
+				targetPVCObjSameMode,
+				restorePVCObj,
+				restorePVObjBound,
+				restorePod,
+			},
+			kubeReactors: []reactor{
+				{
+					verb:     "patch",
+					resource: "persistentvolumes",
+					reactorFunc: func() func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						patchCount := 0
+						return func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+							patchCount++
+							if patchCount < 3 {
+								return false, nil, nil
+							}
+							return true, nil, errors.New("fake-patch-error")
+						}
+					}(),
+				},
+			},
+			err: "error restoring reclaim policy for restore PV fake-restore-pv: error patching PV: fake-patch-error",
 		},
 	}
 

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -804,6 +804,18 @@ func TestRebindVolume(t *testing.T) {
 			},
 			err: "error restoring reclaim policy for restore PV fake-restore-pv: error patching PV: fake-patch-error",
 		},
+		{
+			name:            "[same mode] success",
+			targetPVCName:   "fake-target-pvc",
+			targetNamespace: "fake-ns",
+			ownerRestore:    restore,
+			kubeClientObj: []runtime.Object{
+				targetPVCObjSameMode,
+				restorePVCObj,
+				restorePVObjBound,
+				restorePod,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #10215

`rebindVolumeSameMode` in `pkg/exposer/generic_restore.go` sets a restore PV's reclaim policy to `Retain` at the start (so it survives intermediate pod/PVC deletion steps), then tries to reset it back to the original policy at the very end. If that reset call fails, the error was only logged as a warning, and the function still returned `nil` — so the restore was reported as successful even though the PV could be left permanently on `Retain` instead of its original policy (often `Delete`), which means it would never get cleaned up automatically once its claim is removed.

`SetPVReclaimPolicy` does a real API patch call, so this is reachable through ordinary failure modes like a transient API server issue or a conflict, not just a contrived edge case.

This makes the function return the error instead of just logging it, so the restore accurately reflects what happened. Also added a test case for this path, since `rebindVolumeSameMode` had no dedicated test coverage for its various failure points before this — needed a new PV fixture with `Status.Phase` set to `Bound` so the flow can get far enough to reach this step, and a reactor that only fails on the third patch call to `persistentvolumes` (the first two are the initial retain and the `ResetPVBinding` call).

Verified: `go build ./...` passes cleanly, and `go test ./pkg/exposer/...` passes, including the new test case and all existing ones.

# Please indicate you've done the following:
- [x] Accepted the DCO
- [x] Created a changelog file (`make new-changelog`) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
