### PR TITLE
Add Docker Pulls and GitHub stars badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ![100]
 
 [![Build Status][1]][2] [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3811/badge)](https://bestpractices.coreinfrastructure.org/projects/3811)
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/velero-io/velero)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/velero-io/velero)](https://github.com/velero-io/velero/releases)
+[![GitHub stars](https://img.shields.io/github/stars/velero-io/velero)](https://github.com/velero-io/velero/stargazers)
+[![Docker Pulls](https://img.shields.io/docker/pulls/velero/velero.svg)](https://hub.docker.com/r/velero/velero)
 
 ## Overview
 


### PR DESCRIPTION
# Summary

Add adoption-signal badges to the top of the main README:

- **Docker Pulls** (500M+ from `velero/velero` on Docker Hub)
- **GitHub stars** (10K+)

This brings the main README in line with the org profile README (velero-io/.github), which already surfaces these signals. Also made the existing release badge clickable (it was an unlinked image).

All badges use shields.io and auto-update.

# Does your change fix a particular issue?

Part of the Velero web presence improvement effort.

/kind changelog-not-required

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.