### PR TITLE
Use k8s.io/api well-known label constants instead of hardcoded strings (closes #10277)

### DIFF
--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -569,9 +569,9 @@ func (ib *itemBackupper) executeActions(
 // zoneLabel is the label that stores availability-zone info
 // on PVs
 const (
-	zoneLabelDeprecated = "failure-domain.beta.kubernetes.io/zone"
+	zoneLabelDeprecated = corev1api.LabelFailureDomainBetaZone
 	// this is reused for nodeAffinity requirements
-	zoneLabel = "topology.kubernetes.io/zone"
+	zoneLabel = corev1api.LabelTopologyZone
 
 	awsEbsCsiZoneKey = "topology.ebs.csi.aws.com/zone"
 	azureCsiZoneKey  = "topology.disk.csi.azure.com/zone"

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -811,7 +811,7 @@ func (e *csiSnapshotExposer) createBackupPod(
 		}
 
 		affinity.NodeSelector.MatchExpressions = append(affinity.NodeSelector.MatchExpressions, metav1.LabelSelectorRequirement{
-			Key:      "kubernetes.io/hostname",
+			Key:      corev1api.LabelHostname,
 			Values:   intoleratableNodes,
 			Operator: metav1.LabelSelectorOpNotIn,
 		})
@@ -839,7 +839,7 @@ func (e *csiSnapshotExposer) createBackupPod(
 			TopologySpreadConstraints: []corev1api.TopologySpreadConstraint{
 				{
 					MaxSkew:           1,
-					TopologyKey:       "kubernetes.io/hostname",
+					TopologyKey:       corev1api.LabelHostname,
 					WhenUnsatisfiable: corev1api.ScheduleAnyway,
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -620,7 +620,7 @@ func (e *genericRestoreExposer) createRestorePod(
 	nodeSelector := map[string]string{}
 	if selectedNode != "" {
 		affinity = nil
-		nodeSelector["kubernetes.io/hostname"] = selectedNode
+		nodeSelector[corev1api.LabelHostname] = selectedNode
 		e.log.Infof("Selected node for restore pod. Ignore affinity from the node-agent config.")
 	}
 
@@ -762,7 +762,7 @@ func (e *genericRestoreExposer) createRestorePod(
 			TopologySpreadConstraints: []corev1api.TopologySpreadConstraint{
 				{
 					MaxSkew:           1,
-					TopologyKey:       "kubernetes.io/hostname",
+					TopologyKey:       corev1api.LabelHostname,
 					WhenUnsatisfiable: corev1api.ScheduleAnyway,
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{

--- a/pkg/install/daemonset.go
+++ b/pkg/install/daemonset.go
@@ -247,7 +247,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 						{
 							MatchExpressions: []corev1api.NodeSelectorRequirement{
 								{
-									Key:      "kubernetes.io/os",
+									Key:      corev1api.LabelOSStable,
 									Values:   []string{"windows"},
 									Operator: corev1api.NodeSelectorOpIn,
 								},
@@ -280,7 +280,7 @@ func DaemonSet(namespace string, opts ...podTemplateOption) *appsv1api.DaemonSet
 						{
 							MatchExpressions: []corev1api.NodeSelectorRequirement{
 								{
-									Key:      "kubernetes.io/os",
+									Key:      corev1api.LabelOSStable,
 									Values:   []string{"windows"},
 									Operator: corev1api.NodeSelectorOpNotIn,
 								},

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -395,7 +395,7 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1api.Deployme
 									{
 										MatchExpressions: []corev1api.NodeSelectorRequirement{
 											{
-												Key:      "kubernetes.io/os",
+												Key:      corev1api.LabelOSStable,
 												Values:   []string{"windows"},
 												Operator: corev1api.NodeSelectorOpNotIn,
 											},

--- a/pkg/util/kube/node.go
+++ b/pkg/util/kube/node.go
@@ -30,7 +30,7 @@ import (
 const (
 	NodeOSLinux   = "linux"
 	NodeOSWindows = "windows"
-	NodeOSLabel   = "kubernetes.io/os"
+	NodeOSLabel   = corev1api.LabelOSStable
 )
 
 var realNodeOSMap = map[string]string{


### PR DESCRIPTION
## Please describe what this PR does

Closes #10277.

Several well-known Kubernetes label strings were hardcoded across the codebase instead of using the constants already exported by `k8s.io/api/core/v1` (imported here as `corev1api`). A couple of local `const`s even duplicated the upstream value. This replaces them with the upstream constants:

| Hardcoded string | Constant |
|---|---|
| `"kubernetes.io/hostname"` | `corev1api.LabelHostname` |
| `"kubernetes.io/os"` | `corev1api.LabelOSStable` |
| `"topology.kubernetes.io/zone"` | `corev1api.LabelTopologyZone` |
| `"failure-domain.beta.kubernetes.io/zone"` | `corev1api.LabelFailureDomainBetaZone` |

Files touched: `pkg/backup/item_backupper.go`, `pkg/exposer/csi_snapshot.go`, `pkg/exposer/generic_restore.go`, `pkg/install/daemonset.go`, `pkg/install/deployment.go`, `pkg/util/kube/node.go`.

The two local consts (`zoneLabel`/`zoneLabelDeprecated` in `item_backupper.go`, `NodeOSLabel` in `node.go`) keep their names — used elsewhere — but now reference the upstream constant instead of duplicating the literal.

This is a **pure mechanical replacement**: the constants have identical string values, so there is no functional change. I scoped it to production code (kept the `kubernetes.io/arch` test-file spots out to keep the diff focused; happy to add them if preferred).

## Validation

- Verified each constant name against `k8s.io/api` at the version pinned in `go.mod` (`v0.36.0`, `core/v1/well_known_labels.go`).
- `go build ./pkg/backup/... ./pkg/exposer/... ./pkg/install/... ./pkg/util/kube/...` → passes.
- `gofmt -l` on the changed files → clean.

First-time contributor here — happy to adjust scope or naming to fit your conventions.
