### PR TITLE
Use k8s.io/api well-known label constants instead of hardcoded strings

### DIFF
--- a/changelogs/unreleased/10279-harshitsaini17
+++ b/changelogs/unreleased/10279-harshitsaini17
@@ -1,0 +1,1 @@
+Use the well-known label constants exported by k8s.io/api/core/v1 instead of hardcoded label strings for kubernetes.io/hostname, kubernetes.io/os and topology.kubernetes.io/zone

--- a/changelogs/unreleased/10279-harshitsaini17
+++ b/changelogs/unreleased/10279-harshitsaini17
@@ -1,1 +1,1 @@
-Use the well-known label constants exported by k8s.io/api/core/v1 instead of hardcoded label strings for kubernetes.io/hostname, kubernetes.io/os and topology.kubernetes.io/zone
+Use the well-known label constants exported by k8s.io/api/core/v1 instead of hardcoded label strings for kubernetes.io/hostname, kubernetes.io/os, kubernetes.io/arch, topology.kubernetes.io/zone and failure-domain.beta.kubernetes.io/zone

--- a/pkg/backup/actions/csi/pvc_action_test.go
+++ b/pkg/backup/actions/csi/pvc_action_test.go
@@ -131,7 +131,7 @@ func TestExecute(t *testing.T) {
 			vsClass: builder.ForVolumeSnapshotClass("testVSClass").Driver("hostpath").ObjectMeta(builder.WithLabels(velerov1api.VolumeSnapshotClassSelectorLabel, "")).Result(),
 			extraObjects: []runtime.Object{
 				&corev1api.Node{
-					ObjectMeta: metav1.ObjectMeta{Name: "linux-node", Labels: map[string]string{"kubernetes.io/os": "linux"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "linux-node", Labels: map[string]string{corev1api.LabelOSStable: "linux"}},
 				},
 				&appsv1api.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "velero", Name: "node-agent"},
@@ -186,7 +186,7 @@ func TestExecute(t *testing.T) {
 			vsClass: builder.ForVolumeSnapshotClass("tescVSClass").Driver("hostpath").ObjectMeta(builder.WithLabels(velerov1api.VolumeSnapshotClassSelectorLabel, "")).Result(),
 			extraObjects: []runtime.Object{
 				&corev1api.Node{
-					ObjectMeta: metav1.ObjectMeta{Name: "linux-node", Labels: map[string]string{"kubernetes.io/os": "linux"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "linux-node", Labels: map[string]string{corev1api.LabelOSStable: "linux"}},
 				},
 				&appsv1api.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "velero", Name: "node-agent"},

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -3028,7 +3028,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
-					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels("topology.kubernetes.io/zone", "zone-1")).Result(),
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels(corev1api.LabelTopologyZone, "zone-1")).Result(),
 				),
 			},
 			snapshotterGetter: map[string]vsv1.VolumeSnapshotter{
@@ -3065,7 +3065,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
-					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabelsMap(map[string]string{"failure-domain.beta.kubernetes.io/zone": "zone-1-deprecated", "topology.kubernetes.io/zone": "zone-1-ga"})).Result(),
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabelsMap(map[string]string{"failure-domain.beta.kubernetes.io/zone": "zone-1-deprecated", corev1api.LabelTopologyZone: "zone-1-ga"})).Result(),
 				),
 			},
 			snapshotterGetter: map[string]vsv1.VolumeSnapshotter{

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -2991,7 +2991,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
-					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels("failure-domain.beta.kubernetes.io/zone", "zone-1")).Result(),
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabels(corev1api.LabelFailureDomainBetaZone, "zone-1")).Result(),
 				),
 			},
 			snapshotterGetter: map[string]vsv1.VolumeSnapshotter{
@@ -3065,7 +3065,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
-					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabelsMap(map[string]string{"failure-domain.beta.kubernetes.io/zone": "zone-1-deprecated", corev1api.LabelTopologyZone: "zone-1-ga"})).Result(),
+					builder.ForPersistentVolume("pv-1").ObjectMeta(builder.WithLabelsMap(map[string]string{corev1api.LabelFailureDomainBetaZone: "zone-1-deprecated", corev1api.LabelTopologyZone: "zone-1-ga"})).Result(),
 				),
 			},
 			snapshotterGetter: map[string]vsv1.VolumeSnapshotter{

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -569,7 +569,7 @@ func (ib *itemBackupper) executeActions(
 // zoneLabel is the label that stores availability-zone info
 // on PVs
 const (
-	zoneLabelDeprecated = "failure-domain.beta.kubernetes.io/zone"
+	zoneLabelDeprecated = corev1api.LabelFailureDomainBetaZone
 	// this is reused for nodeAffinity requirements
 	zoneLabel = corev1api.LabelTopologyZone
 

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -571,7 +571,7 @@ func (ib *itemBackupper) executeActions(
 const (
 	zoneLabelDeprecated = "failure-domain.beta.kubernetes.io/zone"
 	// this is reused for nodeAffinity requirements
-	zoneLabel = "topology.kubernetes.io/zone"
+	zoneLabel = corev1api.LabelTopologyZone
 
 	awsEbsCsiZoneKey = "topology.ebs.csi.aws.com/zone"
 	azureCsiZoneKey  = "topology.disk.csi.azure.com/zone"

--- a/pkg/controller/restore_finalizer_controller_test.go
+++ b/pkg/controller/restore_finalizer_controller_test.go
@@ -676,11 +676,11 @@ func TestNeedPatch(t *testing.T) {
 		{
 			name: "same label key different values",
 			newPV: builder.ForPersistentVolume("pv1").
-				ObjectMeta(builder.WithLabels("topology.kubernetes.io/zone", "us-west-2a")).
+				ObjectMeta(builder.WithLabels(corev1api.LabelTopologyZone, "us-west-2a")).
 				ReclaimPolicy(corev1api.PersistentVolumeReclaimDelete).Result(),
 			pvInfo: &volume.PVInfo{
 				ReclaimPolicy: string(corev1api.PersistentVolumeReclaimDelete),
-				Labels:        map[string]string{"topology.kubernetes.io/zone": "us-east-1a"},
+				Labels:        map[string]string{corev1api.LabelTopologyZone: "us-east-1a"},
 			},
 			expected: false,
 		},

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -811,7 +811,7 @@ func (e *csiSnapshotExposer) createBackupPod(
 		}
 
 		affinity.NodeSelector.MatchExpressions = append(affinity.NodeSelector.MatchExpressions, metav1.LabelSelectorRequirement{
-			Key:      "kubernetes.io/hostname",
+			Key:      corev1api.LabelHostname,
 			Values:   intoleratableNodes,
 			Operator: metav1.LabelSelectorOpNotIn,
 		})
@@ -839,7 +839,7 @@ func (e *csiSnapshotExposer) createBackupPod(
 			TopologySpreadConstraints: []corev1api.TopologySpreadConstraint{
 				{
 					MaxSkew:           1,
-					TopologyKey:       "kubernetes.io/hostname",
+					TopologyKey:       corev1api.LabelHostname,
 					WhenUnsatisfiable: corev1api.ScheduleAnyway,
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -794,7 +794,7 @@ func TestExpose(t *testing.T) {
 						NodeSelector: metav1.LabelSelector{
 							MatchExpressions: []metav1.LabelSelectorRequirement{
 								{
-									Key:      "kubernetes.io/arch",
+									Key:      corev1api.LabelArchStable,
 									Operator: metav1.LabelSelectorOpIn,
 									Values:   []string{"amd64"},
 								},
@@ -820,7 +820,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/arch",
+										Key:      corev1api.LabelArchStable,
 										Operator: corev1api.NodeSelectorOpIn,
 										Values:   []string{"amd64"},
 									},

--- a/pkg/exposer/csi_snapshot_test.go
+++ b/pkg/exposer/csi_snapshot_test.go
@@ -492,7 +492,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -530,7 +530,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -570,7 +570,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -615,7 +615,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -661,7 +661,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -705,7 +705,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -732,7 +732,7 @@ func TestExpose(t *testing.T) {
 						NodeSelector: metav1.LabelSelector{
 							MatchExpressions: []metav1.LabelSelectorRequirement{
 								{
-									Key:      "kubernetes.io/os",
+									Key:      corev1api.LabelOSStable,
 									Operator: metav1.LabelSelectorOpIn,
 									Values:   []string{"Linux"},
 								},
@@ -757,12 +757,12 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpIn,
 										Values:   []string{"Linux"},
 									},
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -825,7 +825,7 @@ func TestExpose(t *testing.T) {
 										Values:   []string{"amd64"},
 									},
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -870,7 +870,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -923,7 +923,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -968,7 +968,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
@@ -1015,12 +1015,12 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},
 									{
-										Key:      "kubernetes.io/hostname",
+										Key:      corev1api.LabelHostname,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"node-1", "node-2"},
 									},
@@ -1061,7 +1061,7 @@ func TestExpose(t *testing.T) {
 							{
 								MatchExpressions: []corev1api.NodeSelectorRequirement{
 									{
-										Key:      "kubernetes.io/os",
+										Key:      corev1api.LabelOSStable,
 										Operator: corev1api.NodeSelectorOpNotIn,
 										Values:   []string{"windows"},
 									},

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -620,7 +620,7 @@ func (e *genericRestoreExposer) createRestorePod(
 	nodeSelector := map[string]string{}
 	if selectedNode != "" {
 		affinity = nil
-		nodeSelector["kubernetes.io/hostname"] = selectedNode
+		nodeSelector[corev1api.LabelHostname] = selectedNode
 		e.log.Infof("Selected node for restore pod. Ignore affinity from the node-agent config.")
 	}
 
@@ -762,7 +762,7 @@ func (e *genericRestoreExposer) createRestorePod(
 			TopologySpreadConstraints: []corev1api.TopologySpreadConstraint{
 				{
 					MaxSkew:           1,
-					TopologyKey:       "kubernetes.io/hostname",
+					TopologyKey:       corev1api.LabelHostname,
 					WhenUnsatisfiable: corev1api.ScheduleAnyway,
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -1330,12 +1330,13 @@ func TestCreateRestorePod(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		kubeClientObj []runtime.Object
-		selectedNode  string
-		affinity      *kube.LoadAffinity
-		nodeOS        string
-		expectedPod   *corev1api.Pod
+		name                 string
+		kubeClientObj        []runtime.Object
+		selectedNode         string
+		affinity             *kube.LoadAffinity
+		nodeOS               string
+		expectedPod          *corev1api.Pod
+		expectedNodeSelector map[string]string
 	}{
 		{
 			name:          "linux",
@@ -1373,6 +1374,29 @@ func TestCreateRestorePod(t *testing.T) {
 			},
 			nodeOS: "windows",
 		},
+		{
+			// A selected node is pinned through the node selector, and the
+			// affinity from the node-agent config is ignored.
+			name:          "selected node",
+			kubeClientObj: []runtime.Object{daemonSet, daemonSetWin, targetPVCObj},
+			selectedNode:  "fake-selected-node",
+			affinity: &kube.LoadAffinity{
+				NodeSelector: metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      corev1api.LabelOSStable,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"linux"},
+						},
+					},
+				},
+				StorageClass: scName,
+			},
+			nodeOS: "linux",
+			expectedNodeSelector: map[string]string{
+				corev1api.LabelHostname: "fake-selected-node",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1406,6 +1430,9 @@ func TestCreateRestorePod(t *testing.T) {
 			require.NoError(t, err)
 			if test.expectedPod != nil {
 				assert.Equal(t, test.expectedPod, pod)
+			}
+			if test.expectedNodeSelector != nil {
+				assert.Equal(t, test.expectedNodeSelector, pod.Spec.NodeSelector)
 			}
 		})
 	}

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -1345,7 +1345,7 @@ func TestCreateRestorePod(t *testing.T) {
 				NodeSelector: metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
-							Key:      "kubernetes.io/os",
+							Key:      corev1api.LabelOSStable,
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"linux"},
 						},
@@ -1363,7 +1363,7 @@ func TestCreateRestorePod(t *testing.T) {
 				NodeSelector: metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
-							Key:      "kubernetes.io/os",
+							Key:      corev1api.LabelOSStable,
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"windows"},
 						},

--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -247,7 +247,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 						{
 							MatchExpressions: []corev1api.NodeSelectorRequirement{
 								{
-									Key:      "kubernetes.io/os",
+									Key:      corev1api.LabelOSStable,
 									Values:   []string{"windows"},
 									Operator: corev1api.NodeSelectorOpIn,
 								},
@@ -280,7 +280,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 						{
 							MatchExpressions: []corev1api.NodeSelectorRequirement{
 								{
-									Key:      "kubernetes.io/os",
+									Key:      corev1api.LabelOSStable,
 									Values:   []string{"windows"},
 									Operator: corev1api.NodeSelectorOpNotIn,
 								},

--- a/pkg/install/daemonset_test.go
+++ b/pkg/install/daemonset_test.go
@@ -41,7 +41,7 @@ func TestDaemonSet(t *testing.T) {
 					{
 						MatchExpressions: []corev1api.NodeSelectorRequirement{
 							{
-								Key:      "kubernetes.io/os",
+								Key:      corev1api.LabelOSStable,
 								Values:   []string{"windows"},
 								Operator: corev1api.NodeSelectorOpNotIn,
 							},
@@ -107,7 +107,7 @@ func TestDaemonSet(t *testing.T) {
 					{
 						MatchExpressions: []corev1api.NodeSelectorRequirement{
 							{
-								Key:      "kubernetes.io/os",
+								Key:      corev1api.LabelOSStable,
 								Values:   []string{"windows"},
 								Operator: corev1api.NodeSelectorOpIn,
 							},

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -395,7 +395,7 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1api.Deployme
 									{
 										MatchExpressions: []corev1api.NodeSelectorRequirement{
 											{
-												Key:      "kubernetes.io/os",
+												Key:      corev1api.LabelOSStable,
 												Values:   []string{"windows"},
 												Operator: corev1api.NodeSelectorOpNotIn,
 											},

--- a/pkg/install/deployment_test.go
+++ b/pkg/install/deployment_test.go
@@ -120,7 +120,7 @@ func TestDeployment(t *testing.T) {
 					{
 						MatchExpressions: []corev1api.NodeSelectorRequirement{
 							{
-								Key:      "kubernetes.io/os",
+								Key:      corev1api.LabelOSStable,
 								Values:   []string{"windows"},
 								Operator: corev1api.NodeSelectorOpNotIn,
 							},

--- a/pkg/podvolume/backupper_test.go
+++ b/pkg/podvolume/backupper_test.go
@@ -357,7 +357,7 @@ func createPVBObj(fail bool, withSnapshot bool, index int, uploaderType string) 
 }
 
 func createNodeObj() *corev1api.Node {
-	return builder.ForNode("fake-node-name").Labels(map[string]string{"kubernetes.io/os": "linux"}).Result()
+	return builder.ForNode("fake-node-name").Labels(map[string]string{corev1api.LabelOSStable: "linux"}).Result()
 }
 
 func TestBackupPodVolumes(t *testing.T) {

--- a/pkg/util/kube/node.go
+++ b/pkg/util/kube/node.go
@@ -30,7 +30,7 @@ import (
 const (
 	NodeOSLinux   = "linux"
 	NodeOSWindows = "windows"
-	NodeOSLabel   = "kubernetes.io/os"
+	NodeOSLabel   = corev1api.LabelOSStable
 )
 
 var realNodeOSMap = map[string]string{

--- a/pkg/util/kube/node_test.go
+++ b/pkg/util/kube/node_test.go
@@ -35,8 +35,8 @@ import (
 
 func TestIsLinuxNode(t *testing.T) {
 	nodeNoOSLabel := builder.ForNode("fake-node").Result()
-	nodeWindows := builder.ForNode("fake-node").Labels(map[string]string{"kubernetes.io/os": "windows"}).Result()
-	nodeLinux := builder.ForNode("fake-node").Labels(map[string]string{"kubernetes.io/os": "linux"}).Result()
+	nodeWindows := builder.ForNode("fake-node").Labels(map[string]string{corev1api.LabelOSStable: "windows"}).Result()
+	nodeLinux := builder.ForNode("fake-node").Labels(map[string]string{corev1api.LabelOSStable: "linux"}).Result()
 
 	scheme := runtime.NewScheme()
 	corev1api.AddToScheme(scheme)
@@ -90,8 +90,8 @@ func TestIsLinuxNode(t *testing.T) {
 }
 
 func TestWithLinuxNode(t *testing.T) {
-	nodeWindows := builder.ForNode("fake-node-1").Labels(map[string]string{"kubernetes.io/os": "windows"}).Result()
-	nodeLinux := builder.ForNode("fake-node-2").Labels(map[string]string{"kubernetes.io/os": "linux"}).Result()
+	nodeWindows := builder.ForNode("fake-node-1").Labels(map[string]string{corev1api.LabelOSStable: "windows"}).Result()
+	nodeLinux := builder.ForNode("fake-node-2").Labels(map[string]string{corev1api.LabelOSStable: "linux"}).Result()
 
 	scheme := runtime.NewScheme()
 	corev1api.AddToScheme(scheme)
@@ -135,8 +135,8 @@ func TestWithLinuxNode(t *testing.T) {
 
 func TestGetNodeOSType(t *testing.T) {
 	nodeNoOSLabel := builder.ForNode("fake-node").Result()
-	nodeWindows := builder.ForNode("fake-node").Labels(map[string]string{"kubernetes.io/os": "windows"}).Result()
-	nodeLinux := builder.ForNode("fake-node").Labels(map[string]string{"kubernetes.io/os": "linux"}).Result()
+	nodeWindows := builder.ForNode("fake-node").Labels(map[string]string{corev1api.LabelOSStable: "windows"}).Result()
+	nodeLinux := builder.ForNode("fake-node").Labels(map[string]string{corev1api.LabelOSStable: "linux"}).Result()
 	scheme := runtime.NewScheme()
 	corev1api.AddToScheme(scheme)
 	tests := []struct {
@@ -185,8 +185,8 @@ func TestGetNodeOSType(t *testing.T) {
 
 func TestHasNodeWithOS(t *testing.T) {
 	nodeNoOSLabel := builder.ForNode("fake-node-1").Result()
-	nodeWindows := builder.ForNode("fake-node-2").Labels(map[string]string{"kubernetes.io/os": "windows"}).Result()
-	nodeLinux := builder.ForNode("fake-node-3").Labels(map[string]string{"kubernetes.io/os": "linux"}).Result()
+	nodeWindows := builder.ForNode("fake-node-2").Labels(map[string]string{corev1api.LabelOSStable: "windows"}).Result()
+	nodeLinux := builder.ForNode("fake-node-3").Labels(map[string]string{corev1api.LabelOSStable: "linux"}).Result()
 
 	scheme := runtime.NewScheme()
 	corev1api.AddToScheme(scheme)

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -1374,7 +1374,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 					NodeSelector: metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
-								Key:      "kubernetes.io/arch",
+								Key:      corev1api.LabelArchStable,
 								Operator: metav1.LabelSelectorOpIn,
 								Values:   []string{"amd64"},
 							},
@@ -1425,7 +1425,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 					NodeSelector: metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
-								Key:      "kubernetes.io/arch",
+								Key:      corev1api.LabelArchStable,
 								Operator: metav1.LabelSelectorOpIn,
 								Values:   []string{"amd64"},
 							},
@@ -1487,7 +1487,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 					NodeSelector: metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
-								Key:      "kubernetes.io/arch",
+								Key:      corev1api.LabelArchStable,
 								Operator: metav1.LabelSelectorOpIn,
 								Values:   []string{"amd64"},
 							},
@@ -1517,7 +1517,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 					NodeSelector: metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
-								Key:      "kubernetes.io/arch",
+								Key:      corev1api.LabelArchStable,
 								Operator: metav1.LabelSelectorOpIn,
 								Values:   []string{"amd64"},
 							},

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -1386,7 +1386,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 					NodeSelector: metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
-								Key:      "kubernetes.io/os",
+								Key:      corev1api.LabelOSStable,
 								Operator: metav1.LabelSelectorOpIn,
 								Values:   []string{"Linux"},
 							},
@@ -1399,7 +1399,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 				NodeSelector: metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
-							Key:      "kubernetes.io/os",
+							Key:      corev1api.LabelOSStable,
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"Linux"},
 						},
@@ -1414,7 +1414,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 					NodeSelector: metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
-								Key:      "kubernetes.io/os",
+								Key:      corev1api.LabelOSStable,
 								Operator: metav1.LabelSelectorOpIn,
 								Values:   []string{"Linux"},
 							},
@@ -1436,7 +1436,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 					NodeSelector: metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
-								Key:      "kubernetes.io/os",
+								Key:      corev1api.LabelOSStable,
 								Operator: metav1.LabelSelectorOpIn,
 								Values:   []string{"Windows"},
 							},
@@ -1449,7 +1449,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 				NodeSelector: metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
-							Key:      "kubernetes.io/os",
+							Key:      corev1api.LabelOSStable,
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"Linux"},
 						},
@@ -1475,7 +1475,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 					NodeSelector: metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
-								Key:      "kubernetes.io/os",
+								Key:      corev1api.LabelOSStable,
 								Operator: metav1.LabelSelectorOpIn,
 								Values:   []string{"Linux"},
 							},
@@ -1501,7 +1501,7 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 				NodeSelector: metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
-							Key:      "kubernetes.io/os",
+							Key:      corev1api.LabelOSStable,
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{"Linux"},
 						},

--- a/pkg/util/kube/pvc_pv_test.go
+++ b/pkg/util/kube/pvc_pv_test.go
@@ -1729,7 +1729,7 @@ func TestDiagnosePV(t *testing.T) {
 func TestGetPVCAttachingNodeOS(t *testing.T) {
 	storageClass := "fake-storage-class"
 	nodeNoOSLabel := builder.ForNode("fake-node").Result()
-	nodeWindows := builder.ForNode("fake-node").Labels(map[string]string{"kubernetes.io/os": "windows"}).Result()
+	nodeWindows := builder.ForNode("fake-node").Labels(map[string]string{corev1api.LabelOSStable: "windows"}).Result()
 
 	pvcObj := &corev1api.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/nodeagentconfig/node-agent-config.go
+++ b/test/e2e/nodeagentconfig/node-agent-config.go
@@ -62,7 +62,7 @@ var LoadAffinities func() = TestFunc(&NodeAgentConfigTestCase{
 			{
 				NodeSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"kubernetes.io/arch": "amd64",
+						corev1api.LabelArchStable: "amd64",
 					},
 				},
 				StorageClass: test.StorageClassName2,

--- a/test/util/k8s/deployment.go
+++ b/test/util/k8s/deployment.go
@@ -102,7 +102,7 @@ func NewDeployment(
 						{
 							MatchExpressions: []corev1api.NodeSelectorRequirement{
 								{
-									Key:      "kubernetes.io/os",
+									Key:      corev1api.LabelOSStable,
 									Values:   []string{common.WorkerOSWindows},
 									Operator: corev1api.NodeSelectorOpIn,
 								},

--- a/test/util/k8s/pod.go
+++ b/test/util/k8s/pod.go
@@ -84,7 +84,7 @@ func CreatePod(
 						{
 							MatchExpressions: []corev1api.NodeSelectorRequirement{
 								{
-									Key:      "kubernetes.io/os",
+									Key:      corev1api.LabelOSStable,
 									Values:   []string{common.WorkerOSWindows},
 									Operator: corev1api.NodeSelectorOpIn,
 								},


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Replaces the hardcoded well-known Kubernetes label strings with the constants already exported by `k8s.io/api/core/v1`:

| Hardcoded string | Constant |
|---|---|
| `"kubernetes.io/hostname"` | `corev1api.LabelHostname` |
| `"kubernetes.io/os"` | `corev1api.LabelOSStable` |
| `"topology.kubernetes.io/zone"` | `corev1api.LabelTopologyZone` |
| `"kubernetes.io/arch"` | `corev1api.LabelArchStable` |
| `"failure-domain.beta.kubernetes.io/zone"` | `corev1api.LabelFailureDomainBetaZone` |

The first three are the mapping from the issue; the last two were raised by @opbot-xd in a comment on #10277 and are included here so the cleanup is complete and there is nothing left to follow up on.

21 files, no functional change — every constant has a value identical to the literal it replaces. All affected files already imported `k8s.io/api/core/v1`, so there are no import changes. The alias is `corev1api` rather than `corev1` to match the existing convention (196 files use `corev1api`, 1 uses `corev1`).

Test files are included in the same pass, as the issue suggested. After this change no `.go` file in the repo contains any of the five literals.

### Note on the local consts

`kube.NodeOSLabel`, `zoneLabel` and `zoneLabelDeprecated` are now defined *in terms of* the upstream constants rather than removed:

```go
NodeOSLabel         = corev1api.LabelOSStable
zoneLabel           = corev1api.LabelTopologyZone
zoneLabelDeprecated = corev1api.LabelFailureDomainBetaZone
```

- `NodeOSLabel` is exported and referenced at 21 sites across `pkg/exposer`, `pkg/controller`, `pkg/nodeagent` and `pkg/util/kube`, and it sits in a const block with `NodeOSLinux` / `NodeOSWindows`, which have no upstream equivalent. Collapsing it this way removes the duplicated literal while keeping that trio cohesive and leaving the call sites untouched.
- `zoneLabel` / `zoneLabelDeprecated` are the GA-and-fallback pair compared against each other in `item_backupper.go`, so both now reference upstream rather than one referencing it and the other repeating a literal.

Note on the deprecated zone label: the `// deprecated` marker upstream applies to the *label*, not to the constant — `pkg/backup/item_backupper.go` reads it deliberately as the fallback for PVs created before the topology labels existed, so the behaviour is unchanged and the constant is the right way to spell it.

Happy to delete any of the three outright and update the call sites instead if reviewers would prefer that.

### Verification

`go build ./pkg/... ./test/...` is clean, `gofmt -l` reports nothing, and the affected packages pass: `pkg/install`, `pkg/util/kube`, `pkg/exposer`, `pkg/backup/...`, `pkg/podvolume`, `pkg/controller`. `go vet ./test/e2e/nodeagentconfig/` is clean.

This also adds one test case: `TestCreateRestorePod` only exercised `selectedNode == ""`, so the branch that pins the restore pod to a node — the one place a label is used as a map key rather than a struct field — was never executed. The new case asserts the pod's node selector carries the hostname label.

Two unrelated pre-existing failures show up locally and are not touched by this change — `go vet` reports non-constant format strings in `pkg/util/kube/event.go` and `pkg/podvolume/*_micro_service.go`, and `pkg/controller`'s `TestAPIs` envtest suite needs kubebuilder binaries. Both reproduce identically on an unmodified `main`.

# Does your change fix a particular issue?

Fixes #10277

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main` — not applicable, this is an internal refactor with no user-facing change.
