### PR TITLE
Allow configuration of page buffer size in Item Collector (#10219)

### DIFF
--- a/changelogs/unreleased/10235-opbot-xd
+++ b/changelogs/unreleased/10235-opbot-xd
@@ -1,0 +1,1 @@
+Allow configuration of page buffer size in Item Collector

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -123,6 +123,7 @@ type kubernetesBackupper struct {
 	podVolumeTimeout          time.Duration
 	defaultVolumesToFsBackup  bool
 	clientPageSize            int
+	clientPageBufferSize      int
 	uploaderType              string
 	pluginManager             func(logrus.FieldLogger) clientmgmt.Manager
 	backupStoreGetter         persistence.ObjectBackupStoreGetter
@@ -152,6 +153,7 @@ func NewKubernetesBackupper(
 	podVolumeTimeout time.Duration,
 	defaultVolumesToFsBackup bool,
 	clientPageSize int,
+	clientPageBufferSize int,
 	uploaderType string,
 	pluginManager func(logrus.FieldLogger) clientmgmt.Manager,
 	backupStoreGetter persistence.ObjectBackupStoreGetter,
@@ -165,6 +167,7 @@ func NewKubernetesBackupper(
 		podVolumeTimeout:          podVolumeTimeout,
 		defaultVolumesToFsBackup:  defaultVolumesToFsBackup,
 		clientPageSize:            clientPageSize,
+		clientPageBufferSize:      clientPageBufferSize,
 		uploaderType:              uploaderType,
 		pluginManager:             pluginManager,
 		backupStoreGetter:         backupStoreGetter,
@@ -461,6 +464,7 @@ func (kb *kubernetesBackupper) BackupWithResolvers(
 		cohabitatingResources: cohabitatingResources(),
 		dir:                   tempDir,
 		pageSize:              kb.clientPageSize,
+		pageBufferSize:        kb.clientPageBufferSize,
 	}
 
 	items := collector.getAllItems()
@@ -1135,6 +1139,7 @@ func (kb *kubernetesBackupper) FinalizeBackup(
 		cohabitatingResources: cohabitatingResources(),
 		dir:                   tempDir,
 		pageSize:              kb.clientPageSize,
+		pageBufferSize:        kb.clientPageBufferSize,
 	}
 
 	// Get item list from itemoperation.BackupOperation.Spec.PostOperationItems

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -6283,3 +6283,9 @@ func TestGetNamespaceFilter_CacheBypass(t *testing.T) {
 	// but the cache should return our cachedFilter.
 	assert.Same(t, cachedFilter, req.GetNamespaceFilter("cached-ns"))
 }
+
+func TestNewKubernetesBackupper(t *testing.T) {
+	b, err := NewKubernetesBackupper(nil, nil, nil, nil, nil, 0, false, 100, 10, "", nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+}

--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strings"
@@ -27,7 +28,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
 	corev1api "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -52,6 +53,7 @@ type itemCollector struct {
 	cohabitatingResources map[string]*cohabitatingResource
 	dir                   string
 	pageSize              int
+	pageBufferSize        int
 	nsTracker             nsTracker
 }
 
@@ -604,7 +606,7 @@ func (r *itemCollector) listResourceByLabelsPerNamespace(
 	// Listing items for orLabelSelectors
 	errListingForNS := false
 	for _, label := range orLabelSelectors {
-		unstructuredItems, err = r.listItemsForLabel(unstructuredItems, gr, label, resourceClient)
+		unstructuredItems, err = r.listItemsForLabel(unstructuredItems, label, resourceClient)
 		if err != nil {
 			errListingForNS = true
 		}
@@ -619,7 +621,6 @@ func (r *itemCollector) listResourceByLabelsPerNamespace(
 	if len(orLabelSelectors) == 0 {
 		unstructuredItems, err = r.listItemsForLabel(
 			unstructuredItems,
-			gr,
 			labelSelector,
 			resourceClient,
 		)
@@ -728,49 +729,25 @@ func newCohabitatingResource(resource, group1, group2 string) *cohabitatingResou
 	}
 }
 
-// function to process pager client calls when the pageSize is specified
-func (r *itemCollector) processPagerClientCalls(
-	gr schema.GroupResource,
-	label string,
-	resourceClient client.Dynamic,
-) (runtime.Object, error) {
-	// If limit is positive, use a pager to split list over multiple requests
-	// Use Velero's dynamic list function instead of the default
-	listPager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
-		return resourceClient.List(opts)
-	}))
-	// Use the page size defined in the server config
-	// TODO allow configuration of page buffer size
-	listPager.PageSize = int64(r.pageSize)
-	// Add each item to temporary slice
-	list, paginated, err := listPager.List(context.Background(), metav1.ListOptions{LabelSelector: label})
-
-	if err != nil {
-		r.log.WithError(errors.WithStack(err)).Error("Error listing resources")
-		return list, err
-	}
-
-	if !paginated {
-		r.log.Infof("list for groupResource %s was not paginated", gr)
-	}
-
-	return list, nil
-}
-
 func (r *itemCollector) listItemsForLabel(
 	unstructuredItems []unstructured.Unstructured,
-	gr schema.GroupResource,
 	label string,
 	resourceClient client.Dynamic,
 ) ([]unstructured.Unstructured, error) {
 	if r.pageSize > 0 {
-		// process pager client calls
-		list, err := r.processPagerClientCalls(gr, label, resourceClient)
-		if err != nil {
-			return unstructuredItems, err
+		initialCount := len(unstructuredItems)
+		listPager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
+			return resourceClient.List(opts)
+		}))
+
+		listPager.PageSize = int64(r.pageSize)
+		if r.pageBufferSize > math.MaxInt32 {
+			listPager.PageBufferSize = math.MaxInt32
+		} else if r.pageBufferSize >= 0 {
+			listPager.PageBufferSize = int32(r.pageBufferSize)
 		}
 
-		err = meta.EachListItem(list, func(object runtime.Object) error {
+		err := listPager.EachListItem(context.Background(), metav1.ListOptions{LabelSelector: label}, func(object runtime.Object) error {
 			u, ok := object.(*unstructured.Unstructured)
 			if !ok {
 				r.log.WithError(errors.WithStack(fmt.Errorf("expected *unstructured.Unstructured but got %T", u))).
@@ -780,9 +757,22 @@ func (r *itemCollector) listItemsForLabel(
 			unstructuredItems = append(unstructuredItems, *u)
 			return nil
 		})
+
 		if err != nil {
+			if apierrors.IsResourceExpired(err) {
+				r.log.WithError(err).Warn("continuation token expired during pagination, falling back to full list")
+				unstructuredItems = unstructuredItems[:initialCount]
+				unstructuredList, listErr := resourceClient.List(metav1.ListOptions{LabelSelector: label})
+				if listErr != nil {
+					r.log.WithError(errors.WithStack(listErr)).Error("Error listing items after pagination expiration")
+					return unstructuredItems, listErr
+				}
+				unstructuredItems = append(unstructuredItems, unstructuredList.Items...)
+				return unstructuredItems, nil
+			}
+
 			r.log.WithError(errors.WithStack(err)).Error("unable to understand paginated list")
-			return unstructuredItems, err
+			return unstructuredItems[:initialCount], err
 		}
 	} else {
 		unstructuredList, err := resourceClient.List(metav1.ListOptions{LabelSelector: label})

--- a/pkg/backup/item_collector_test.go
+++ b/pkg/backup/item_collector_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package backup
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -24,6 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	corev1api "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -465,4 +467,178 @@ func TestGetOrderedResourcesForTypeTrimsSpaces(t *testing.T) {
 		{namespace: "ns1", name: "pod1", orderedResource: true},
 		{namespace: "ns1", name: "pod3"},
 	}, sorted)
+}
+
+func TestListItemsForLabel(t *testing.T) {
+	makePod := func(name string) unstructured.Unstructured {
+		return unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": "default",
+				},
+			},
+		}
+	}
+
+	pod1 := makePod("pod1")
+	pod2 := makePod("pod2")
+	pod3 := makePod("pod3")
+	pod4 := makePod("pod4")
+	pod5 := makePod("pod5")
+	existingPod := makePod("existing")
+
+	t.Run("multiple pages collected exactly once using configured page size", func(t *testing.T) {
+		dc := &test.FakeDynamicClient{}
+		// Page 1: Limit=2, continue="" -> returns [pod1, pod2], continue="c1"
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo", Limit: 2, Continue: ""}).
+			Return(&unstructured.UnstructuredList{
+				Object: map[string]any{
+					"metadata": map[string]any{"continue": "c1"},
+				},
+				Items: []unstructured.Unstructured{pod1, pod2},
+			}, nil).Once()
+
+		// Page 2: Limit=2, continue="c1" -> returns [pod3, pod4], continue="c2"
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo", Limit: 2, Continue: "c1"}).
+			Return(&unstructured.UnstructuredList{
+				Object: map[string]any{
+					"metadata": map[string]any{"continue": "c2"},
+				},
+				Items: []unstructured.Unstructured{pod3, pod4},
+			}, nil).Once()
+
+		// Page 3: Limit=2, continue="c2" -> returns [pod5], continue=""
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo", Limit: 2, Continue: "c2"}).
+			Return(&unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{pod5},
+			}, nil).Once()
+
+		collector := &itemCollector{
+			pageSize:       2,
+			pageBufferSize: 5,
+			log:            test.NewLogger(),
+		}
+
+		res, err := collector.listItemsForLabel(nil, "app=foo", dc)
+		require.NoError(t, err)
+		assert.Equal(t, []unstructured.Unstructured{pod1, pod2, pod3, pod4, pod5}, res)
+		dc.AssertExpectations(t)
+	})
+
+	t.Run("error from later page is propagated and partial items are discarded", func(t *testing.T) {
+		dc := &test.FakeDynamicClient{}
+		// Page 1 succeeds
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo", Limit: 2, Continue: ""}).
+			Return(&unstructured.UnstructuredList{
+				Object: map[string]any{
+					"metadata": map[string]any{"continue": "c1"},
+				},
+				Items: []unstructured.Unstructured{pod1, pod2},
+			}, nil).Once()
+
+		// Page 2 returns an error
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo", Limit: 2, Continue: "c1"}).
+			Return((*unstructured.UnstructuredList)(nil), errors.New("network error on page 2")).Once()
+
+		collector := &itemCollector{
+			pageSize:       2,
+			pageBufferSize: 5,
+			log:            test.NewLogger(),
+		}
+
+		res, err := collector.listItemsForLabel([]unstructured.Unstructured{existingPod}, "app=foo", dc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "network error on page 2")
+		// Verify partial items from page 1 were not retained and existingPod was preserved
+		assert.Equal(t, []unstructured.Unstructured{existingPod}, res)
+		dc.AssertExpectations(t)
+	})
+
+	t.Run("continuation token expiration recovers with full list without duplicating items", func(t *testing.T) {
+		dc := &test.FakeDynamicClient{}
+		// Page 1 succeeds with continue token
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo", Limit: 2, Continue: ""}).
+			Return(&unstructured.UnstructuredList{
+				Object: map[string]any{
+					"metadata": map[string]any{"continue": "expired-token"},
+				},
+				Items: []unstructured.Unstructured{pod1, pod2},
+			}, nil).Once()
+
+		// Page 2 fails with ResourceExpired error
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo", Limit: 2, Continue: "expired-token"}).
+			Return((*unstructured.UnstructuredList)(nil), apierrors.NewResourceExpired("too old")).Once()
+
+		// Fallback unpaginated full list succeeds
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo"}).
+			Return(&unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{pod1, pod2, pod3, pod4},
+			}, nil).Once()
+
+		collector := &itemCollector{
+			pageSize:       2,
+			pageBufferSize: 5,
+			log:            test.NewLogger(),
+		}
+
+		res, err := collector.listItemsForLabel([]unstructured.Unstructured{existingPod}, "app=foo", dc)
+		require.NoError(t, err)
+		// Should contain existingPod and all 4 pods from full list exactly once
+		assert.Equal(t, []unstructured.Unstructured{existingPod, pod1, pod2, pod3, pod4}, res)
+		dc.AssertExpectations(t)
+	})
+
+	t.Run("continuation token expiration fallback error is propagated", func(t *testing.T) {
+		dc := &test.FakeDynamicClient{}
+		// Page 1 succeeds
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo", Limit: 2, Continue: ""}).
+			Return(&unstructured.UnstructuredList{
+				Object: map[string]any{
+					"metadata": map[string]any{"continue": "expired-token"},
+				},
+				Items: []unstructured.Unstructured{pod1, pod2},
+			}, nil).Once()
+
+		// Page 2 fails with ResourceExpired error
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo", Limit: 2, Continue: "expired-token"}).
+			Return((*unstructured.UnstructuredList)(nil), apierrors.NewResourceExpired("too old")).Once()
+
+		// Fallback fails
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo"}).
+			Return((*unstructured.UnstructuredList)(nil), errors.New("unrecoverable error")).Once()
+
+		collector := &itemCollector{
+			pageSize:       2,
+			pageBufferSize: 5,
+			log:            test.NewLogger(),
+		}
+
+		res, err := collector.listItemsForLabel([]unstructured.Unstructured{existingPod}, "app=foo", dc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unrecoverable error")
+		assert.Equal(t, []unstructured.Unstructured{existingPod}, res)
+		dc.AssertExpectations(t)
+	})
+
+	t.Run("unpaginated listing when pageSize is 0", func(t *testing.T) {
+		dc := &test.FakeDynamicClient{}
+		dc.On("List", metav1.ListOptions{LabelSelector: "app=foo"}).
+			Return(&unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{pod1, pod2},
+			}, nil).Once()
+
+		collector := &itemCollector{
+			pageSize:       0,
+			pageBufferSize: 10,
+			log:            test.NewLogger(),
+		}
+
+		res, err := collector.listItemsForLabel([]unstructured.Unstructured{existingPod}, "app=foo", dc)
+		require.NoError(t, err)
+		assert.Equal(t, []unstructured.Unstructured{existingPod, pod1, pod2}, res)
+		dc.AssertExpectations(t)
+	})
 }

