### PR TITLE
Add configurable image-pull-policy flag to velero install

### DIFF
--- a/changelogs/unreleased/10268-sahilnyk
+++ b/changelogs/unreleased/10268-sahilnyk
@@ -1,0 +1,1 @@
+Add an --image-pull-policy flag to velero install, applying to the Velero server, node agent and plugin containers

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	corev1api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/vmware-tanzu/velero/internal/velero"
@@ -44,6 +45,7 @@ import (
 type Options struct {
 	Namespace                        string
 	Image                            string
+	ImagePullPolicy                  flag.Enum
 	BucketName                       string
 	Prefix                           string
 	ProviderName                     string
@@ -108,6 +110,7 @@ func (o *Options) BindFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.Apply, "apply", o.Apply, "Flag indicating if resources should be applied instead of created. This can be used for updating existing resources.")
 	flags.BoolVar(&o.NoDefaultBackupLocation, "no-default-backup-location", o.NoDefaultBackupLocation, "Flag indicating if a default backup location should be created. Must be used as confirmation if --bucket or --provider are not provided. Optional.")
 	flags.StringVar(&o.Image, "image", o.Image, "Image to use for the Velero and node agent pods. Optional.")
+	flags.Var(&o.ImagePullPolicy, "image-pull-policy", fmt.Sprintf("The imagePullPolicy for the Velero, node agent, and plugin containers. Valid values are %s. Optional, defaults to Always for images tagged \"latest\" and IfNotPresent otherwise.", strings.Join(o.ImagePullPolicy.AllowedValues(), ", ")))
 	flags.StringVar(&o.Prefix, "prefix", o.Prefix, "Prefix under which all Velero data should be stored within the bucket. Optional.")
 	flags.Var(&o.PodAnnotations, "pod-annotations", "Annotations to add to the Velero and node agent pods. Optional. Format is key1=value1,key2=value2")
 	flags.Var(&o.PodLabels, "pod-labels", "Labels to add to the Velero and node agent pods. Optional. Format is key1=value1,key2=value2")
@@ -233,6 +236,7 @@ func NewInstallOptions() *Options {
 	return &Options{
 		Namespace:                 velerov1api.DefaultNamespace,
 		Image:                     velero.DefaultVeleroImage(),
+		ImagePullPolicy:           *flag.NewEnum("", string(corev1api.PullAlways), string(corev1api.PullIfNotPresent), string(corev1api.PullNever)),
 		BackupStorageConfig:       flag.NewMap(),
 		VolumeSnapshotConfig:      flag.NewMap(),
 		PodAnnotations:            flag.NewMap(),
@@ -307,6 +311,7 @@ func (o *Options) AsVeleroOptions() (*install.VeleroOptions, error) {
 	return &install.VeleroOptions{
 		Namespace:                        o.Namespace,
 		Image:                            o.Image,
+		ImagePullPolicy:                  o.ImagePullPolicy.String(),
 		ProviderName:                     o.ProviderName,
 		Bucket:                           o.BucketName,
 		Prefix:                           o.Prefix,

--- a/pkg/cmd/cli/install/install_test.go
+++ b/pkg/cmd/cli/install/install_test.go
@@ -233,6 +233,36 @@ func TestValidateConfigMapsUseFactoryNamespace(t *testing.T) {
 	}
 }
 
+func TestImagePullPolicyFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		{name: "unset falls back to the image tag", want: ""},
+		{name: "valid value", args: []string{"--image-pull-policy", "Never"}, want: "Never"},
+		{name: "invalid value", args: []string{"--image-pull-policy", "sometimes"}, wantErr: true},
+		{name: "wrong case", args: []string{"--image-pull-policy", "always"}, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := NewInstallOptions()
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			o.BindFlags(flags)
+
+			err := flags.Parse(tc.args)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, o.ImagePullPolicy.String())
+		})
+	}
+}
+
 // TestNewCommandRunClosureOrder covers the Run closure in NewCommand (the lines that were
 // reordered by the fix: Complete → Validate → Run).
 //

