### PR TITLE
Reject negative --ttl in backup create validation

### DIFF
--- a/changelogs/unreleased/10237-harshitsaini17
+++ b/changelogs/unreleased/10237-harshitsaini17
@@ -1,1 +1,1 @@
-Reject negative --ttl in backup create validation, which previously produced a backup whose expiration was in the past and was garbage collected immediately after creation
+Reject negative TTLs when creating a backup, in both the CLI and the backup controller. A negative TTL previously produced a backup whose expiration was in the past, so it was garbage collected immediately after creation

--- a/changelogs/unreleased/10237-harshitsaini17
+++ b/changelogs/unreleased/10237-harshitsaini17
@@ -1,0 +1,1 @@
+Reject negative --ttl in backup create validation, which previously produced a backup whose expiration was in the past and was garbage collected immediately after creation

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -207,6 +207,14 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 			"They cannot be used together")
 	}
 
+	// A negative TTL is never meaningful: the backup's expiration is computed as
+	// "now + TTL", so it would be in the past and the backup would be eligible for
+	// garbage collection as soon as it is created. Note that a zero TTL is valid and
+	// means "use the server's default TTL".
+	if o.TTL < 0 {
+		return fmt.Errorf("--ttl must be non-negative")
+	}
+
 	if o.StorageLocation != "" {
 		location := &velerov1api.BackupStorageLocation{}
 		if err := o.client.Get(context.Background(), kbclient.ObjectKey{

--- a/pkg/cmd/cli/backup/create_test.go
+++ b/pkg/cmd/cli/backup/create_test.go
@@ -162,6 +162,47 @@ func TestCreateOptions_ValidateBackupType(t *testing.T) {
 	})
 }
 
+func TestCreateOptions_ValidateTTL(t *testing.T) {
+	// A zero TTL is valid and means "use the server's default TTL", so only
+	// negative values must be rejected.
+	tests := []struct {
+		name        string
+		ttl         time.Duration
+		expectedErr string
+	}{
+		{
+			name: "zero TTL is allowed and means use the default",
+			ttl:  0,
+		},
+		{
+			name: "positive TTL is allowed",
+			ttl:  time.Hour,
+		},
+		{
+			name:        "negative TTL is rejected",
+			ttl:         -time.Hour,
+			expectedErr: "--ttl must be non-negative",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := &factorymocks.Factory{}
+			cmd := NewCreateCommand(f, "")
+
+			o := NewCreateOptions()
+			o.TTL = test.ttl
+
+			err := o.Validate(cmd, []string{"backup-1"}, f)
+			if test.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, test.expectedErr)
+		})
+	}
+}
+
 func TestCreateOptions_BuildBackupFromSchedule(t *testing.T) {
 	o := NewCreateOptions()
 	o.FromSchedule = "test"

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -408,7 +408,13 @@ func (b *backupReconciler) prepareBackupRequest(ctx context.Context, backup *vel
 	// set backup major, minor, and patch version
 	request.Status.FormatVersion = pkgbackup.BackupFormatVersion
 
-	if request.Spec.TTL.Duration == 0 {
+	if request.Spec.TTL.Duration < 0 {
+		// A negative TTL would put Status.Expiration in the past, making the backup
+		// eligible for garbage collection as soon as it is created. The CLI rejects
+		// this, but the spec can also be submitted directly, e.g. via `kubectl apply`.
+		request.Status.ValidationErrors = append(request.Status.ValidationErrors,
+			fmt.Sprintf("invalid TTL %s: TTL must be non-negative", request.Spec.TTL.Duration))
+	} else if request.Spec.TTL.Duration == 0 {
 		// set default backup TTL
 		request.Spec.TTL.Duration = b.defaultBackupTTL
 	}
@@ -436,8 +442,13 @@ func (b *backupReconciler) prepareBackupRequest(ctx context.Context, backup *vel
 		request.Spec.DataMover = datamover.GetDefaultBuiltInDataMover()
 	}
 
-	// calculate expiration
-	request.Status.Expiration = &metav1.Time{Time: b.clock.Now().Add(request.Spec.TTL.Duration)}
+	// calculate expiration. A negative TTL is left without an expiration: the
+	// garbage collector only looks at Status.Expiration, not at the backup phase, so
+	// computing "now + negative TTL" here would delete the backup that just failed
+	// validation.
+	if request.Spec.TTL.Duration >= 0 {
+		request.Status.Expiration = &metav1.Time{Time: b.clock.Now().Add(request.Spec.TTL.Duration)}
+	}
 
 	// TODO: After we drop the support for backup v1 CR.  Remove this code block after DefaultVolumesToRestic is removed from CRD
 	// For now, for CRs created by old versions, we need to respect the DefaultVolumesToRestic value if it is set true

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -526,6 +526,44 @@ func TestDefaultBackupTTL(t *testing.T) {
 	}
 }
 
+func TestPrepareBackupRequest_NegativeTTL(t *testing.T) {
+	defaultBackupTTL := metav1.Duration{Duration: 24 * 30 * time.Hour}
+
+	now, err := time.Parse(time.RFC1123Z, time.RFC1123Z)
+	require.NoError(t, err)
+	now = now.Local()
+
+	formatFlag := logging.FormatText
+	logger := logging.DefaultLogger(logrus.DebugLevel, formatFlag)
+
+	apiServer := velerotest.NewAPIServer(t)
+	discoveryHelper, err := discovery.NewHelper(apiServer.DiscoveryClient, logger)
+	require.NoError(t, err)
+
+	c := &backupReconciler{
+		logger:           logger,
+		discoveryHelper:  discoveryHelper,
+		kbClient:         velerotest.NewFakeControllerRuntimeClient(t),
+		defaultBackupTTL: defaultBackupTTL.Duration,
+		clock:            testclocks.NewFakeClock(now),
+		formatFlag:       formatFlag,
+	}
+
+	res := c.prepareBackupRequest(ctx, defaultBackup().TTL(-time.Hour).Result(), logger)
+	defer res.WorkerPool.Stop()
+
+	require.NotNil(t, res)
+	assert.Contains(t, res.Status.ValidationErrors, "invalid TTL -1h0m0s: TTL must be non-negative")
+
+	// The negative TTL must not be replaced by the server default: only a zero TTL
+	// means "use the default".
+	assert.Equal(t, metav1.Duration{Duration: -time.Hour}, res.Spec.TTL)
+
+	// No expiration is set, otherwise the garbage collector, which only looks at
+	// Status.Expiration, would delete the backup that just failed validation.
+	assert.Nil(t, res.Status.Expiration)
+}
+
 func TestPrepareBackupRequest_SetBackupType(t *testing.T) {
 	now, err := time.Parse(time.RFC1123Z, time.RFC1123Z)
 	require.NoError(t, err)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

`velero backup create --ttl=-1h` was accepted without complaint, and the negative value then flowed all the way through to backup deletion:

1. `CreateOptions.Validate` had no TTL check, so the negative duration reached the submitted `Backup` object verbatim.
2. Server-side defaulting only replaces a TTL that is **exactly** zero (`backup_controller.go`: `if request.Spec.TTL.Duration == 0`), so a negative TTL survives it.
3. `Status.Expiration` is computed as `now + TTL`, so it lands in the **past**.
4. `gc_controller.go` skips only backups whose expiration is still `After(now)`, so the brand-new backup is immediately eligible for deletion.

The user-visible effect is that the backup appears to be created and then quietly disappears, which reads as data loss rather than as a rejected flag.

This PR rejects negative values in `CreateOptions.Validate`:

```go
// A negative TTL is never meaningful: the backup's expiration is computed as
// "now + TTL", so it would be in the past and the backup would be eligible for
// garbage collection as soon as it is created. Note that a zero TTL is valid and
// means "use the server's default TTL".
if o.TTL < 0 {
    return fmt.Errorf("--ttl must be non-negative")
}
```

This follows the convention the `install` command already uses, which returns an error for negative `--default-repo-maintain-frequency`, `--garbage-collection-frequency` and `--pod-volume-operation-timeout` — so `--ttl` was simply not following an existing pattern.

A zero TTL remains valid and continues to mean "use the server's default TTL"; the new test covers that explicitly so the defaulting path can't regress.

Because `velero schedule create` delegates to the same `CreateOptions.Validate` (`pkg/cmd/cli/schedule/create.go`), this covers that command too.

**Scope note:** #10182 mentioned a second possible fix — treating `<= 0` as "use the default" in `prepareBackupRequest`, which would additionally repair *existing* objects that already carry a negative TTL. I've deliberately kept this PR to the client-side check only, since that's the minimal change and matches the existing convention. Happy to add the controller-side half here or in a follow-up if you'd like existing objects corrected as well.

**Testing:** added `TestCreateOptions_ValidateTTL` covering zero, positive and negative TTLs. Full `./pkg/cmd/cli/backup/...` suite passes locally.

# Does your change fix a particular issue?

Fixes #10182

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`. — no documentation change needed; the `--ttl` flag help text is unchanged and this only adds validation for a value that was never meaningful.
