### PR TITLE
fix nil pointer dereference in EnsureDeletePVC, EnsureDeletePV and EnsureDeletePod timeout paths

### DIFF
--- a/changelogs/unreleased/10293-samay43
+++ b/changelogs/unreleased/10293-samay43
@@ -1,0 +1,1 @@
+Fix nil pointer dereference in EnsureDeletePVC, EnsureDeletePV and EnsureDeletePod when the API call times out before the object is retrieved

--- a/pkg/util/kube/pod.go
+++ b/pkg/util/kube/pod.go
@@ -129,6 +129,12 @@ func EnsureDeletePod(ctx context.Context, podGetter corev1client.CoreV1Interface
 
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
+			// updated is only set once the pod has been retrieved successfully, so it
+			// is still nil when the deadline is exceeded before that happens, e.g.
+			// when the first Get times out. No finalizers are available to report.
+			if updated == nil {
+				return errors.Errorf("timeout to assure pod %s is deleted", pod)
+			}
 			return errors.Errorf("timeout to assure pod %s is deleted, finalizers in pod %v", pod, updated.Finalizers)
 		} else {
 			return errors.Wrapf(err, "error to assure pod is deleted, %s", pod)

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -107,6 +107,29 @@ func TestEnsureDeletePod(t *testing.T) {
 			err: "timeout to assure pod fake-pod is deleted, finalizers in pod []",
 		},
 		{
+			name:      "wait timeout before the pod is ever retrieved",
+			podName:   "fake-pod",
+			namespace: "fake-ns",
+			clientObj: []runtime.Object{podObjectWithFinalizer},
+			reactors: []reactor{
+				{
+					verb:     "delete",
+					resource: "pods",
+					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, nil
+					},
+				},
+				{
+					verb:     "get",
+					resource: "pods",
+					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, context.DeadlineExceeded
+					},
+				},
+			},
+			err: "timeout to assure pod fake-pod is deleted",
+		},
+		{
 			name:      "wait fail",
 			podName:   "fake-pod",
 			namespace: "fake-ns",

--- a/pkg/util/kube/pvc_pv.go
+++ b/pkg/util/kube/pvc_pv.go
@@ -153,6 +153,12 @@ func EnsureDeletePVC(ctx context.Context, pvcGetter corev1client.CoreV1Interface
 
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
+			// updated is only set once the PVC has been retrieved successfully, so it
+			// is still nil when the deadline is exceeded before that happens, e.g.
+			// when the first Get times out. No finalizers are available to report.
+			if updated == nil {
+				return errors.Errorf("timeout to assure pvc %s is deleted", pvcName)
+			}
 			return errors.Errorf("timeout to assure pvc %s is deleted, finalizers in pvc %v", pvcName, updated.Finalizers)
 		} else {
 			return errors.Wrapf(err, "error to ensure pvc deleted for %s", pvcName)
@@ -189,6 +195,12 @@ func EnsureDeletePV(ctx context.Context, pvGetter corev1client.CoreV1Interface, 
 
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
+			// updated is only set once the PV has been retrieved successfully, so it
+			// is still nil when the deadline is exceeded before that happens, e.g.
+			// when the first Get times out. No finalizers are available to report.
+			if updated == nil {
+				return errors.Errorf("timeout to assure pv %s is deleted", pvName)
+			}
 			return errors.Errorf("timeout to assure pv %s is deleted, finalizers in pv %v", pvName, updated.Finalizers)
 		} else {
 			return errors.Wrapf(err, "error to ensure pv deleted for %s", pvName)

--- a/pkg/util/kube/pvc_pv_test.go
+++ b/pkg/util/kube/pvc_pv_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kube
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -686,6 +687,30 @@ func TestEnsureDeletePVC(t *testing.T) {
 				},
 			},
 			err: "timeout to assure pvc fake-pvc is deleted, finalizers in pvc []",
+		},
+		{
+			name:      "wait timeout before the pvc is ever retrieved",
+			pvcName:   "fake-pvc",
+			namespace: "fake-ns",
+			clientObj: []runtime.Object{pvcObjectWithFinalizer},
+			timeout:   time.Millisecond,
+			reactors: []reactor{
+				{
+					verb:     "delete",
+					resource: "persistentvolumeclaims",
+					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, pvcObject, nil
+					},
+				},
+				{
+					verb:     "get",
+					resource: "persistentvolumeclaims",
+					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, context.DeadlineExceeded
+					},
+				},
+			},
+			err: "timeout to assure pvc fake-pvc is deleted",
 		},
 	}
 
