### PR TITLE
fix(cli): accept != in label selectors

### DIFF
--- a/changelogs/unreleased/4724-Jay2006sawant
+++ b/changelogs/unreleased/4724-Jay2006sawant
@@ -1,0 +1,1 @@
+Accept "!=" in --selector / --or-selector by mapping it to NotIn when building metav1.LabelSelector

--- a/pkg/cmd/util/flag/label_selector_parse.go
+++ b/pkg/cmd/util/flag/label_selector_parse.go
@@ -1,0 +1,77 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// parseToLabelSelector parses a Kubernetes label selector string into a
+// metav1.LabelSelector. It mirrors metav1.ParseToLabelSelector, but also
+// accepts the "!=" operator (selection.NotEquals) by mapping it to NotIn,
+// which is how kubectl and labels.Parse treat inequality.
+func parseToLabelSelector(selector string) (*metav1.LabelSelector, error) {
+	reqs, err := labels.ParseToRequirements(selector)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse the selector string %q: %v", selector, err)
+	}
+
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels:      map[string]string{},
+		MatchExpressions: []metav1.LabelSelectorRequirement{},
+	}
+	for _, req := range reqs {
+		var op metav1.LabelSelectorOperator
+		switch req.Operator() {
+		case selection.Equals, selection.DoubleEquals:
+			vals := req.Values()
+			if vals.Len() != 1 {
+				return nil, fmt.Errorf("equals operator must have exactly one value")
+			}
+			val, ok := vals.PopAny()
+			if !ok {
+				return nil, fmt.Errorf("equals operator has exactly one value but it cannot be retrieved")
+			}
+			labelSelector.MatchLabels[req.Key()] = val
+			continue
+		case selection.In:
+			op = metav1.LabelSelectorOpIn
+		case selection.NotIn, selection.NotEquals:
+			// "!=" is valid for labels.Parse / kubectl but not stored on
+			// metav1.LabelSelector; NotIn with the same values is equivalent.
+			op = metav1.LabelSelectorOpNotIn
+		case selection.Exists:
+			op = metav1.LabelSelectorOpExists
+		case selection.DoesNotExist:
+			op = metav1.LabelSelectorOpDoesNotExist
+		case selection.GreaterThan, selection.LessThan:
+			return nil, fmt.Errorf("%q isn't supported in label selectors", req.Operator())
+		default:
+			return nil, fmt.Errorf("%q is not a valid label selector operator", req.Operator())
+		}
+		labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, metav1.LabelSelectorRequirement{
+			Key:      req.Key(),
+			Operator: op,
+			Values:   req.Values().List(),
+		})
+	}
+	return labelSelector, nil
+}

