### PR TITLE
E2E: run CSI snapshot tests on kind CI

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -89,6 +89,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      csi-matrix: ${{ steps.set-matrix.outputs.csi-matrix }}
     steps:
       - name: Set k8s versions
         id: set-matrix
@@ -98,13 +99,27 @@ jobs:
         # and removes older patches of the same minor version
         # awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}'
         run: |
+          K8S_VERSIONS=$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]')
+
           echo "matrix={\
-            \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
+            \"k8s\":${K8S_VERSIONS},\
             \"labels\":[\
               \"Basic && (ClusterResource || NodePort || StorageClass)\", \
               \"ResourceFiltering && !FSBackup\", \
               \"ResourceModifier || (Backups && BackupsSync) || PrivilegesMgmt || OrderedResources\", \
               \"(NamespaceMapping && Single && FSBackup) || (NamespaceMapping && Multiple && FSBackup)\"\
+            ]}" >> $GITHUB_OUTPUT
+
+          CSI_K8S_MIN=1034
+          CSI_K8S_MAX=1035
+          CSI_K8S=$(echo "${K8S_VERSIONS}" | jq -c --argjson min "$CSI_K8S_MIN" --argjson max "$CSI_K8S_MAX" '
+            [ .[] | select((split(".") | (.[0]|tonumber) * 1000 + (.[1]|tonumber)) as $v
+                           | $v >= $min and $v <= $max) ]
+            | sort_by(split(".") | map(tonumber)) | reverse | .[0:2]')
+          echo "csi-matrix={\
+            \"k8s\":${CSI_K8S},\
+            \"labels\":[\
+              \"BackupVolumeInfo && (CSISnapshot || CSIDataMover)\"\
             ]}" >> $GITHUB_OUTPUT
 
   # Run E2E test against all Kubernetes versions on kind
@@ -198,4 +213,102 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: DebugBundle-k8s-${{ matrix.k8s }}-job-${{ strategy.job-index }}
+          path: /home/runner/work/velero/velero/test/e2e/debug-bundle*
+
+  run-csi-e2e-test:
+    needs:
+      - build
+      - setup-test-matrix
+      - get-go-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{fromJson(needs.setup-test-matrix.outputs.csi-matrix)}}
+      fail-fast: false
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v7
+
+      - name: Set up Go version
+        uses: actions/setup-go@v7
+        with:
+          go-version: ${{ needs.get-go-version.outputs.version }}
+
+      - name: Fetch built MinIO Image
+        uses: actions/cache@v6
+        id: minio-cache
+        with:
+          path: ./minio-image.tar
+          key: minio-bitnami-${{ env.BITNAMI_CONTAINERS_COMMIT }}
+      - name: Load MinIO Image
+        run: |
+          echo "Loading MinIO image..."
+          docker load < ./minio-image.tar
+      - name: Install MinIO
+        run: |
+          docker run -d --rm -p 9000:9000 -e "MINIO_ROOT_USER=minio" -e "MINIO_ROOT_PASSWORD=minio123" -e "MINIO_DEFAULT_BUCKETS=bucket,additional-bucket" bitnami/minio:local
+      - uses: helm/kind-action@v1
+        with:
+          cluster_name: "kind"
+          version: "v0.32.0"
+          node_image: "kindest/node:v${{ matrix.k8s }}"
+
+      - name: Install kubectl
+        run: |
+          curl -fLO https://dl.k8s.io/release/v${{ matrix.k8s }}/bin/linux/amd64/kubectl
+          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+      - name: Install CSI snapshot stack
+        run: ./hack/install-csi-hostpath.sh
+        timeout-minutes: 10
+
+      - name: Fetch built CLI
+        id: cli-cache
+        uses: actions/cache@v6
+        with:
+          path: ./_output/bin/linux/amd64/velero
+          key: velero-cli-${{ github.event.pull_request.number }}-${{ github.sha }}
+      - name: Fetch built Image
+        id: image-cache
+        uses: actions/cache@v6
+        with:
+          path: ./velero.tar
+          key: velero-image-${{ github.event.pull_request.number }}-${{ github.sha }}
+      - name: Load Velero Image
+        run:
+          kind load image-archive velero.tar
+      - name: Run CSI E2E test
+        run: |
+          cat << EOF > /tmp/credential
+          [default]
+          aws_access_key_id=minio
+          aws_secret_access_key=minio123
+          EOF
+
+          git init -q /tmp/kibishii
+          git -C /tmp/kibishii remote add origin https://github.com/vmware-tanzu-experiments/distributed-data-generator.git
+          git -C /tmp/kibishii fetch --depth 1 origin "${KIBISHII_COMMIT}"
+          git -C /tmp/kibishii checkout -q "${KIBISHII_COMMIT}"
+
+          GOPATH=~/go \
+              CLOUD_PROVIDER=kind \
+              OBJECT_STORE_PROVIDER=aws \
+              BSL_CONFIG=region=minio,s3ForcePathStyle="true",s3Url=http://$(hostname -i):9000 \
+              CREDS_FILE=/tmp/credential \
+              BSL_BUCKET=bucket \
+              ADDITIONAL_OBJECT_STORE_PROVIDER=aws \
+              ADDITIONAL_BSL_CONFIG=region=minio,s3ForcePathStyle="true",s3Url=http://$(hostname -i):9000 \
+              ADDITIONAL_CREDS_FILE=/tmp/credential \
+              ADDITIONAL_BSL_BUCKET=additional-bucket \
+              VELERO_IMAGE=velero:pr-test-linux-amd64 \
+              PLUGINS=velero/velero-plugin-for-aws:latest \
+              FEATURES=EnableCSI \
+              GINKGO_LABELS="${{ matrix.labels }}" \
+              KIBISHII_DIRECTORY=/tmp/kibishii/kubernetes/yaml/ \
+              make -C test/ run-e2e
+        timeout-minutes: 30
+      - name: Upload debug bundle
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: CSI-DebugBundle-k8s-${{ matrix.k8s }}-job-${{ strategy.job-index }}
           path: /home/runner/work/velero/velero/test/e2e/debug-bundle*

