### PR TITLE
Log the discovered parent snapshot ID, not the empty lookup parameter

### DIFF
--- a/pkg/uploader/block/snapshot.go
+++ b/pkg/uploader/block/snapshot.go
@@ -149,6 +149,12 @@ func snapshotSource(
 
 func getParentBackupInfo(ctx context.Context, rep udmrepo.BackupRepo, forceFull bool, parentSnapshot string, volumeID string, realSource string, snapshotTags map[string]string, log logrus.FieldLogger) parentBackupInfo {
 	var previous *udmrepo.Snapshot
+
+	// parentID names whichever snapshot ended up being the parent. On the discovery
+	// branch the parentSnapshot parameter is empty by definition, so logging it there
+	// produces messages that describe a decision without naming the object it was about.
+	parentID := parentSnapshot
+
 	if !forceFull {
 		if parentSnapshot != "" {
 			snap, err := rep.GetSnapshot(ctx, udmrepo.ID(parentSnapshot))
@@ -166,6 +172,7 @@ func getParentBackupInfo(ctx context.Context, rep udmrepo.BackupRepo, forceFull 
 				log.WithError(err).Warn("Failed to search previous snapshot, fallback to full backup")
 			} else {
 				previous = &snap
+				parentID = string(snap.RootObject.ID)
 				log.Infof("Using previous snapshot %s", snap.RootObject.ID)
 			}
 		}
@@ -176,21 +183,21 @@ func getParentBackupInfo(ctx context.Context, rep udmrepo.BackupRepo, forceFull 
 	parentInfo := parentBackupInfo{}
 	if previous != nil {
 		if previous.Tags == nil {
-			log.Warnf("No tag from parent snapshot %s, fallback to full backup", parentSnapshot)
+			log.Warnf("No tag from parent snapshot %s, fallback to full backup", parentID)
 		} else if previous.Tags[uploader.CBTChangeIDTag] == "" {
-			log.Warnf("No ChangeID tag from parent snapshot %s, fallback to full backup", parentSnapshot)
+			log.Warnf("No ChangeID tag from parent snapshot %s, fallback to full backup", parentID)
 		} else if previous.Tags[uploader.CBTVolumeIDTag] == "" {
-			log.Warnf("No VolumeID tag from parent snapshot %s, fallback to full backup", parentSnapshot)
+			log.Warnf("No VolumeID tag from parent snapshot %s, fallback to full backup", parentID)
 		} else if previous.Tags[uploader.CBTVolumeIDTag] != volumeID {
-			log.Warnf("VolumeID %s from parent snapshot %s is not expected as %s, fallback to full backup", previous.Tags[uploader.CBTVolumeIDTag], parentSnapshot, volumeID)
+			log.Warnf("VolumeID %s from parent snapshot %s is not expected as %s, fallback to full backup", previous.Tags[uploader.CBTVolumeIDTag], parentID, volumeID)
 		} else if obj, err := loadObjectFromSnapshot(ctx, rep, previous); err != nil {
-			log.WithError(err).Warnf("Failed to load object from parent snapshot %s, fallback to full backup", parentSnapshot)
+			log.WithError(err).Warnf("Failed to load object from parent snapshot %s, fallback to full backup", parentID)
 		} else {
 			parentInfo.parentObject = obj
 			parentInfo.changeID = previous.Tags[uploader.CBTChangeIDTag]
 			parentInfo.volumeID = previous.Tags[uploader.CBTVolumeIDTag]
 
-			log.Infof("Using parent snapshot %s, start time %v, end time %v, description %s", parentSnapshot, previous.StartTime, previous.EndTime, previous.Description)
+			log.Infof("Using parent snapshot %s, start time %v, end time %v, description %s", parentID, previous.StartTime, previous.EndTime, previous.Description)
 		}
 	}
 

--- a/pkg/uploader/block/snapshot_test.go
+++ b/pkg/uploader/block/snapshot_test.go
@@ -21,11 +21,13 @@ package block
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -273,6 +275,58 @@ func TestSnapshotSource(t *testing.T) {
 			mockBlkup.AssertExpectations(t)
 		})
 	}
+}
+
+// TestGetParentBackupInfoLogsDiscoveredParentID pins that the parent-selection messages
+// name the snapshot they are about. On the discovery branch the parentSnapshot parameter
+// is empty by definition, so logging it there emits "Using parent snapshot , start time ..."
+// - a decision logged without the identifier needed to act on it.
+func TestGetParentBackupInfoLogsDiscoveredParentID(t *testing.T) {
+	const volumeID = "vol-123"
+	const realSource = "/test/source"
+	const rootObj = "root-obj-42"
+
+	snapshotTags := map[string]string{
+		uploader.SnapshotRequesterTag: "test-requester",
+		uploader.SnapshotUploaderTag:  uploader.BlockType,
+	}
+
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	repo := udmrepomocks.NewBackupRepo(t)
+	repo.On("ListSnapshot", mock.Anything, realSource).
+		Return([]udmrepo.Snapshot{{
+			RootObject: udmrepo.ObjectMetadata{ID: rootObj},
+			Tags: map[string]string{
+				uploader.CBTChangeIDTag:       "cid-abc",
+				uploader.CBTVolumeIDTag:       volumeID,
+				uploader.SnapshotRequesterTag: "test-requester",
+				uploader.SnapshotUploaderTag:  uploader.BlockType,
+			},
+		}}, nil)
+	repo.On("ReadMetadata", mock.Anything, udmrepo.ID(rootObj)).
+		Return(&udmrepo.Metadata{
+			SubObjects: []udmrepo.ObjectMetadata{{ID: udmrepo.ID("parent-obj")}},
+		}, nil)
+
+	info := getParentBackupInfo(
+		context.Background(), repo,
+		false, "", // no explicit parent -> discovery branch
+		volumeID, realSource, snapshotTags, logger,
+	)
+
+	require.Equal(t, udmrepo.ID("parent-obj"), info.parentObject)
+
+	var found bool
+	for _, entry := range hook.AllEntries() {
+		if strings.HasPrefix(entry.Message, "Using parent snapshot ") {
+			found = true
+			assert.Contains(t, entry.Message, rootObj,
+				"parent-selection message must name the discovered snapshot, got %q", entry.Message)
+		}
+	}
+	require.True(t, found, "expected a \"Using parent snapshot\" message")
 }
 
 func TestGetParentBackupInfo(t *testing.T) {


### PR DESCRIPTION
> [!Note]
> Responses generated with Claude

## Does your change fix a particular issue?

No issue for this one — it's a pure log-string fix with no behavior change. `/kind changelog-not-required`.

## Summary

`getParentBackupInfo`'s parent-selection log lines interpolated the `parentSnapshot` parameter. On the discovery branch (no explicit parent passed by the caller — the normal path for scheduled/incremental backups) that parameter is empty by definition, so every message about which parent was chosen, or why a run fell back to full, printed no identifier at all:

```
Using parent snapshot , start time 2026-08-15 14:35:07.865360327 +0000 UTC, end time ..., description ...
```

Note the empty slot after "snapshot". This directly slows down diagnosing why a fallback happened, since the one identifier that would let someone check the object in question is missing from the message describing the decision.

## Fix

Bind a `parentID` local that starts as the `parentSnapshot` parameter but is overwritten once a parent is actually resolved (explicit or discovered), and log that instead of the parameter directly. No behavior change — this only affects log message content.

## Test

`TestGetParentBackupInfoLogsDiscoveredParentID` — asserts the "Using parent snapshot" message on the discovery branch names the discovered snapshot's root object ID, not an empty string. Verified this test fails against the pre-fix code (empty string in the message) and passes after.

## Live validation

This fix was developed and validated live on a real Ceph/ODF cluster as part of a combined branch carrying all five of this campaign's fixes together (this one plus #10306/#10307/#10308/#10309's changes) — full diff: https://github.com/velero-io/velero/compare/main...kaovilai:velero:ceph-changeid

Specifically for this fix: with all five patches deployed together, parent-snapshot log lines correctly named the discovered snapshot ID across every incremental backup run in that session (including the CBT-error and cross-volume-mismatch test cases used to validate #10306 and #10294), where every prior run had printed an empty slot. It has not additionally been re-validated live in isolation as this standalone single-commit PR — the unit test above is what pins the behavior at this PR's own scope.

## Please indicate you have done the following:

- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Created a changelog file (`make new-changelog`) or comment `/kind changelog-not-required` on this PR — will comment `/kind changelog-not-required` once this PR is open, since it's log-only.
- [x] Updated the corresponding documentation in `site/content/docs/main` — n/a, no user-observable behavior change.