--- a/pkg/cmd/util/flag/label_selector_test.go
+++ b/pkg/cmd/util/flag/label_selector_test.go
@@ -6,10 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestStringOfLabelSelector(t *testing.T) {
-	ls, err := metav1.ParseToLabelSelector("k1=v1,k2=v2")
+	ls, err := parseToLabelSelector("k1=v1,k2=v2")
 	require.NoError(t, err)
 	selector := &LabelSelector{
 		LabelSelector: ls,
@@ -21,10 +22,69 @@ func TestSetOfLabelSelector(t *testing.T) {
 	selector := &LabelSelector{}
 	require.NoError(t, selector.Set("k1=v1,k2=v2"))
 	str := selector.String()
-	assert.True(t, str == "k1=v1,k2=v2" || str == "k2=v2,k2=v2")
+	assert.True(t, str == "k1=v1,k2=v2" || str == "k2=v2,k1=v1")
 }
 
 func TestTypeOfLabelSelector(t *testing.T) {
 	selector := &LabelSelector{}
 	assert.Equal(t, "labelSelector", selector.Type())
+}
+
+func TestSetOfLabelSelectorNotEquals(t *testing.T) {
+	// Reproduces https://github.com/velero-io/velero/issues/4724:
+	// metav1.ParseToLabelSelector rejects "!=", but kubectl / labels.Parse accept it.
+	selector := &LabelSelector{}
+	require.NoError(t, selector.Set("for!=1"))
+	require.NotNil(t, selector.LabelSelector)
+	require.Len(t, selector.LabelSelector.MatchExpressions, 1)
+	expr := selector.LabelSelector.MatchExpressions[0]
+	assert.Equal(t, "for", expr.Key)
+	assert.Equal(t, metav1.LabelSelectorOpNotIn, expr.Operator)
+	assert.Equal(t, []string{"1"}, expr.Values)
+
+	as, err := metav1.LabelSelectorAsSelector(selector.LabelSelector)
+	require.NoError(t, err)
+	assert.False(t, as.Matches(labels.Set{"for": "1"}))
+	assert.True(t, as.Matches(labels.Set{"for": "2"}))
+	assert.True(t, as.Matches(labels.Set{}))
+}
+
+func TestSetOfOrLabelSelectorNotEquals(t *testing.T) {
+	selector := &OrLabelSelector{}
+	require.NoError(t, selector.Set("env!=prod or tier=frontend"))
+	require.Len(t, selector.OrLabelSelectors, 2)
+
+	as0, err := metav1.LabelSelectorAsSelector(selector.OrLabelSelectors[0])
+	require.NoError(t, err)
+	assert.False(t, as0.Matches(labels.Set{"env": "prod"}))
+	assert.True(t, as0.Matches(labels.Set{"env": "dev"}))
+
+	as1, err := metav1.LabelSelectorAsSelector(selector.OrLabelSelectors[1])
+	require.NoError(t, err)
+	assert.True(t, as1.Matches(labels.Set{"tier": "frontend"}))
+	assert.False(t, as1.Matches(labels.Set{"tier": "backend"}))
+}
+
+func TestParseToLabelSelectorSupportsCommonOperators(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "equals", input: "a=b"},
+		{name: "double equals", input: "a==b"},
+		{name: "not equals", input: "a!=b"},
+		{name: "in", input: "a in (b,c)"},
+		{name: "notin", input: "a notin (b,c)"},
+		{name: "exists", input: "a"},
+		{name: "does not exist", input: "!a"},
+		{name: "mixed with not equals", input: "a!=b,c=d"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ls, err := parseToLabelSelector(tc.input)
+			require.NoError(t, err)
+			_, err = metav1.LabelSelectorAsSelector(ls)
+			require.NoError(t, err)
+		})
+	}
 }

--- a/pkg/cmd/util/flag/labelselector.go
+++ b/pkg/cmd/util/flag/labelselector.go
@@ -36,7 +36,7 @@ func (ls *LabelSelector) String() string {
 // to the label-selector receiver. It returns an error if
 // the string is not parseable.
 func (ls *LabelSelector) Set(s string) error {
-	parsed, err := metav1.ParseToLabelSelector(s)
+	parsed, err := parseToLabelSelector(s)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/util/flag/orlabelselector.go
+++ b/pkg/cmd/util/flag/orlabelselector.go
@@ -45,7 +45,7 @@ func (ls *OrLabelSelector) Set(s string) error {
 	orItems := strings.Split(s, " or ")
 	ls.OrLabelSelectors = make([]*metav1.LabelSelector, 0)
 	for _, orItem := range orItems {
-		parsed, err := metav1.ParseToLabelSelector(orItem)
+		parsed, err := parseToLabelSelector(orItem)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Fixes #4724.

`velero backup create --selector key!=value` failed because `metav1.ParseToLabelSelector` rejects the `!=` operator, even though kubectl and `labels.Parse` accept it.

The CLI now parses selectors with the same operators as kubectl and maps `!=` to `NotIn` when storing a `metav1.LabelSelector` on the Backup/Restore.

## Checklist

- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Created a changelog file (`make new-changelog`) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.

Documentation update not required. Behavior now matches kubectl label selector syntax for `!=`.

## Test plan

- [x] Unit tests cover `for!=1` on `--selector` and `env!=prod or tier=frontend` on `--or-selector`
- [x] Existing equals / in / notin / exists cases still parse
- [ ] Manual: `velero backup create test --selector for!=1 -o yaml` shows MatchExpressions with operator NotIn