--- a/hack/install-csi-hostpath.sh
+++ b/hack/install-csi-hostpath.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Copyright the Velero contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SNAPSHOTTER_VERSION="${SNAPSHOTTER_VERSION:-v8.6.0}"
+HOSTPATH_VERSION="${HOSTPATH_VERSION:-v1.18.0}"
+HOSTPATH_K8S_DIR="${HOSTPATH_K8S_DIR:-kubernetes-1.34}"
+
+PROVISIONER_VERSION="${PROVISIONER_VERSION:-v6.3.0}"
+ATTACHER_VERSION="${ATTACHER_VERSION:-v4.12.0}"
+SNAPSHOTTER_SIDECAR_VERSION="${SNAPSHOTTER_SIDECAR_VERSION:-v8.6.0}"
+RESIZER_VERSION="${RESIZER_VERSION:-v2.2.1}"
+HEALTH_MONITOR_VERSION="${HEALTH_MONITOR_VERSION:-v0.18.0}"
+
+ENABLE_VGS="${ENABLE_VGS:-true}"
+KUBECTL="${KUBECTL:-kubectl}"
+
+ES_RAW="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}"
+HP_RAW="https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/${HOSTPATH_VERSION}"
+
+echo "==> [1/4] Installing VolumeSnapshot and VolumeGroupSnapshot CRDs (${SNAPSHOTTER_VERSION})"
+for crd in \
+  snapshot.storage.k8s.io_volumesnapshotclasses \
+  snapshot.storage.k8s.io_volumesnapshotcontents \
+  snapshot.storage.k8s.io_volumesnapshots \
+  groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses \
+  groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents \
+  groupsnapshot.storage.k8s.io_volumegroupsnapshots ; do
+  $KUBECTL apply -f "${ES_RAW}/client/config/crd/${crd}.yaml"
+done
+$KUBECTL wait --for=condition=established --timeout=60s \
+  crd/volumesnapshots.snapshot.storage.k8s.io \
+  crd/volumegroupsnapshots.groupsnapshot.storage.k8s.io
+
+echo "==> [2/4] Installing snapshot-controller"
+$KUBECTL apply -f "${ES_RAW}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml"
+$KUBECTL apply -f "${ES_RAW}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml"
+$KUBECTL -n kube-system set image deployment/snapshot-controller \
+  snapshot-controller="registry.k8s.io/sig-storage/snapshot-controller:${SNAPSHOTTER_VERSION}"
+if [ "$ENABLE_VGS" = "true" ]; then
+  $KUBECTL -n kube-system patch deployment snapshot-controller --type=strategic -p '
+spec:
+  template:
+    spec:
+      containers:
+        - name: snapshot-controller
+          args:
+            - "--v=5"
+            - "--leader-election=true"
+            - "--feature-gates=CSIVolumeGroupSnapshot=true"
+'
+fi
+$KUBECTL -n kube-system rollout status deployment/snapshot-controller --timeout=180s
+
+echo "==> [3/4] Installing CSI sidecar ClusterRoles"
+$KUBECTL apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/${PROVISIONER_VERSION}/deploy/kubernetes/rbac.yaml"
+$KUBECTL apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-attacher/${ATTACHER_VERSION}/deploy/kubernetes/rbac.yaml"
+$KUBECTL apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_SIDECAR_VERSION}/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml"
+$KUBECTL apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-resizer/${RESIZER_VERSION}/deploy/kubernetes/rbac.yaml"
+$KUBECTL apply -f "https://raw.githubusercontent.com/kubernetes-csi/external-health-monitor/${HEALTH_MONITOR_VERSION}/deploy/kubernetes/external-health-monitor-controller/rbac.yaml"
+
+echo "==> [4/4] Installing csi-driver-host-path (${HOSTPATH_VERSION}, ${HOSTPATH_K8S_DIR})"
+$KUBECTL apply -f "${HP_RAW}/deploy/${HOSTPATH_K8S_DIR}/hostpath/csi-hostpath-driverinfo.yaml"
+$KUBECTL apply -f "${HP_RAW}/deploy/${HOSTPATH_K8S_DIR}/hostpath/csi-hostpath-plugin.yaml"
+if [ "$ENABLE_VGS" = "true" ]; then
+  $KUBECTL patch statefulset csi-hostpathplugin --type=strategic -p '
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-snapshotter
+          args:
+            - "-v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--feature-gates=CSIVolumeGroupSnapshot=true"
+'
+fi
+$KUBECTL rollout restart statefulset/csi-hostpathplugin
+$KUBECTL rollout status statefulset/csi-hostpathplugin --timeout=300s
+
+echo "==> Verifying the csi-snapshotter sidecar synced its caches"
+synced=0
+for _ in $(seq 1 30); do
+  synced=$($KUBECTL logs csi-hostpathplugin-0 -c csi-snapshotter 2>/dev/null \
+    | grep -c "Caches populated" || true)
+  [ "${synced}" -ge 4 ] && break
+  sleep 2
+done
+if [ "${synced}" -lt 4 ]; then
+  echo "ERROR: csi-snapshotter populated ${synced} of 4 caches."
+  echo "       A CRD version that does not serve every API the sidecar watches will hang it"
+  echo "       silently, and no VolumeSnapshot will ever become ready. Check SNAPSHOTTER_VERSION."
+  $KUBECTL logs csi-hostpathplugin-0 -c csi-snapshotter --tail=40 || true
+  exit 1
+fi
+
+echo "==> CSI snapshot stack installed"
+$KUBECTL get csidrivers

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -147,6 +147,12 @@ Start kind cluster
 kind create cluster
 ```
 
+Install the CSI snapshot stack. The kind StorageClass uses the csi-driver-host-path
+provisioner, so PVCs stay unbound without it.
+``` bash
+./hack/install-csi-hostpath.sh
+```
+
 ``` bash
 BSL_PREFIX=<PREFIX_UNDER_BUCKET> \
 BSL_BUCKET=<BUCKET_FOR_E2E_TEST_BACKUP> \
