### PR TITLE
Site: add a troubleshooting entry for log downloads failing with "no such host"

### DIFF
--- a/changelogs/unreleased/10231-Ralthos
+++ b/changelogs/unreleased/10231-Ralthos
@@ -1,0 +1,1 @@
+Add a troubleshooting entry for artifact downloads failing when the BackupStorageLocation s3Url is only resolvable inside the cluster

--- a/site/content/docs/main/troubleshooting.md
+++ b/site/content/docs/main/troubleshooting.md
@@ -77,6 +77,19 @@ Here are some things to verify if you receive `SignatureDoesNotMatch` errors:
   * Make sure your S3-compatible layer is using [signature version 4][5] (such as Ceph RADOS v12.2.7)
   * For Ceph, try using a native Ceph account for credentials instead of external providers such as OpenStack Keystone
 
+### `velero backup logs` or `velero describe` fails with `no such host`
+
+Downloading artifacts uses a pre-signed URL built from the `s3Url` in your `BackupStorageLocation`. If that address is only resolvable inside the cluster, such as a Kubernetes Service name, the Velero client cannot fetch the artifact even though the backup or restore itself succeeded:
+
+```
+Warnings:  <error getting warnings: Get "http://minio.velero.svc:9000/velero/restores/...":
+dial tcp: lookup minio.velero.svc: no such host>
+```
+
+The backup or restore is unaffected. Only the download of its log or results file fails.
+
+To fix this, give the location a `publicUrl` that your client can reach. See [Expose Minio outside your cluster][26] for the Minio case; the same applies to any object store addressed by an in-cluster name.
+
 ## Velero (or a pod it was backing up) restarted during a backup and the backup is stuck InProgress
 
 Velero cannot resume backups that were interrupted. Backups stuck in the `InProgress` phase can be deleted with `kubectl delete backup <name> -n <velero-namespace>`.
@@ -250,3 +263,4 @@ Please refer to [Issue 9007](https://github.com/velero-io/velero/issues/9007) fo
 [11]: /plugins
 [12]: https://kubernetes.io/docs/concepts/configuration/secret/#editing-a-secret
 [25]: https://kubernetes.slack.com/messages/velero
+[26]: contributions/minio.md


### PR DESCRIPTION
**Thank you for contributing to Velero!**

**Please add a summary of your change**

`troubleshooting.md` covers `SignatureDoesNotMatch` from S3-compatible providers, but not the other way a log download fails: the signed URL carries a host the Velero client cannot resolve.

On a MinIO install whose `BackupStorageLocation` uses an in-cluster service name for `s3Url`, `velero restore describe` produces this:

```
Warnings:  <error getting warnings: Get "http://minio.velero.svc:9000/velero/restores/s2-restore/
restore-s2-restore-results.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&...": dial tcp:
lookup minio.velero.svc: no such host>
```

The backup and restore both succeeded. Only the artifact download failed, and it failed because the pre-signed URL is built from `s3Url`, which resolves inside the cluster and not on the machine running the CLI.

The fix is `publicUrl`, and it is already documented, but only in `contributions/minio.md` under the heading about exposing MinIO outside the cluster. Someone hitting this error is reading `troubleshooting.md`, and the symptom they have does not obviously point at a page about MinIO deployment.

This adds a short entry next to the existing `SignatureDoesNotMatch` one, showing the error text and linking to the existing `publicUrl` documentation, which it does not repeat.

**Does your change fix a particular issue?**

No filed issue. I hit this while running Velero locally and spent a while assuming the restore had failed, when the restore was fine and only `describe` could not fetch the results file.

**Please indicate you've done the following:**

The entry is placed under `## Miscellaneous issues`, after the `SignatureDoesNotMatch` section, because the two are the same class of problem: the artifact download failing for a reason unrelated to the backup itself.

I kept it to the symptom, the cause and a link. The `publicUrl` mechanics are covered well in `contributions/minio.md` and duplicating them would give two places to keep in step.

One thing I was unsure about: whether to mention that this affects any object store reached over an in-cluster address, not only MinIO. I wrote it that way, since the same thing happens with any `s3Url` pointing at a Service, but I have only reproduced it with MinIO.

- [x] Added a changelog
- [x] Signed off the commit
- [ ] Added or updated tests (docs only)