@@ -2059,6 +2084,13 @@ func TestEnsureDeletePV(t *testing.T) {
 		},
 	}
 
+	pvObjWithFinalizer := &corev1api.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "fake-pv",
+			Finalizers: []string{"fake-finalizer-1", "fake-finalizer-2"},
+		},
+	}
+
 	tests := []struct {
 		name          string
 		pvName        string
@@ -2133,6 +2165,29 @@ func TestEnsureDeletePV(t *testing.T) {
 				},
 			},
 			expectedErr: "timeout to assure pv fake-pv is deleted, finalizers in pv []",
+		},
+		{
+			name:          "wait timeout before the pv is ever retrieved",
+			pvName:        "fake-pv",
+			timeout:       time.Millisecond,
+			kubeClientObj: []runtime.Object{pvObjWithFinalizer},
+			kubeReactors: []reactor{
+				{
+					verb:     "delete",
+					resource: "persistentvolumes",
+					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, nil
+					},
+				},
+				{
+					verb:     "get",
+					resource: "persistentvolumes",
+					reactorFunc: func(action clientTesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, context.DeadlineExceeded
+					},
+				},
+			},
+			expectedErr: "timeout to assure pv fake-pv is deleted",
 		},
 	}
 


### PR DESCRIPTION
# Please add a summary of your change

`EnsureDeletePVC`, `EnsureDeletePV` and `EnsureDeletePod` keep the last-seen object in an `updated` pointer so that, on timeout, they can report which finalizers are holding the deletion. That pointer is only assigned when a `Get` succeeds, but the `context.DeadlineExceeded` branch dereferences it unconditionally:

```go
var updated *corev1api.Pod          // nil
err = wait.PollUntilContextTimeout(ctx, waitInternal, timeout, true, func(ctx context.Context) (bool, error) {
	po, err := podGetter.Pods(namespace).Get(ctx, pod, metav1.GetOptions{})
	if err != nil {
		if apierrors.IsNotFound(err) {
			return true, nil        // deleted - success, updated still nil
		}
		return false, errors.Wrapf(err, "error to get pod %s", pod)  // abort, updated still nil
	}

	updated = po                    // the only assignment
	return false, nil
})

if err != nil {
	if errors.Is(err, context.DeadlineExceeded) {
		return errors.Errorf("timeout to assure pod %s is deleted, finalizers in pod %v", pod, updated.Finalizers)
	}
```

If the first `Get` does not return before the poll deadline, client-go returns an error wrapping `context.DeadlineExceeded`. `errors.Wrapf` preserves that chain, so `errors.Is` matches and we dereference a pointer that was never assigned. The error path built to explain *why* deletion is stuck is itself what crashes.

All callers are in `pkg/exposer/generic_restore.go` on the DataDownload restore path, so this is a node-agent panic rather than a returned error. It triggers precisely when the cluster is already unhealthy enough for API calls to be timing out.

This adds a nil guard that falls back to reporting the timeout without finalizers. The wording matches `pkg/util/kube/pvc_pv.go:223`, which already handles a timeout this way, so no new error semantics are introduced. When the object *was* retrieved the existing message is unchanged — the finalizer list is genuinely useful for debugging a stuck deletion and is worth keeping.

Each new test case seeds a fixture that *has* finalizers and makes `Get` return `context.DeadlineExceeded`. Finalizers are therefore absent from the message only because the object was never read, which pins the nil path specifically rather than just asserting on an object that happens to have none. All three cases panic on `main` without the source change:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]
	kube.EnsureDeletePod   pkg/util/kube/pod.go:132
	kube.EnsureDeletePVC   pkg/util/kube/pvc_pv.go:156
	kube.EnsureDeletePV    pkg/util/kube/pvc_pv.go:192
```

Note that a pre-expired context does *not* reach this, since `PollUntilContextTimeout` with `immediate=true` runs the condition once regardless; it needs a real timeout during the API call.

Two incidental test changes worth calling out so they are not a surprise in review:

- `"context"` was added to the imports in `pvc_pv_test.go`, which did not previously import it.
- A `pvObjWithFinalizer` fixture was added to `TestEnsureDeletePV`, which had no with-finalizers PV to build the new case from.

# Does your change fix a particular issue?

Part of #10291

#10291 covers five call sites across two packages. This PR fixes the three in `pkg/util/kube`; the two in `pkg/util/csi` are handled in a companion PR. Using "Part of" rather than "Fixes" so the issue is not auto-closed while the other half is still open.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
