### PR TITLE
Make backport/pr-filepath-check/auto_assign_prs reusable across velero-io repos

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -3,6 +3,13 @@ name: "Auto Assign Author"
 
 # pull_request_target means that this will run on pull requests, but in
 # the context of the base repo. This should mean PRs from forks are supported.
+#
+# Also callable as a reusable workflow (`uses:
+# velero-io/velero/.github/workflows/auto_assign_prs.yml@main`) from other
+# velero-io repos — see velero-plugin-for-aws/gcp/microsoft-azure. Each caller
+# repo needs its own `.github/auto-assignees.yml` (checkout below resolves to
+# the calling repo) and its own `.github/CODEOWNERS` naming the reviewer team
+# for the re-request-review job below to make sense.
 on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
@@ -10,6 +17,7 @@ on:
   # review once only one maintainer has approved.
   pull_request_review:
     types: [submitted]
+  workflow_call:
 
 permissions:
   contents: read
@@ -18,7 +26,7 @@ permissions:
 jobs:
   # Automatically assigns reviewers and owner
   add-reviews:
-    if: github.repository == 'velero-io/velero' && github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Set the author of a PR as the assignee
@@ -34,7 +42,7 @@ jobs:
   # fewer than the required number of approvals, so a second CODEOWNERS
   # reviewer gets pinged.
   re-request-review:
-    if: github.repository == 'velero-io/velero' && github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     steps:
       - name: Re-request review from maintainers if more approvals are needed

--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -6,10 +6,14 @@ name: "Auto Assign Author"
 #
 # Also callable as a reusable workflow (`uses:
 # velero-io/velero/.github/workflows/auto_assign_prs.yml@main`) from other
-# velero-io repos — see velero-plugin-for-aws/gcp/microsoft-azure. Each caller
-# repo needs its own `.github/auto-assignees.yml` (checkout below resolves to
-# the calling repo) and its own `.github/CODEOWNERS` naming the reviewer team
-# for the re-request-review job below to make sense.
+# velero-io repos — see velero-plugin-for-aws/gcp/microsoft-azure. Each
+# caller repo needs its own `.github/auto-assignees.yml` (kentaro-m/auto-
+# assign-action fetches it via the GitHub API using the calling repo's
+# context — there's no checkout step in this workflow) and its own
+# `.github/CODEOWNERS` naming the reviewer team for the re-request-review
+# job below to make sense. Callers must grant at least `pull-requests: write`
+# in their own job-level permissions — a caller's permissions cap what this
+# called workflow's jobs can request, regardless of what's declared here.
 on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -44,9 +44,17 @@ name: Backport merged pull request
 # Without it, korthout/backport-action's PR-creation call fails even though
 # this workflow requests pull-requests: write.
 #
+# Callers must grant contents: write, issues: write, and pull-requests: write
+# in their own job-level permissions (see the label-for-backport and backport
+# jobs below for what each scope is for) — a caller's permissions cap what
+# this called workflow's jobs can request, regardless of what's declared here.
+#
 # Also callable as a reusable workflow (`uses:
 # velero-io/velero/.github/workflows/backport.yml@main`) from other velero-io
-# repos — see velero-plugin-for-aws/gcp/microsoft-azure. The same "Allow
+# repos — see velero-plugin-for-aws/gcp/microsoft-azure. Callers must trigger
+# with `pull_request_target: types: [closed]` and/or `issue_comment: types:
+# [created]` — these are the only two event/type combinations the jobs below
+# check via `if:`; any other trigger event just no-ops. The same "Allow
 # GitHub Actions to create and approve pull requests" setting must be enabled
 # on the CALLING repo too, since GITHUB_TOKEN's permission gate is evaluated
 # in the caller's context, not here.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -37,12 +37,26 @@ name: Backport merged pull request
 # check always passes regardless of whether the original commit had one.
 #
 # See: https://github.com/velero-io/velero/issues/9603
