### PR TITLE
E2E: add kind VolumeSnapshotClass test data

### DIFF
--- a/test/testdata/volume-snapshot-class/kind.yaml
+++ b/test/testdata/volume-snapshot-class/kind.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Delete
+driver: hostpath.csi.k8s.io
+kind: VolumeSnapshotClass
+metadata:
+  labels:
+    velero.io/csi-volumesnapshot-class: "true"
+  name: e2e-volume-snapshot-class


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

BeforeSuite applies testdata/volume-snapshot-class/<provider>.yaml when CSI is enabled, and there is no kind.yaml, so the suite fails before any spec runs and none of the existing CSI tests can run on kind.

This adds a class for csi-driver-host-path. The driver ships its own, but it lacks the velero.io/csi-volumesnapshot-class label so Velero never selects it. Nothing sets FEATURES=EnableCSI for kind yet, so no test that runs today is affected.

# Does your change fix a particular issue?

No filed issue. I hit it setting up CSI snapshot tests on kind, and spent a while looking for a mistake in my own setup before noticing the suite was failing on a file that does not exist.

# Please indicate you've done the following:

I ran it on kind v1.34.8 with external-snapshotter v8.6.0 and csi-driver-host-path v1.18.0, MinIO for object storage. 
BeforeSuite applies the class and the CSI specs pass : 2 passed, 0 failed, 66 skipped, for BackupVolumeInfo && (CSISnapshot || CSIDataMover). 
The snapshot case came back with CSISnapshotInfo set and PreserveLocalSnapshot true, the data mover case with SnapshotDataMovementInfo set and SnapshotDataMoved true, which is what those two specs check.

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
