### PR TITLE
Remove PVC and PV inclusion check during creating PVR.

### DIFF
--- a/changelogs/unreleased/10269-blackpiglet
+++ b/changelogs/unreleased/10269-blackpiglet
@@ -1,0 +1,1 @@
+Remove PVC and PV inclusion check during creating PVR.

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -2072,10 +2072,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 			return warnings, errs, itemExists
 		}
 
-		// Do not create podvolumerestore when current restore excludes pv/pvc
-		if ctx.resourceIncludesExcludes.ShouldInclude(kuberesource.PersistentVolumeClaims.String()) &&
-			ctx.resourceIncludesExcludes.ShouldInclude(kuberesource.PersistentVolumes.String()) &&
-			len(podvolume.GetVolumeBackupsForPod(ctx.podVolumeBackups, pod, originalNamespace)) > 0 {
+		if len(podvolume.GetVolumeBackupsForPod(ctx.podVolumeBackups, pod, originalNamespace)) > 0 {
 			restorePodVolumeBackups(ctx, createdObj, originalNamespace)
 		}
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Removed the explicit exclusion checks for `PersistentVolumeClaims` (PVCs) and `PersistentVolumes` (PVs) in `pkg/restore/restore.go` that wrapped the `restorePodVolumeBackups` call. 

The logic was reverted to simply check if there are volume backups for the pod (`len(podvolume.GetVolumeBackupsForPod(...)) > 0`) before proceeding to create `PodVolumeRestore` (PVR) resources.

### Reason for the Change
The removed check was originally introduced in **PR #4769** to fix **Issue #4754**. In that issue, users reported that if they explicitly excluded PVCs/PVs from a restore, the restore would finish with a "partial failure" error (`error getting persistent volume claim for volume...`). PR #4769 attempted to "fix" this by silently skipping PVR creation if PVCs and PVs were excluded.

However, this approach was flawed and introduced severe architectural inconsistencies:
1. **Inconsistent Lifecycle (Hanging Pods):** During the Pre-Creation Phase, the `PodVolumeRestoreAction` plugin injects the `restore-wait` init container into the pod if volume backups exist, completely unaware of the global exclusion filters. By skipping PVR creation in the Post-Creation Phase (`restore.go`), PR #4769 created a scenario where the pod receives the init container but never receives the PVRs. The node-agent never processes the volumes, and the pod hangs indefinitely in the `restore-wait` state.
2. **Breaks `mustInclude` Workflow:** This hardcoded check broke the `additionalItems` workflow. If a custom plugin (e.g., handling a `PackageInstall`) returns a PVC and PV as `additionalItems` (using the `must-include-additional-items` annotation to bypass global exclusions), the hardcoded check in `restore.go` still evaluated the global filter, incorrectly blocked PVR creation, and caused the restored pod to hang.

### Why it is reasonable to remove PR #4769's change
Removing the change from PR #4769 is the correct architectural decision because:
1. **Errors should not be masked:** Issue #4754 was not actually a bug. If a user explicitly excludes PVCs and PVs from a restore, but attempts to restore a Pod that relies on volume backups, Velero *should* report a partial failure because a required dependency (the PVC) is missing. PR #4769 masked this legitimate failure by silently skipping PVR creation, which resulted in a much worse user experience (a silently hanging pod instead of a clear error message).
2. **Restores Phase Consistency:** By removing the check, the Pre-Creation Phase (init container injection) and Post-Creation Phase (PVR creation) are realigned. Both phases now simply check `len(podvolume.GetVolumeBackupsForPod(...)) > 0`, ensuring they always act consistently.

### Expected Behavior Change
* **For Custom Plugins (`additionalItems`):** When a plugin returns PVCs and PVs as `additionalItems` (ensuring they are returned and created before the Pod), Velero will now correctly bypass global exclusions, create the associated PVRs, and the pod will successfully start without hanging.
* **For Normal Restores (Reverting to pre-PR #4769 behavior):** If a user explicitly excludes PVCs and PVs but restores a pod with volume backups, Velero will attempt to create the PVR, fail to find the required PVC (as strictly enforced by `pkg/podvolume/restorer.go`), and correctly report a partial failure error instead of silently leaving the pod hanging forever.


# Does your change fix a particular issue?

Fixes #10320 

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