--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -39,11 +39,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 		opt(c)
 	}
 
-	pullPolicy := corev1api.PullAlways
-	imageParts := strings.Split(c.image, ":")
-	if len(imageParts) == 2 && imageParts[1] != "latest" {
-		pullPolicy = corev1api.PullIfNotPresent
-	}
+	pullPolicy := resolveImagePullPolicy(c.image, c.imagePullPolicy)
 
 	daemonSetArgs := []string{
 		"node-agent",

--- a/pkg/install/daemonset_test.go
+++ b/pkg/install/daemonset_test.go
@@ -63,6 +63,9 @@ func TestDaemonSet(t *testing.T) {
 	assert.Equal(t, "velero/velero:v0.11", ds.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, corev1api.PullIfNotPresent, ds.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 
+	ds = DaemonSet("velero", WithImage("velero/velero:v0.11"), WithImagePullPolicy(string(corev1api.PullAlways)))
+	assert.Equal(t, corev1api.PullAlways, ds.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+
 	ds = DaemonSet("velero", WithSecret(true))
 	assert.Len(t, ds.Spec.Template.Spec.Containers[0].Env, 7)
 	assert.Len(t, ds.Spec.Template.Spec.Volumes, 4)

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -31,10 +31,24 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
 )
 
+// resolveImagePullPolicy returns pullPolicy if set, otherwise one based on the image tag.
+func resolveImagePullPolicy(image, pullPolicy string) corev1api.PullPolicy {
+	if pullPolicy != "" {
+		return corev1api.PullPolicy(pullPolicy)
+	}
+
+	imageParts := strings.Split(image, ":")
+	if len(imageParts) == 2 && imageParts[1] != "latest" {
+		return corev1api.PullIfNotPresent
+	}
+	return corev1api.PullAlways
+}
+
 type podTemplateOption func(*podTemplateConfig)
 
 type podTemplateConfig struct {
 	image                            string
+	imagePullPolicy                  string
 	envVars                          []corev1api.EnvVar
 	restoreOnly                      bool
 	annotations                      map[string]string
@@ -71,6 +85,12 @@ type podTemplateConfig struct {
 func WithImage(image string) podTemplateOption {
 	return func(c *podTemplateConfig) {
 		c.image = image
+	}
+}
+
+func WithImagePullPolicy(pullPolicy string) podTemplateOption {
+	return func(c *podTemplateConfig) {
+		c.imagePullPolicy = pullPolicy
 	}
 }
 
@@ -282,11 +302,7 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1api.Deployme
 		opt(c)
 	}
 
-	pullPolicy := corev1api.PullAlways
-	imageParts := strings.Split(c.image, ":")
-	if len(imageParts) == 2 && imageParts[1] != "latest" {
-		pullPolicy = corev1api.PullIfNotPresent
-	}
+	pullPolicy := resolveImagePullPolicy(c.image, c.imagePullPolicy)
 
 	args := []string{"server"}
 	if len(c.features) > 0 {

--- a/pkg/install/deployment_test.go
+++ b/pkg/install/deployment_test.go
@@ -44,6 +44,15 @@ func TestDeployment(t *testing.T) {
 	assert.Equal(t, "velero/velero:v0.11", deploy.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, corev1api.PullIfNotPresent, deploy.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 
+	// An explicit policy overrides the tag-based default, including plugin init containers.
+	deploy = Deployment("velero", WithImage("velero/velero:v0.11"), WithImagePullPolicy(string(corev1api.PullAlways)),
+		WithPlugins([]string{"velero/velero-plugin-for-aws:v1.12.0"}))
+	assert.Equal(t, corev1api.PullAlways, deploy.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+	assert.Equal(t, corev1api.PullAlways, deploy.Spec.Template.Spec.InitContainers[0].ImagePullPolicy)
+
+	deploy = Deployment("velero", WithImage("velero/velero:latest"), WithImagePullPolicy(string(corev1api.PullNever)))
+	assert.Equal(t, corev1api.PullNever, deploy.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+
 	deploy = Deployment("velero", WithSecret(true))
 	assert.Len(t, deploy.Spec.Template.Spec.Containers[0].Env, 7)
 	assert.Len(t, deploy.Spec.Template.Spec.Volumes, 3)

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -236,6 +236,7 @@ func appendUnstructured(list *unstructured.UnstructuredList, obj runtime.Object)
 type VeleroOptions struct {
 	Namespace                        string
 	Image                            string
+	ImagePullPolicy                  string
 	ProviderName                     string
 	Bucket                           string
 	Prefix                           string
@@ -354,6 +355,7 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 		WithAnnotations(o.PodAnnotations),
 		WithLabels(o.PodLabels),
 		WithImage(o.Image),
+		WithImagePullPolicy(o.ImagePullPolicy),
 		WithResources(o.VeleroPodResources),
 		WithSecret(secretPresent),
 		WithDefaultRepoMaintenanceFrequency(o.DefaultRepoMaintenanceFrequency),
@@ -423,6 +425,7 @@ func AllResources(o *VeleroOptions) *unstructured.UnstructuredList {
 			WithAnnotations(o.PodAnnotations),
 			WithLabels(o.PodLabels),
 			WithImage(o.Image),
+			WithImagePullPolicy(o.ImagePullPolicy),
 			WithResources(o.NodeAgentPodResources),
 			WithSecret(secretPresent),
 			WithServiceAccountName(serviceAccountName),

--- a/site/content/docs/main/velero-install.md
+++ b/site/content/docs/main/velero-install.md
@@ -33,13 +33,16 @@ velero install \
     [--maintenance-job-cpu-limit <CPU_LIMIT>] \
     [--maintenance-job-mem-limit <MEMORY_LIMIT>] \
     [--server-priority-class-name <PRIORITY_CLASS_NAME>] \
-    [--node-agent-priority-class-name <PRIORITY_CLASS_NAME>]
+    [--node-agent-priority-class-name <PRIORITY_CLASS_NAME>] \
+    [--image-pull-policy <IMAGE_PULL_POLICY>]
 ```
 
 The values for the resource requests and limits flags follow the same format as [Kubernetes resource requirements][3]
 For plugin container images, please refer to our [supported providers][2] page.
 
 The `--server-priority-class-name` and `--node-agent-priority-class-name` flags allow you to set priority classes for the Velero server deployment and node agent daemonset respectively. This can help ensure proper scheduling and eviction behavior in resource-constrained environments. Note that you must create the priority class before installing Velero.
+
+The `--image-pull-policy` flag sets the `imagePullPolicy` for the Velero server, node agent and plugin containers. Valid values are `Always`, `IfNotPresent` and `Never`. When the flag is not set, the policy defaults to `Always` for images tagged `latest` and `IfNotPresent` otherwise. Set it to `Always` if you rebuild a development image under a tag that is not `latest`, otherwise the node reuses the cached image and the new build never runs.
 
 ## Examples
 


### PR DESCRIPTION
Fixes #8457

Right now `velero install` decides the pull policy by looking at the image tag. If the tag is `latest` you get `Always`, otherwise you get `IfNotPresent`. There's no way to change it.

That's a problem if you rebuild a dev image under the same tag, which is what the issue describes. The tag isn't `latest`, so the node keeps serving the old image and your new build never runs.

## What this adds

`--image-pull-policy` on `velero install`, taking `Always`, `IfNotPresent` or `Never`. It covers the Velero server, the node agent and the plugin containers.

I reused `flag.Enum` for validation, since `velero plugin add` already uses it for a flag of the same name. Leaving the flag off keeps the current behavior, so existing installs are unaffected.

## Testing

- [x] Unit tests in `pkg/install` and `pkg/cmd/cli/install`
- [x] kind cluster with MinIO, installed with `--image-pull-policy Always`
- [x] Backup and restore both completed, no errors

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.