### PR TITLE
fall back to VolumeSnapshotRef lookup when cleaning up an unbound VolumeSnapshotContent

### DIFF
--- a/changelogs/unreleased/10289-samay43
+++ b/changelogs/unreleased/10289-samay43
@@ -1,0 +1,1 @@
+fix csi data mover cleanup to remove orphaned VolumeSnapshotContent when DataUpload creation fails

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -563,6 +563,30 @@ func SetVolumeSnapshotContentDeletionPolicy(
 	return vsc, crClient.Patch(ctx, vsc, crclient.MergeFrom(originVSC))
 }
 
+// findVolumeSnapshotContentByRef looks up a VolumeSnapshotContent whose
+// Spec.VolumeSnapshotRef points to the given VolumeSnapshot. This is used as
+// a fallback when the VolumeSnapshot's Status.BoundVolumeSnapshotContentName
+// has not yet been populated by the CSI snapshot controller, since
+// Spec.VolumeSnapshotRef is set on the VolumeSnapshotContent as soon as it is
+// created, before the VolumeSnapshot's status is updated.
+func findVolumeSnapshotContentByRef(
+	ctx context.Context,
+	volSnap *snapshotv1api.VolumeSnapshot,
+	crClient crclient.Client,
+) (*snapshotv1api.VolumeSnapshotContent, error) {
+	vscList := new(snapshotv1api.VolumeSnapshotContentList)
+	if err := crClient.List(ctx, vscList); err != nil {
+		return nil, err
+	}
+	for i := range vscList.Items {
+		ref := vscList.Items[i].Spec.VolumeSnapshotRef
+		if ref.Name == volSnap.Name && ref.Namespace == volSnap.Namespace {
+			return &vscList.Items[i], nil
+		}
+	}
+	return nil, nil
+}
+
 // CleanupVolumeSnapshot deletes the VolumeSnapshot and the associated VolumeSnapshotContent.  It will make sure the
 // physical snapshot is also deleted.
 func CleanupVolumeSnapshot(
@@ -582,13 +606,28 @@ func CleanupVolumeSnapshot(
 		log.Debugf("Failed to get volumesnapshot %s/%s", volSnap.Namespace, volSnap.Name)
 		return
 	}
-
+	vscName := ""
 	if vs.Status != nil && vs.Status.BoundVolumeSnapshotContentName != nil {
+		vscName = *vs.Status.BoundVolumeSnapshotContentName
+	} else {
+		// The VolumeSnapshot may not have been bound to a VolumeSnapshotContent yet
+		// (e.g. cleanup runs immediately after a downstream failure, before the CSI
+		// snapshot controller has updated status). Fall back to looking up the
+		// VolumeSnapshotContent by its VolumeSnapshotRef so it isn't orphaned.
+		vsc, err := findVolumeSnapshotContentByRef(ctx, vs, crClient)
+		if err != nil {
+			log.Debugf("Failed to look up VolumeSnapshotContent for volumesnapshot %s/%s: %v",
+				vs.Namespace, vs.Name, err)
+		} else if vsc != nil {
+			vscName = vsc.Name
+		}
+	}
+	if vscName != "" {
 		// we patch the DeletionPolicy of the VolumeSnapshotContent to set it to Delete.
 		// This ensures that the volume snapshot in the storage provider is also deleted.
 		_, err := SetVolumeSnapshotContentDeletionPolicy(
 			ctx,
-			*vs.Status.BoundVolumeSnapshotContentName,
+			vscName,
 			crClient,
 			snapshotv1api.VolumeSnapshotContentDelete,
 		)

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -2251,6 +2251,39 @@ func TestCleanupVolumeSnapshot(t *testing.T) {
 			expectDeleted: true,
 			expectedVSC:   "retain-vsc",
 		},
+		{
+			name: "should fall back to VolumeSnapshotRef lookup when BoundVolumeSnapshotContentName is not yet set",
+			volSnap: &snapshotv1api.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vs-not-yet-bound",
+					Namespace: "velero",
+				},
+			},
+			objs: []runtime.Object{
+				&snapshotv1api.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vs-not-yet-bound",
+						Namespace: "velero",
+					},
+					// Status intentionally nil, simulating cleanup running before
+					// the CSI snapshot controller has bound the VolumeSnapshot.
+				},
+				&snapshotv1api.VolumeSnapshotContent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "orphan-prone-vsc",
+					},
+					Spec: snapshotv1api.VolumeSnapshotContentSpec{
+						DeletionPolicy: snapshotv1api.VolumeSnapshotContentRetain,
+						VolumeSnapshotRef: corev1api.ObjectReference{
+							Name:      "vs-not-yet-bound",
+							Namespace: "velero",
+						},
+					},
+				},
+			},
+			expectDeleted: true,
+			expectedVSC:   "orphan-prone-vsc",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
# summary of change

