### PR TITLE
Refactor: Remove legacy resticrepositories hardcoding from restore controller

### DIFF
--- a/changelogs/unreleased/10253-ayush4958
+++ b/changelogs/unreleased/10253-ayush4958
@@ -1,0 +1,1 @@
+Remove deprecated resticrepositories.velero.io from default restore resources

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -79,12 +79,6 @@ var nonRestorableResources = []string{
 	// https://github.com/vmware-tanzu/velero/issues/622
 	"restores.velero.io",
 
-	// TODO: Remove this in v1.11 or v1.12
-	// Restic repositories are automatically managed by Velero and will be automatically
-	// created as needed if they don't exist.
-	// https://github.com/vmware-tanzu/velero/issues/1113
-	"resticrepositories.velero.io",
-
 	// CSINode delegates cluster node for CSI operation.
 	// VolumeAttachement records PV mounts to which node.
 	// https://github.com/vmware-tanzu/velero/issues/4823


### PR DESCRIPTION
# Please add a summary of your change

I had cleans up technical debt by removing the deprecated `resticrepositories.velero.io` hardcoding from the `defaultRestoreResources` exclusion list in `pkg/controller/restore_controller.go`.

# Does your change fix a particular issue?
NA, CleanUp

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