@@ -155,6 +161,8 @@ CLOUD_PROVIDER=kind \
 OBJECT_STORE_PROVIDER=aws \
 make test-e2e
 ```
+
+To run the CSI snapshot tests, add `FEATURES=EnableCSI`.
 
 Stop kind cluster
 ``` bash

--- a/test/testdata/storage-class/kind.yaml
+++ b/test/testdata/storage-class/kind.yaml
@@ -3,8 +3,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: e2e-storage-class
-parameters:
-  type: pd-standard
-provisioner: rancher.io/local-path
+provisioner: hostpath.csi.k8s.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
The kind matrix excludes every Snapshot and CSI label because the cluster has no CSI driver, so the CSI tests that already exist have never run. This installs the external-snapshotter CRDs, the snapshot-controller and csi-driver-host-path, then adds a job that runs the BackupVolumeInfo CSI labels against them.

The kind StorageClass moves to the hostpath provisioner in the same change, since local-path cannot snapshot and switching it before the driver exists would leave PVCs unbound in the jobs that pass today.

external-snapshotter is pinned to v8.6.0 deliberately. The bundled csi-snapshotter v8.6.0 sidecar watches groupsnapshot.storage.k8s.io/v1, which older CRD sets do not serve, so with the group snapshot gate on it never finishes syncing its caches and processes nothing — ordinary VolumeSnapshots included. It fails silently: readyToUse never becomes true and CreateSnapshot is never called. The install script asserts all four caches populated so a wrong pin fails loudly.

# Does your change fix a particular issue?

NONE
# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
