### PR TITLE
Add "SnapshotClass" to DataUploadResult

### DIFF
--- a/pkg/apis/velero/v2alpha1/data_upload_types.go
+++ b/pkg/apis/velero/v2alpha1/data_upload_types.go
@@ -268,4 +268,8 @@ type DataUploadResult struct {
 	// FSType is the file system type of the volume.
 	// +optional
 	FSType string `json:"fsType,omitempty"`
+
+	// SnapshotClass is the name of the snapshot class that the volume snapshot is created with
+	// +optional
+	SnapshotClass string `json:"snapshotClass,omitempty"`
 }

--- a/pkg/restore/actions/dataupload_retrieve_action.go
+++ b/pkg/restore/actions/dataupload_retrieve_action.go
@@ -82,6 +82,9 @@ func (d *DataUploadRetrieveAction) Execute(input *velero.RestoreItemActionExecut
 		NodeOS:                dataUpload.Status.NodeOS,
 		FSType:                dataUpload.Spec.SourceFSType,
 	}
+	if dataUpload.Spec.CSISnapshot != nil {
+		dataUploadResult.SnapshotClass = dataUpload.Spec.CSISnapshot.SnapshotClass
+	}
 
 	jsonBytes, err := json.Marshal(dataUploadResult)
 	if err != nil {

--- a/pkg/restore/actions/dataupload_retrieve_action_test.go
+++ b/pkg/restore/actions/dataupload_retrieve_action_test.go
@@ -67,6 +67,29 @@ func TestDataUploadRetrieveActionExectue(t *testing.T) {
 			expectedDataUploadResult: builder.ForConfigMap("velero", "").ObjectMeta(builder.WithGenerateName("testDU-"), builder.WithLabels(velerov1.PVCNamespaceNameLabel, "testNamespace.testPVC", velerov1.RestoreUIDLabel, "testingUID", velerov1.ResourceUsageLabel, string(velerov1.VeleroResourceUsageDataUploadResult))).Data("testingUID", `{"backupStorageLocation":"testLocation","snapshotID":"fake-id","sourceNamespace":"testNamespace","snapshotSize":1000}`).Result(),
 		},
 		{
+			name: "DataUploadRetrieve Action test with optional fields",
+			dataUpload: func() *velerov2alpha1.DataUpload {
+				du := builder.ForDataUpload("velero", "testDU").
+					SourceNamespace("testNamespace").
+					SourcePVC("testPVC").
+					SnapshotID("fake-id").
+					TotalBytes(1000).
+					DataMover("velero").
+					NodeOS("linux").
+					CSISnapshot(&velerov2alpha1.CSISnapshotSpec{SnapshotClass: "testClass"}).
+					Result()
+				du.Status.DataMoverResult = &map[string]string{"key": "value"}
+				du.Spec.SourceFSType = "ext4"
+				return du
+			}(),
+			restore:       builder.ForRestore("velero", "testRestore").ObjectMeta(builder.WithUID("testingUID")).Backup("testBackup").Result(),
+			runtimeScheme: scheme,
+			veleroObjs: []runtime.Object{
+				builder.ForBackup("velero", "testBackup").StorageLocation("testLocation").Result(),
+			},
+			expectedDataUploadResult: builder.ForConfigMap("velero", "").ObjectMeta(builder.WithGenerateName("testDU-"), builder.WithLabels(velerov1.PVCNamespaceNameLabel, "testNamespace.testPVC", velerov1.RestoreUIDLabel, "testingUID", velerov1.ResourceUsageLabel, string(velerov1.VeleroResourceUsageDataUploadResult))).Data("testingUID", `{"backupStorageLocation":"testLocation","datamover":"velero","snapshotID":"fake-id","sourceNamespace":"testNamespace","dataMoverResult":{"key":"value"},"nodeOS":"linux","snapshotSize":1000,"fsType":"ext4","snapshotClass":"testClass"}`).Result(),
+		},
+		{
 			name:          "Long source namespace and PVC name should also work",
 			dataUpload:    builder.ForDataUpload("velero", "testDU").SourceNamespace("migre209d0da-49c7-45ba-8d5a-3e59fd591ec1").SourcePVC("kibishii-data-kibishii-deployment-0").Result(),
 			restore:       builder.ForRestore("velero", "testRestore").ObjectMeta(builder.WithUID("testingUID")).Backup("testBackup").Result(),


### PR DESCRIPTION
Add "SnapshotClass" to DataUploadResult, this field is needed when does the in-place incremental restore with block data mover

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
