### PR TITLE
Replace CSI snapshot handle polling with watch when available

### DIFF
--- a/changelogs/unreleased/10249-Pragati5-DEBUG
+++ b/changelogs/unreleased/10249-Pragati5-DEBUG
@@ -1,0 +1,1 @@
+Replace CSI snapshot handle early frequent polling with Kubernetes watch when available, reducing apiserver GET traffic while preserving VSS timeout behavior.

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -74,7 +74,7 @@ const (
 // pvcBackupItemAction is a backup item action plugin for Velero.
 type pvcBackupItemAction struct {
 	log      logrus.FieldLogger
-	crClient crclient.Client
+	crClient crclient.WithWatch
 
 	// pvcPodCache provides lazy per-namespace caching of PVC-to-Pod mappings.
 	// Since plugin instances are unique per backup (created via newPluginManager and
@@ -684,7 +684,7 @@ func cancelDataUpload(
 
 func NewPvcBackupItemAction(f veleroclient.Factory) plugincommon.HandlerInitializer {
 	return func(logger logrus.FieldLogger) (any, error) {
-		crClient, err := f.KubebuilderClient()
+		crClient, err := f.KubebuilderWatchClient()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/pkg/backup/actions/csi/pvc_action_test.go
+++ b/pkg/backup/actions/csi/pvc_action_test.go
@@ -63,7 +63,7 @@ const testDriver = "csi.example.com"
 // errorInjectingClient is a wrapper around a normal client that injects an error
 // when a specific resource type (VolumeSnapshot) is created.
 type errorInjectingClient struct {
-	crclient.Client
+	crclient.WithWatch
 }
 
 // Create overrides the embedded client's Create method.
@@ -74,7 +74,7 @@ func (c *errorInjectingClient) Create(ctx context.Context, obj crclient.Object, 
 		return errors.New("injected error on create")
 	}
 	// For all other object types, call the original, embedded Create method.
-	return c.Client.Create(ctx, obj, opts...)
+	return c.WithWatch.Create(ctx, obj, opts...)
 }
 
 func TestExecute(t *testing.T) {
@@ -252,12 +252,12 @@ func TestExecute(t *testing.T) {
 			}
 			objects = append(objects, tc.extraObjects...)
 
-			var crClient crclient.Client
+			var crClient crclient.WithWatch
 			if tc.failVSCreate {
-				realFakeClient := velerotest.NewFakeControllerRuntimeClient(t, objects...)
-				crClient = &errorInjectingClient{Client: realFakeClient}
+				realFakeClient := velerotest.NewFakeControllerRuntimeWatchClient(t, objects...)
+				crClient = &errorInjectingClient{WithWatch: realFakeClient}
 			} else {
-				crClient = velerotest.NewFakeControllerRuntimeClient(t, objects...)
+				crClient = velerotest.NewFakeControllerRuntimeWatchClient(t, objects...)
 			}
 
 			pvcBIA := pvcBackupItemAction{
@@ -435,7 +435,7 @@ func TestProgress(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			crClient := velerotest.NewFakeControllerRuntimeClient(t)
+			crClient := velerotest.NewFakeControllerRuntimeWatchClient(t)
 			logger := logrus.New()
 
 			pvcBIA := pvcBackupItemAction{
@@ -529,7 +529,7 @@ func TestCancel(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			crClient := velerotest.NewFakeControllerRuntimeClient(t)
+			crClient := velerotest.NewFakeControllerRuntimeWatchClient(t)
 			logger := logrus.New()
 
 			pvcBIA := pvcBackupItemAction{
@@ -577,16 +577,16 @@ func TestPVCAppliesTo(t *testing.T) {
 
 func TestNewPVCBackupItemAction(t *testing.T) {
 	logger := logrus.StandardLogger()
-	crClient := velerotest.NewFakeControllerRuntimeClient(t)
+	crClient := velerotest.NewFakeControllerRuntimeWatchClient(t)
 
 	f := &factorymocks.Factory{}
-	f.On("KubebuilderClient").Return(nil, fmt.Errorf(""))
+	f.On("KubebuilderWatchClient").Return(nil, fmt.Errorf(""))
 	plugin := NewPvcBackupItemAction(f)
 	_, err := plugin(logger)
 	require.Error(t, err)
 
 	f1 := &factorymocks.Factory{}
-	f1.On("KubebuilderClient").Return(crClient, nil)
+	f1.On("KubebuilderWatchClient").Return(crClient, nil)
 	plugin1 := NewPvcBackupItemAction(f1)
 	_, err1 := plugin1(logger)
 	require.NoError(t, err1)
@@ -685,7 +685,7 @@ func TestListGroupedPVCs(t *testing.T) {
 			for i := range tt.pvcs {
 				objs = append(objs, &tt.pvcs[i])
 			}
-			client := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+			client := velerotest.NewFakeControllerRuntimeWatchClient(t, objs...)
 
 			action := &pvcBackupItemAction{
 				log:      logrus.New(),
@@ -925,7 +925,7 @@ volumePolicies:
 				objs = append(objs, &tt.pvs[i])
 			}
 
-			client := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+			client := velerotest.NewFakeControllerRuntimeWatchClient(t, objs...)
 
 			backup := &velerov1api.Backup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1034,7 +1034,7 @@ func TestFilterPVCsByVolumePolicyWithVolumeHelper(t *testing.T) {
 	for i := range pvs {
 		objs = append(objs, &pvs[i])
 	}
-	client := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+	client := velerotest.NewFakeControllerRuntimeWatchClient(t, objs...)
 
 	// Create backup with volume policy that skips NFS volumes
 	volumePolicyStr := `
@@ -1216,7 +1216,7 @@ func TestDetermineCSIDriver(t *testing.T) {
 				initObjs = append(initObjs, &pv)
 			}
 
-			client := velerotest.NewFakeControllerRuntimeClient(t, initObjs...)
+			client := velerotest.NewFakeControllerRuntimeWatchClient(t, initObjs...)
 			action := &pvcBackupItemAction{
 				log:      logrus.New(),
 				crClient: client,
@@ -1319,7 +1319,7 @@ func TestDetermineVGSClass(t *testing.T) {
 				initObjs = append(initObjs, &vgsClassCopy)
 			}
 
-			client := velerotest.NewFakeControllerRuntimeClient(t, initObjs...)
+			client := velerotest.NewFakeControllerRuntimeWatchClient(t, initObjs...)
 			logger := logrus.New()
 			require.NoError(t, volumegroupsnapshotv1beta2.AddToScheme(client.Scheme()))
 
@@ -1358,7 +1358,7 @@ func TestCreateVolumeGroupSnapshot(t *testing.T) {
 		},
 	}
 
-	crClient := velerotest.NewFakeControllerRuntimeClient(t)
+	crClient := velerotest.NewFakeControllerRuntimeWatchClient(t)
 	log := logrus.New()
 	action := &pvcBackupItemAction{
 		log:      log,
@@ -1514,7 +1514,7 @@ func TestWaitForVGSAssociatedVS(t *testing.T) {
 				objs = append(objs, &pvc)
 			}
 
-			client := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+			client := velerotest.NewFakeControllerRuntimeWatchClient(t, objs...)
 			action := &pvcBackupItemAction{
 				log:      velerotest.NewLogger(),
 				crClient: client,
@@ -1613,7 +1613,7 @@ func TestUpdateVGSCreatedVS(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := velerotest.NewFakeControllerRuntimeClient(t, vgs, tt.vs)
+			client := velerotest.NewFakeControllerRuntimeWatchClient(t, vgs, tt.vs)
 			action := &pvcBackupItemAction{
 				log:      velerotest.NewLogger(),
 				crClient: client,
@@ -1694,7 +1694,7 @@ func TestPatchVGSCDeletionPolicy(t *testing.T) {
 				},
 			}
 
-			client := velerotest.NewFakeControllerRuntimeClient(t, vgs, vgsc)
+			client := velerotest.NewFakeControllerRuntimeWatchClient(t, vgs, vgsc)
 			action := &pvcBackupItemAction{
 				log:      velerotest.NewLogger(),
 				crClient: client,
@@ -1774,7 +1774,7 @@ func TestDeleteVGSAndVGSC(t *testing.T) {
 				objs = append(objs, tt.existingVGSC)
 			}
 
-			client := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+			client := velerotest.NewFakeControllerRuntimeWatchClient(t, objs...)
 			action := &pvcBackupItemAction{
 				log:      velerotest.NewLogger(),
 				crClient: client,
@@ -1866,7 +1866,7 @@ func TestFindExistingVSForBackup(t *testing.T) {
 				objs = append(objs, vs)
 			}
 
-			client := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+			client := velerotest.NewFakeControllerRuntimeWatchClient(t, objs...)
 			action := &pvcBackupItemAction{
 				log:      velerotest.NewLogger(),
 				crClient: client,
@@ -1921,7 +1921,7 @@ func TestWaitForVGSCBinding(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := velerotest.NewFakeControllerRuntimeClient(t, tt.vgs.DeepCopy())
+			client := velerotest.NewFakeControllerRuntimeWatchClient(t, tt.vgs.DeepCopy())
 
 			action := &pvcBackupItemAction{
 				log:      velerotest.NewLogger(),
@@ -1992,12 +1992,14 @@ func TestGetVGSByLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var client crclient.Client
+			var client crclient.WithWatch
 			if tt.name == "client list error" {
 				// Inject a client that always errors on List
-				client = &failingClient{}
+				client = &failingClient{
+					WithWatch: velerotest.NewFakeControllerRuntimeWatchClient(t),
+				}
 			} else {
-				client = velerotest.NewFakeControllerRuntimeClient(t, tt.vgsObjects...)
+				client = velerotest.NewFakeControllerRuntimeWatchClient(t, tt.vgsObjects...)
 			}
 
 			action := &pvcBackupItemAction{
@@ -2025,7 +2027,7 @@ func TestGetVGSByLabels(t *testing.T) {
 
 // failingClient is a dummy client that fails on List
 type failingClient struct {
-	crclient.Client
+	crclient.WithWatch
 }
 
 func (f *failingClient) List(ctx context.Context, list crclient.ObjectList, opts ...crclient.ListOption) error {
@@ -2193,7 +2195,7 @@ func TestPVCRequestSize(t *testing.T) {
 // cleaned up via CleanupClients at backup completion), we verify that the pvcPodCache
 // is properly initialized and reused across calls.
 func TestGetOrCreateVolumeHelper(t *testing.T) {
-	client := velerotest.NewFakeControllerRuntimeClient(t)
+	client := velerotest.NewFakeControllerRuntimeWatchClient(t)
 	action := &pvcBackupItemAction{
 		log:      velerotest.NewLogger(),
 		crClient: client,

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -33,9 +33,11 @@ import (
 	corev1api "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -47,6 +49,8 @@ import (
 const (
 	waitInternal                          = 2 * time.Second
 	volumeSnapshotContentProtectFinalizer = "velero.io/volume-snapshot-content-protect-finalizer"
+	earlyFrequentPollingTimeout           = 10 * time.Second
+	defaultVSCHandlePollInterval          = 5 * time.Second
 )
 
 // WaitVolumeSnapshotReady waits a VS to become ready to use until the timeout reaches
@@ -631,94 +635,263 @@ func DeleteReadyVolumeSnapshot(
 	}
 }
 
-// WaitUntilVSCHandleIsReady returns the VolumeSnapshotContent
-// object associated with the volumesnapshot
-func WaitUntilVSCHandleIsReady(
-	volSnap *snapshotv1api.VolumeSnapshot,
+func earlyFrequentPollingEnabled() bool {
+	frequentPolling, err := strconv.ParseBool(os.Getenv("CSI_SNAPSHOT_EARLY_FREQUENT_POLLING"))
+	return err == nil && frequentPolling
+}
+
+// tryPopulateVSCHandle loads the VolumeSnapshotContent for volSnap when its
+// snapshot handle is ready.
+func tryPopulateVSCHandle(
+	ctx context.Context,
 	crClient crclient.Client,
+	volSnap *snapshotv1api.VolumeSnapshot,
+	vsc *snapshotv1api.VolumeSnapshotContent,
+	log logrus.FieldLogger,
+	retryInterval time.Duration,
+) (bool, error) {
+	vs := new(snapshotv1api.VolumeSnapshot)
+	if err := crClient.Get(
+		ctx,
+		crclient.ObjectKeyFromObject(volSnap),
+		vs,
+	); err != nil {
+		return false,
+			errors.Wrapf(
+				err,
+				"failed to get volumesnapshot %s/%s",
+				volSnap.Namespace, volSnap.Name,
+			)
+	}
+
+	if vs.Status == nil || vs.Status.BoundVolumeSnapshotContentName == nil {
+		if retryInterval > 0 {
+			log.Infof("Waiting for CSI driver to reconcile volumesnapshot %s/%s. Retrying in %ds",
+				volSnap.Namespace, volSnap.Name, retryInterval/time.Second)
+		} else {
+			log.Infof("Waiting for CSI driver to reconcile volumesnapshot %s/%s",
+				volSnap.Namespace, volSnap.Name)
+		}
+		return false, nil
+	}
+
+	if err := crClient.Get(
+		ctx,
+		crclient.ObjectKey{
+			Name: *vs.Status.BoundVolumeSnapshotContentName,
+		},
+		vsc,
+	); err != nil {
+		return false,
+			errors.Wrapf(
+				err,
+				"failed to get VolumeSnapshotContent %s for VolumeSnapshot %s/%s",
+				*vs.Status.BoundVolumeSnapshotContentName, vs.Namespace, vs.Name,
+			)
+	}
+
+	// we need to wait for the VolumeSnapshotContent
+	// to have a snapshot handle because during restore,
+	// we'll use that snapshot handle as the source for
+	// the VolumeSnapshotContent so it's statically
+	// bound to the existing snapshot.
+	if vsc.Status == nil ||
+		vsc.Status.SnapshotHandle == nil {
+		if retryInterval > 0 {
+			log.Infof(
+				"Waiting for VolumeSnapshotContents %s to have snapshot handle. Retrying in %ds",
+				vsc.Name, retryInterval/time.Second)
+		} else {
+			log.Infof(
+				"Waiting for VolumeSnapshotContents %s to have snapshot handle",
+				vsc.Name)
+		}
+		if vsc.Status != nil &&
+			vsc.Status.Error != nil {
+			log.Warnf("VolumeSnapshotContent %s has error: %v",
+				vsc.Name, *vsc.Status.Error.Message)
+		}
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func finalizeVSCHandleWaitError(
+	err error,
+	volSnap *snapshotv1api.VolumeSnapshot,
+	vsc *snapshotv1api.VolumeSnapshotContent,
+	log logrus.FieldLogger,
+) error {
+	if err == nil {
+		return nil
+	}
+	if wait.Interrupted(err) {
+		if vsc != nil &&
+			vsc.Status != nil &&
+			vsc.Status.Error != nil {
+			log.Errorf(
+				"Timed out awaiting reconciliation of VolumeSnapshot, VolumeSnapshotContent %s has error: %v",
+				vsc.Name, *vsc.Status.Error.Message)
+			// Wrap the original interrupted error so callers can still detect
+			// timeout via wait.Interrupted and avoid falling back to polling.
+			return errors.Wrapf(err, "CSI got timed out with error: %v",
+				*vsc.Status.Error.Message)
+		}
+		log.Errorf(
+			"Timed out awaiting reconciliation of volumesnapshot %s/%s",
+			volSnap.Namespace, volSnap.Name)
+	}
+	return err
+}
+
+func watchUntilVSCHandleReady(
+	ctx context.Context,
+	watchClient crclient.WithWatch,
+	crClient crclient.Client,
+	volSnap *snapshotv1api.VolumeSnapshot,
+	vsc *snapshotv1api.VolumeSnapshotContent,
+	log logrus.FieldLogger,
+) error {
+	if ready, err := tryPopulateVSCHandle(ctx, crClient, volSnap, vsc, log, 0); ready || err != nil {
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	vsList := &snapshotv1api.VolumeSnapshotList{}
+	vsWatch, err := watchClient.Watch(ctx, vsList, &crclient.ListOptions{
+		Namespace: volSnap.Namespace,
+		FieldSelector: fields.OneTermEqualSelector(
+			"metadata.name", volSnap.Name),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to watch VolumeSnapshot")
+	}
+	defer vsWatch.Stop()
+
+	var boundVSCName string
+	for boundVSCName == "" {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event, ok := <-vsWatch.ResultChan():
+			if !ok {
+				return errors.New("VolumeSnapshot watch channel closed")
+			}
+			switch event.Type {
+			case watch.Deleted:
+				return errors.Errorf("VolumeSnapshot %s/%s was deleted",
+					volSnap.Namespace, volSnap.Name)
+			case watch.Error:
+				return errors.Errorf("VolumeSnapshot watch error: %v", event.Object)
+			default:
+				vs := new(snapshotv1api.VolumeSnapshot)
+				if err := crClient.Get(
+					ctx,
+					crclient.ObjectKeyFromObject(volSnap),
+					vs,
+				); err != nil {
+					return errors.Wrapf(
+						err,
+						"failed to get volumesnapshot %s/%s",
+						volSnap.Namespace, volSnap.Name,
+					)
+				}
+				if vs.Status != nil &&
+					vs.Status.BoundVolumeSnapshotContentName != nil {
+					boundVSCName = *vs.Status.BoundVolumeSnapshotContentName
+				}
+			}
+		}
+	}
+
+	if ready, err := tryPopulateVSCHandle(ctx, crClient, volSnap, vsc, log, 0); ready || err != nil {
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	vscList := &snapshotv1api.VolumeSnapshotContentList{}
+	vscWatch, err := watchClient.Watch(ctx, vscList, &crclient.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", boundVSCName),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to watch VolumeSnapshotContent")
+	}
+	defer vscWatch.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event, ok := <-vscWatch.ResultChan():
+			if !ok {
+				return errors.New("VolumeSnapshotContent watch channel closed")
+			}
+			switch event.Type {
+			case watch.Deleted:
+				return errors.Errorf("VolumeSnapshotContent %s was deleted", boundVSCName)
+			case watch.Error:
+				return errors.Errorf("VolumeSnapshotContent watch error: %v", event.Object)
+			default:
+				if ready, err := tryPopulateVSCHandle(
+					ctx, crClient, volSnap, vsc, log, 0,
+				); ready {
+					return nil
+				} else if err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+func waitUntilVSCHandleIsReadyWithWatch(
+	watchClient crclient.WithWatch,
+	crClient crclient.Client,
+	volSnap *snapshotv1api.VolumeSnapshot,
 	log logrus.FieldLogger,
 	csiSnapshotTimeout time.Duration,
 ) (*snapshotv1api.VolumeSnapshotContent, error) {
-	// We'll wait for the VSC to be reconciled, trying a fast poll interval first
-	// before falling back to a slower poll interval for the full csiSnapshotTimeout.
+	ctx, cancel := context.WithTimeout(context.Background(), csiSnapshotTimeout)
+	defer cancel()
+
+	vsc := new(snapshotv1api.VolumeSnapshotContent)
+	err := watchUntilVSCHandleReady(ctx, watchClient, crClient, volSnap, vsc, log)
+	if err != nil {
+		return nil, finalizeVSCHandleWaitError(err, volSnap, vsc, log)
+	}
+	return vsc, nil
+}
+
+func waitUntilVSCHandleIsReadyWithPoll(
+	crClient crclient.Client,
+	volSnap *snapshotv1api.VolumeSnapshot,
+	log logrus.FieldLogger,
+	csiSnapshotTimeout time.Duration,
+) (*snapshotv1api.VolumeSnapshotContent, error) {
 	vsc := new(snapshotv1api.VolumeSnapshotContent)
 	var interval time.Duration
 
 	pollFunc := func(ctx context.Context) (bool, error) {
-		vs := new(snapshotv1api.VolumeSnapshot)
-		if err := crClient.Get(
-			ctx,
-			crclient.ObjectKeyFromObject(volSnap),
-			vs,
-		); err != nil {
-			return false,
-				errors.Wrapf(
-					err,
-					"failed to get volumesnapshot %s/%s",
-					volSnap.Namespace, volSnap.Name,
-				)
-		}
-
-		if vs.Status == nil || vs.Status.BoundVolumeSnapshotContentName == nil {
-			log.Infof("Waiting for CSI driver to reconcile volumesnapshot %s/%s. Retrying in %ds",
-				volSnap.Namespace, volSnap.Name, interval/time.Second)
-			return false, nil
-		}
-
-		if err := crClient.Get(
-			ctx,
-			crclient.ObjectKey{
-				Name: *vs.Status.BoundVolumeSnapshotContentName,
-			},
-			vsc,
-		); err != nil {
-			return false,
-				errors.Wrapf(
-					err,
-					"failed to get VolumeSnapshotContent %s for VolumeSnapshot %s/%s",
-					*vs.Status.BoundVolumeSnapshotContentName, vs.Namespace, vs.Name,
-				)
-		}
-
-		// we need to wait for the VolumeSnapshotContent
-		// to have a snapshot handle because during restore,
-		// we'll use that snapshot handle as the source for
-		// the VolumeSnapshotContent so it's statically
-		// bound to the existing snapshot.
-		if vsc.Status == nil ||
-			vsc.Status.SnapshotHandle == nil {
-			log.Infof(
-				"Waiting for VolumeSnapshotContents %s to have snapshot handle. Retrying in %ds",
-				vsc.Name, interval/time.Second)
-			if vsc.Status != nil &&
-				vsc.Status.Error != nil {
-				log.Warnf("VolumeSnapshotContent %s has error: %v",
-					vsc.Name, *vsc.Status.Error.Message)
-			}
-			return false, nil
-		}
-
-		return true, nil
+		return tryPopulateVSCHandle(ctx, crClient, volSnap, vsc, log, interval)
 	}
 
-	var err error
-	frequentPolling, err := strconv.ParseBool(os.Getenv("CSI_SNAPSHOT_EARLY_FREQUENT_POLLING"))
-
-	if err == nil && frequentPolling {
+	if earlyFrequentPollingEnabled() {
 		// The short interval for the first ten seconds is due to the fact that
 		// Microsoft VSS backups have a hard-coded unfreeze call after 10 seconds,
 		// so we need to minimize waiting time during the first 10 seconds.
-		// First poll with a short interval and timeout.
 		interval = 1 * time.Second
-		timeout := 10 * time.Second
-		err = wait.PollUntilContextTimeout(
+		err := wait.PollUntilContextTimeout(
 			context.Background(),
 			interval,
-			timeout,
+			earlyFrequentPollingTimeout,
 			true,
 			pollFunc,
 		)
-
 		if err == nil {
 			return vsc, nil
 		}
@@ -727,37 +900,65 @@ func WaitUntilVSCHandleIsReady(
 		}
 	}
 
-	// If the first poll timed out, poll with a longer interval and the full timeout.
-	interval = 5 * time.Second
-	err = wait.PollUntilContextTimeout(
+	interval = defaultVSCHandlePollInterval
+	err := wait.PollUntilContextTimeout(
 		context.Background(),
 		interval,
 		csiSnapshotTimeout,
 		true,
 		pollFunc,
 	)
-
 	if err != nil {
-		if wait.Interrupted(err) {
-			if vsc != nil &&
-				vsc.Status != nil &&
-				vsc.Status.Error != nil {
-				log.Errorf(
-					"Timed out awaiting reconciliation of VolumeSnapshot, VolumeSnapshotContent %s has error: %v",
-					vsc.Name, *vsc.Status.Error.Message)
-				return nil,
-					errors.Errorf("CSI got timed out with error: %v",
-						*vsc.Status.Error.Message)
-			} else {
-				log.Errorf(
-					"Timed out awaiting reconciliation of volumesnapshot %s/%s",
-					volSnap.Namespace, volSnap.Name)
-			}
+		return nil, finalizeVSCHandleWaitError(err, volSnap, vsc, log)
+	}
+	return vsc, nil
+}
+
+// WaitUntilVSCHandleIsReady returns the VolumeSnapshotContent
+// object associated with the volumesnapshot.
+func WaitUntilVSCHandleIsReady(
+	volSnap *snapshotv1api.VolumeSnapshot,
+	crClient crclient.Client,
+	log logrus.FieldLogger,
+	csiSnapshotTimeout time.Duration,
+) (*snapshotv1api.VolumeSnapshotContent, error) {
+	if watchClient, ok := crClient.(crclient.WithWatch); ok {
+		vsc, err := waitUntilVSCHandleIsReadyWithWatch(
+			watchClient,
+			crClient,
+			volSnap,
+			log,
+			csiSnapshotTimeout,
+		)
+		if err == nil {
+			return vsc, nil
 		}
-		return nil, err
+		// Do not fall back to polling on timeout or other permanent failures.
+		// Falling back after a timeout would approximately double the wait.
+		if wait.Interrupted(err) || isPermanentVSCHandleWaitError(err) {
+			return nil, err
+		}
+		log.Debugf(
+			"Watch-based wait for VolumeSnapshot %s/%s failed, falling back to polling: %v",
+			volSnap.Namespace, volSnap.Name, err,
+		)
 	}
 
-	return vsc, nil
+	return waitUntilVSCHandleIsReadyWithPoll(
+		crClient,
+		volSnap,
+		log,
+		csiSnapshotTimeout,
+	)
+}
+
+func isPermanentVSCHandleWaitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "was deleted") ||
+		strings.Contains(msg, "watch error:")
 }
 
 func DiagnoseVS(vs *snapshotv1api.VolumeSnapshot, events *corev1api.EventList) string {

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csi
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientTesting "k8s.io/client-go/testing"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -1730,7 +1732,7 @@ func TestWaitUntilVSCHandleIsReady(t *testing.T) {
 		vscWithNilStatusField,
 		vsForNilStatusFieldVsc,
 	}
-	fakeClient := velerotest.NewFakeControllerRuntimeClient(t, objs...)
+	fakeClient := velerotest.NewFakeControllerRuntimeWatchClient(t, objs...)
 	testCases := []struct {
 		name        string
 		volSnap     *snapshotv1api.VolumeSnapshot
@@ -1776,6 +1778,96 @@ func TestWaitUntilVSCHandleIsReady(t *testing.T) {
 			assert.Equal(t, tc.exepctedVSC, actualVSC)
 		})
 	}
+}
+
+func TestFinalizeVSCHandleWaitErrorPreservesInterrupted(t *testing.T) {
+	log := logrus.New()
+	volSnap := &snapshotv1api.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: "vs", Namespace: "default"},
+	}
+	errMsg := "snapshot failed"
+	vsc := &snapshotv1api.VolumeSnapshotContent{
+		ObjectMeta: metav1.ObjectMeta{Name: "vsc"},
+		Status: &snapshotv1api.VolumeSnapshotContentStatus{
+			Error: &snapshotv1api.VolumeSnapshotError{Message: &errMsg},
+		},
+	}
+
+	err := finalizeVSCHandleWaitError(context.DeadlineExceeded, volSnap, vsc, log)
+	require.Error(t, err)
+	assert.True(t, wait.Interrupted(err), "timeout with VSC error must remain Interrupted so callers do not fall back to polling")
+	assert.Contains(t, err.Error(), "CSI got timed out with error")
+}
+
+func TestWaitUntilVSCHandleIsReadyWatchPathEventuallyReady(t *testing.T) {
+	vscName := "watch-vsc"
+	snapshotHandle := "watch-handle"
+	vs := &snapshotv1api.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "watch-vs",
+			Namespace: "default",
+		},
+		Status: &snapshotv1api.VolumeSnapshotStatus{},
+	}
+	client := velerotest.NewFakeControllerRuntimeWatchClient(t, vs)
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+
+		vsc := &snapshotv1api.VolumeSnapshotContent{
+			ObjectMeta: metav1.ObjectMeta{Name: vscName},
+			Status: &snapshotv1api.VolumeSnapshotContentStatus{
+				SnapshotHandle: &snapshotHandle,
+			},
+		}
+		require.NoError(t, client.Create(context.Background(), vsc))
+
+		updatedVS := vs.DeepCopy()
+		updatedVS.Status = &snapshotv1api.VolumeSnapshotStatus{
+			BoundVolumeSnapshotContentName: &vscName,
+		}
+		require.NoError(t, client.Update(context.Background(), updatedVS))
+	}()
+
+	got, err := WaitUntilVSCHandleIsReady(
+		vs,
+		client,
+		logrus.New().WithField("fake", "test"),
+		5*time.Second,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Status)
+	require.NotNil(t, got.Status.SnapshotHandle)
+	assert.Equal(t, snapshotHandle, *got.Status.SnapshotHandle)
+}
+
+func TestWaitUntilVSCHandleIsReadyWatchTimeoutDoesNotFallBack(t *testing.T) {
+	vs := &snapshotv1api.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "timeout-vs",
+			Namespace: "default",
+		},
+		Status: &snapshotv1api.VolumeSnapshotStatus{},
+	}
+	client := velerotest.NewFakeControllerRuntimeWatchClient(t, vs)
+	timeout := 300 * time.Millisecond
+
+	start := time.Now()
+	got, err := WaitUntilVSCHandleIsReady(
+		vs,
+		client,
+		logrus.New().WithField("fake", "test"),
+		timeout,
+	)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.True(t, wait.Interrupted(err))
+	// If the watch timeout incorrectly fell back to another full poll wait,
+	// elapsed would be closer to 2x timeout.
+	assert.Less(t, elapsed, timeout+500*time.Millisecond)
 }
 
 func TestDiagnoseVS(t *testing.T) {


### PR DESCRIPTION
### Summary
Replace CSI VolumeSnapshotContent handle readiness polling with Kubernetes watch when a WithWatch client is available, reducing apiserver GET traffic during CSI backups.

WaitUntilVSCHandleIsReady now:

Tries a watch-based wait on VolumeSnapshot, then VolumeSnapshotContent
Falls back to polling if watch is unavailable or fails (except on timeout)
Preserves existing VSS behavior via CSI_SNAPSHOT_EARLY_FREQUENT_POLLING (1s polling for the first 10s, then 5s intervals)
The PVC backup item action is updated to use KubebuilderWatchClient() so the watch path is used in production.

### Does your change fix a particular issue?
Fixes #9956

### Changes
Refactor WaitUntilVSCHandleIsReady into tryPopulateVSCHandle, watchUntilVSCHandleReady, and poll/watch wrappers
Switch pvcBackupItemAction client from crclient.Client to crclient.WithWatch
Update unit tests to use NewFakeControllerRuntimeWatchClient

### Testing

1.  go test ./pkg/util/csi/... ./pkg/backup/actions/csi/...

### Checklist

 [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.

 [Created a changelog file (make new-changelog)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment /kind changelog-not-required on this PR.

 Updated the corresponding documentation in site/content/docs/main.