+#
+# Requires "Allow GitHub Actions to create and approve pull requests" enabled
+# under Settings > Actions > General for THIS repo (org-locked as of writing;
+# only an org owner can toggle it). Tracked: velero-io/velero#9603.
+# Without it, korthout/backport-action's PR-creation call fails even though
+# this workflow requests pull-requests: write.
+#
+# Also callable as a reusable workflow (`uses:
+# velero-io/velero/.github/workflows/backport.yml@main`) from other velero-io
+# repos — see velero-plugin-for-aws/gcp/microsoft-azure. The same "Allow
+# GitHub Actions to create and approve pull requests" setting must be enabled
+# on the CALLING repo too, since GITHUB_TOKEN's permission gate is evaluated
+# in the caller's context, not here.
 
 on:
   pull_request_target:
     types: [closed]
   issue_comment:
     types: [created]
+  workflow_call:
 
 permissions: {}
 
@@ -73,7 +87,6 @@ jobs:
     name: Label PR for deferred backport
     # Run only when an authorized command is posted on an *open* (unmerged) PR.
     if: >
-      github.repository == 'velero-io/velero' &&
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != '' &&
       github.event.issue.state == 'open' &&
@@ -128,7 +141,6 @@ jobs:
     # recursive triggers. The bot does not post /backport commands, so startsWith
     # already blocks recursion; the id check is defense in depth.
     if: >
-      github.repository == 'velero-io/velero' &&
       (
         (
           github.event_name == 'pull_request_target' &&

--- a/.github/workflows/pr-filepath-check.yml
+++ b/.github/workflows/pr-filepath-check.yml
@@ -1,9 +1,10 @@
 name: Pull Request File Path Check
-on: [pull_request]
+on:
+  pull_request:
+  workflow_call:
 jobs:
 
   filepath-check:
-    if: github.repository == 'velero-io/velero'
     name: Check for invalid characters in file paths
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Makes `backport.yml`, `pr-filepath-check.yml`, and `auto_assign_prs.yml` callable as reusable workflows (`uses: velero-io/velero/.github/workflows/<file>@main`) so `velero-plugin-for-aws`/`-gcp`/`-microsoft-azure` can call them instead of maintaining drifted local copies. This is the same pattern already used for `get-go-version.yaml`, which had already drifted (different `actions/checkout` pins per repo).

Changes:
- Add `workflow_call:` as a trigger to each of the 3 workflows.
- Drop their `github.repository == 'velero-io/velero'` guards. This is not a security tradeoff — `GITHUB_TOKEN` in a reusable-workflow call is scoped to the *calling* repo only, so a fork calling this workflow can never touch `velero-io/velero` itself. The comment-trigger path on backport.yml is still gated by `author_association: OWNER/MEMBER/COLLABORATOR`.
- Added code comments documenting the reusable-workflow usage and a known blocker (see below).

**Known blocker (pre-existing, tracked separately):** backport still won't actually create PRs until "Allow GitHub Actions to create and approve pull requests" is enabled under `Settings > Actions > General` — currently unchecked/org-locked. Tracked in #9603. This needs to be enabled on this repo **and** on each plugin repo calling it (the gate is evaluated in the caller's context).

**Companion PRs on the plugin repos — blocked on this PR merging first** (they call `@main` on this repo, so nothing executes until this lands):
- velero-io/velero-plugin-for-aws#319
- velero-io/velero-plugin-for-gcp#266
- velero-io/velero-plugin-for-microsoft-azure#324

# Does your change fix a particular issue?

Related to #9603 (does not fully fix it — the repo Actions setting still needs an org owner to enable it)

# Please indicate you've done the following:

- [x] Accepted the DCO (commit is signed off)
- [x] Created a changelog file (`make new-changelog`) or comment `/kind changelog-not-required` on this PR. — commented `/kind changelog-not-required`; this is CI/infra-only, no user-facing behavior change.
- [x] Updated the corresponding documentation in `site/content/docs/main`. — N/A, no user-facing docs affected (GitHub Actions internals only).

> [!Note]
> Responses generated with Claude