--- a/pkg/cmd/server/config/config.go
+++ b/pkg/cmd/server/config/config.go
@@ -29,9 +29,10 @@ const (
 	defaultResourceTerminatingTimeout = 10 * time.Minute
 
 	// server's client default qps and burst
-	defaultClientQPS      float32 = 100.0
-	defaultClientBurst    int     = 100
-	defaultClientPageSize int     = 500
+	defaultClientQPS            float32 = 100.0
+	defaultClientBurst          int     = 100
+	defaultClientPageSize       int     = 500
+	defaultClientPageBufferSize int     = 10
 
 	defaultProfilerAddress = "localhost:6060"
 
@@ -164,6 +165,7 @@ type Config struct {
 	ClientQPS                           float32
 	ClientBurst                         int
 	ClientPageSize                      int
+	ClientPageBufferSize                int
 	ProfilerAddress                     string
 	LogLevel                            *logging.LevelFlag
 	LogFormat                           *logging.FormatFlag
@@ -204,6 +206,7 @@ func GetDefaultConfig() *Config {
 		ClientQPS:                      defaultClientQPS,
 		ClientBurst:                    defaultClientBurst,
 		ClientPageSize:                 defaultClientPageSize,
+		ClientPageBufferSize:           defaultClientPageBufferSize,
 		ProfilerAddress:                defaultProfilerAddress,
 		ResourceTerminatingTimeout:     defaultResourceTerminatingTimeout,
 		LogLevel:                       logging.LogLevelFlag(logrus.InfoLevel),
@@ -237,6 +240,7 @@ func (c *Config) BindFlags(flags *pflag.FlagSet) {
 	flags.Float32Var(&c.ClientQPS, "client-qps", c.ClientQPS, "Maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached.")
 	flags.IntVar(&c.ClientBurst, "client-burst", c.ClientBurst, "Maximum number of requests by the server to the Kubernetes API in a short period of time.")
 	flags.IntVar(&c.ClientPageSize, "client-page-size", c.ClientPageSize, "Page size of requests by the server to the Kubernetes API when listing objects during a backup. Set to 0 to disable paging.")
+	flags.IntVar(&c.ClientPageBufferSize, "client-page-buffer-size", c.ClientPageBufferSize, "Number of pages to buffer concurrently when listing resources during a backup. Higher values use more memory but may improve throughput. Default is 10.")
 	flags.StringVar(&c.ProfilerAddress, "profiler-address", c.ProfilerAddress, "The address to expose the pprof profiler.")
 	flags.DurationVar(&c.ResourceTerminatingTimeout, "terminating-resource-timeout", c.ResourceTerminatingTimeout, "How long to wait on persistent volumes and namespaces to terminate during a restore before timing out.")
 	flags.DurationVar(&c.DefaultBackupTTL, "default-backup-ttl", c.DefaultBackupTTL, "How long to wait by default before backups can be garbage collected.")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -183,6 +184,10 @@ func newServer(f client.Factory, config *config.Config, logger *logrus.Logger) (
 
 	if config.ClientPageSize < 0 {
 		return nil, errors.New("client-page-size must not be negative")
+	}
+
+	if config.ClientPageBufferSize < 0 || config.ClientPageBufferSize > math.MaxInt32 {
+		return nil, errors.Errorf("client-page-buffer-size must be between 0 and %d", math.MaxInt32)
 	}
 
 	kubeClient, err := f.KubeClient()
@@ -650,6 +655,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.config.PodVolumeOperationTimeout,
 			s.config.DefaultVolumesToFsBackup,
 			s.config.ClientPageSize,
+			s.config.ClientPageBufferSize,
 			s.config.UploaderType,
 			newPluginManager,
 			backupStoreGetter,
@@ -736,6 +742,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.config.PodVolumeOperationTimeout,
 			s.config.DefaultVolumesToFsBackup,
 			s.config.ClientPageSize,
+			s.config.ClientPageBufferSize,
 			s.config.UploaderType,
 			newPluginManager,
 			backupStoreGetter,

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -220,7 +220,7 @@ func Test_newServer(t *testing.T) {
 	}, logger)
 	require.Error(t, err)
 
-	// invalid clientBclientPageSizeurst
+	// invalid clientPageSize
 	factory.On("SetClientQPS", mock.Anything).Return().
 		On("SetClientBurst", mock.Anything).Return()
 	_, err = newServer(factory, &config.Config{
@@ -228,6 +228,16 @@ func Test_newServer(t *testing.T) {
 		ClientQPS:      1,
 		ClientBurst:    1,
 		ClientPageSize: -1,
+	}, logger)
+	require.Error(t, err)
+
+	// invalid clientPageBufferSize (negative)
+	_, err = newServer(factory, &config.Config{
+		UploaderType:         uploader.KopiaType,
+		ClientQPS:            1,
+		ClientBurst:          1,
+		ClientPageSize:       100,
+		ClientPageBufferSize: -1,
 	}, logger)
 	require.Error(t, err)
 

--- a/pkg/test/fake_dynamic.go
+++ b/pkg/test/fake_dynamic.go
@@ -51,6 +51,9 @@ var _ client.Dynamic = &FakeDynamicClient{}
 
 func (c *FakeDynamicClient) List(options metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	args := c.Called(options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*unstructured.UnstructuredList), args.Error(1)
 }
 

--- a/site/content/docs/main/backup-reference.md
+++ b/site/content/docs/main/backup-reference.md
@@ -157,6 +157,8 @@ By default, Velero will paginate the LIST API call for each resource type in the
 
 Depending on the cluster's scale, tuning the page size can improve backup performance. You can experiment with higher values, noting their impact on the relevant `apiserver_request_duration_seconds_*` metrics from the Kubernetes apiserver.
 
+You can also configure the number of pages to buffer concurrently by setting the `--client-page-buffer-size` flag (default 10). Higher values use more memory but may improve throughput in large environments, provided the Velero server has sufficient memory.
+
 Pagination can be entirely disabled by setting `--client-page-size` to `0`. This will request all items in a single unpaginated LIST call.
 
 ## Deleting Backups


### PR DESCRIPTION
# Please add a summary of your change

Added `ClientPageBufferSize` configuration to allow users to override the default page buffer size used in the `itemCollector`, replacing the hardcoded `TODO`. This helps users tune Velero's memory usage and performance in extremely large environments.

# Does your change fix a particular issue?

Fixes #10219

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