When CSI snapshot data movement is enabled, `createDataUpload` can fail after the `VolumeSnapshot` has been created but before the CSI snapshot controller has bound it to a `VolumeSnapshotContent` — that is, before `Status.BoundVolumeSnapshotContentName` is populated.

In that window `CleanupVolumeSnapshot` finds no bound content name, so it deletes only the `VolumeSnapshot` and returns. The `VolumeSnapshotContent` and its underlying provider snapshot are left behind with nothing referencing them.

This adds a fallback: when `Status.BoundVolumeSnapshotContentName` is not yet set, `CleanupVolumeSnapshot` lists `VolumeSnapshotContent`s and matches on `Spec.VolumeSnapshotRef`, which is populated at content-creation time regardless of the `VolumeSnapshot`'s status.

```
changelogs/unreleased/10289-samay43   +1/-0
pkg/util/csi/volume_snapshot.go      +41/-2
pkg/util/csi/volume_snapshot_test.go +33/-0
```

Rebased onto current main. The three `TestCleanupVolumeSnapshot` cases that #10198 now owns have been dropped, so the test diff is +33 rather than +135.

# open design question

@Lyndon-Li raised on #10287 that a `Retain` policy is the user's choice and should not be overridden. I went looking for how much of the change that actually touches, and the answer is: one path.

He compared it to the exposer — "if the policy is changed by the exposer, it will be changed back whenever fails." I could not find that behaviour in the tree. `createBackupVSC` (`pkg/exposer/csi_snapshot.go:574`) creates its **own** `VolumeSnapshotContent` with `DeletionPolicy: Delete` hardcoded rather than mutating an existing one, and there is no restore-on-failure path; `SetVolumeSnapshotContentDeletionPolicy` has exactly two non-test callers, both in `pkg/util/csi/volume_snapshot.go`.

`CleanupVolumeSnapshot` has six call sites. Five can only ever receive a `VolumeSnapshot` that Velero itself created for the current backup or restore:

- `pkg/backup/actions/csi/pvc_action.go:383` — every path through `getVolumeSnapshotReference` returns a Velero-created VS (new VGS-derived, legacy `createVolumeSnapshot`, or one reused via `findExistingVSForBackup`, which matches on `BackupNameLabel` + `BackupUIDLabel`)
- `pkg/restore/actions/csi/pvc_action.go:249` — the in-place incremental restore baseline, created by `p.createVolumeSnapshot` immediately above the deferred cleanup
- `pkg/restore/actions/csi/pvc_action.go:707` and `:715`
- `pkg/controller/backup_deletion_controller.go:538` — lists strictly by `BackupNameLabel`

The sixth is different. `pkg/backup/actions/csi/volumesnapshot_action.go:122` is the VolumeSnapshot BIA, operating on a `VolumeSnapshot` that is itself *being backed up* — which can be a user's own pre-existing snapshot. The file says as much a few lines below that call:

```go
// when we are backing up VolumeSnapshots created outside of velero, we
// will not await VolumeSnapshot reconciliation and in this case
```

It calls cleanup when `GetVSCForVS` fails, and a `VolumeSnapshot` whose VSC lookup just failed is exactly the unbound case this fallback targets. On that one path, forcing `Delete` would override a policy the user set.

So the objection holds on one path out of six. Rather than argue the edge, I would rather narrow the change: locate the orphaned `VolumeSnapshotContent` and delete it, but leave `Spec.DeletionPolicy` alone. That repairs the orphan on all six paths and overrides no user-set policy anywhere — dropping the half that was objected to and keeping the half nobody has disputed.

Happy to push that version if maintainers agree it is the right shape.

# fixed issue

Fixes #10287

# Please indicate you've done the following:
- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
