### PR TITLE
fix nil pointer dereference in EnsureDeleteVS and EnsureDeleteVSC timeout paths

### DIFF
--- a/changelogs/unreleased/10292-samay43
+++ b/changelogs/unreleased/10292-samay43
@@ -1,0 +1,1 @@
+Fix nil pointer dereference in EnsureDeleteVS and EnsureDeleteVSC when the API call times out before the object is retrieved

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -187,6 +187,12 @@ func EnsureDeleteVS(ctx context.Context, snapshotClient snapshotter.SnapshotV1In
 
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
+			// updated is only set once the VS has been retrieved successfully, so it
+			// is still nil when the deadline is exceeded before that happens, e.g.
+			// when the first Get times out. No finalizers are available to report.
+			if updated == nil {
+				return errors.Errorf("timeout to assure VolumeSnapshot %s is deleted", vsName)
+			}
 			return errors.Errorf("timeout to assure VolumeSnapshot %s is deleted, finalizers in VS %v", vsName, updated.Finalizers)
 		} else {
 			return errors.Wrapf(err, "error to assure VolumeSnapshot is deleted, %s", vsName)
@@ -246,6 +252,12 @@ func EnsureDeleteVSC(ctx context.Context, snapshotClient snapshotter.SnapshotV1I
 
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
+			// updated is only set once the VSC has been retrieved successfully, so it
+			// is still nil when the deadline is exceeded before that happens, e.g.
+			// when the first Get times out. No finalizers are available to report.
+			if updated == nil {
+				return errors.Errorf("timeout to assure VolumeSnapshotContent %s is deleted", vscName)
+			}
 			return errors.Errorf("timeout to assure VolumeSnapshotContent %s is deleted, finalizers in VSC %v", vscName, updated.Finalizers)
 		} else {
 			return errors.Wrapf(err, "error to assure VolumeSnapshotContent is deleted, %s", vscName)

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -378,6 +378,29 @@ func TestEnsureDeleteVS(t *testing.T) {
 			err: "timeout to assure VolumeSnapshot fake-vs is deleted, finalizers in VS []",
 		},
 		{
+			name:      "wait timeout before the VS is ever retrieved",
+			vsName:    "fake-vs",
+			namespace: "fake-ns",
+			clientObj: []runtime.Object{vsObjWithFinalizer},
+			reactors: []reactor{
+				{
+					verb:     "delete",
+					resource: "volumesnapshots",
+					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, nil
+					},
+				},
+				{
+					verb:     "get",
+					resource: "volumesnapshots",
+					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, context.DeadlineExceeded
+					},
+				},
+			},
+			err: "timeout to assure VolumeSnapshot fake-vs is deleted",
+		},
+		{
 			name:      "success",
 			vsName:    "fake-vs",
 			namespace: "fake-ns",
@@ -487,6 +510,28 @@ func TestEnsureDeleteVSC(t *testing.T) {
 				},
 			},
 			err: "timeout to assure VolumeSnapshotContent fake-vsc is deleted, finalizers in VSC []",
+		},
+		{
+			name:      "wait timeout before the VSC is ever retrieved",
+			vscName:   "fake-vsc",
+			clientObj: []runtime.Object{vscObjWithFinalizer},
+			reactors: []reactor{
+				{
+					verb:     "delete",
+					resource: "volumesnapshotcontents",
+					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, nil
+					},
+				},
+				{
+					verb:     "get",
+					resource: "volumesnapshotcontents",
+					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, context.DeadlineExceeded
+					},
+				},
+			},
+			err: "timeout to assure VolumeSnapshotContent fake-vsc is deleted",
 		},
 		{
 			name:      "success",


### PR DESCRIPTION
# Please add a summary of your change

`EnsureDeleteVS` and `EnsureDeleteVSC` keep the last-seen object in an `updated` pointer so that, on timeout, they can report which finalizers are holding the deletion. That pointer is only assigned when a `Get` succeeds, but the `context.DeadlineExceeded` branch dereferences it unconditionally:

```go
var updated *snapshotv1api.VolumeSnapshot   // nil
err = wait.PollUntilContextTimeout(ctx, waitInternal, timeout, true, func(ctx context.Context) (bool, error) {
	vs, err := snapshotClient.VolumeSnapshots(vsNamespace).Get(ctx, vsName, metav1.GetOptions{})
	if err != nil {
		if apierrors.IsNotFound(err) {
			return true, nil        // deleted - success, updated still nil
		}
		return false, errors.Wrapf(err, "error to get VolumeSnapshot %s", vsName)  // abort, updated still nil
	}

	updated = vs                    // the only assignment
	return false, nil
})

if err != nil {
	if errors.Is(err, context.DeadlineExceeded) {
		return errors.Errorf("timeout to assure VolumeSnapshot %s is deleted, finalizers in VS %v", vsName, updated.Finalizers)
	}
```

If the first `Get` does not return before the poll deadline, client-go returns an error wrapping `context.DeadlineExceeded`. `errors.Wrapf` preserves that chain, so `errors.Is` matches and we dereference a pointer that was never assigned. The error path built to explain *why* deletion is stuck is itself what crashes.

Both callers are in `pkg/exposer/csi_snapshot.go` on the DataUpload expose path, so this is a node-agent panic rather than a returned error. It triggers precisely when the cluster is already unhealthy enough for API calls to be timing out.

This adds a nil guard that falls back to reporting the timeout without finalizers. The wording matches `pkg/util/kube/pvc_pv.go:223`, which already handles a timeout this way, so no new error semantics are introduced. When the object *was* retrieved the existing message is unchanged — the finalizer list is genuinely useful for debugging a stuck deletion and is worth keeping.

Each new test case seeds a fixture that *has* finalizers and makes `Get` return `context.DeadlineExceeded`. Finalizers are therefore absent from the message only because the object was never read, which pins the nil path specifically rather than just asserting on an object that happens to have none. Both cases panic on `main` without the source change:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]
	csi.EnsureDeleteVS    pkg/util/csi/volume_snapshot.go:190
	csi.EnsureDeleteVSC   pkg/util/csi/volume_snapshot.go:249
```

Note that a pre-expired context does *not* reach this, since `PollUntilContextTimeout` with `immediate=true` runs the condition once regardless; it needs a real timeout during the API call.

# Does your change fix a particular issue?

Part of #10291

#10291 covers five call sites across two packages. This PR fixes the two in `pkg/util/csi`; the three in `pkg/util/kube` are handled in a companion PR. Using "Part of" rather than "Fixes" so the issue is not auto-closed while the other half is still open.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
