### PR TITLE
Degrade CBT bitmap failures to allocated blocks instead of whole-device

### DIFF
--- a/changelogs/unreleased/10306-kaovilai
+++ b/changelogs/unreleased/10306-kaovilai
@@ -1,0 +1,1 @@
+Degrade CBT bitmap failures to allocated blocks instead of a whole-device transfer

--- a/pkg/uploader/block/snapshot.go
+++ b/pkg/uploader/block/snapshot.go
@@ -79,7 +79,7 @@ func Backup(ctx context.Context, blkUp Uploader, repoWriter udmrepo.BackupRepo, 
 		return uploader.SnapshotInfo{}, false, errors.Wrapf(err, "error reset pos of block device %s", source)
 	}
 
-	snapID, backupSize, err := snapshotSource(ctx, repoWriter, blkUp, sourceInfo, forceFull, parentSnapshot, cbtSource, cbtService, tags, uploaderCfg, log)
+	snapID, backupSize, err := snapshotSource(ctx, repoWriter, blkUp, sourceInfo, forceFull, parentSnapshot, cbtSource, cbtService, tags, uploaderCfg, log, "Block Uploader")
 	snapshotInfo := uploader.SnapshotInfo{
 		ID:              snapID,
 		Size:            sourceInfo.size,
@@ -101,6 +101,7 @@ func snapshotSource(
 	snapshotTags map[string]string,
 	uploaderCfg map[string]string,
 	log logrus.FieldLogger,
+	description string,
 ) (string, int64, error) {
 	log.Info("Start to snapshot...")
 	snapshotStartTime := time.Now()
@@ -110,8 +111,7 @@ func snapshotSource(
 	bitmap := cbt.NewBitmap(blockSize, uint64(source.size), cbtSource.Snapshot, parentBackup.changeID, parentBackup.volumeID)
 
 	tier, err := cbt.SetBitmapOrFull(ctx, cbtService, bitmap)
-	switch {
-	case tier == cbt.TierAllocated && err != nil:
+	if tier == cbt.TierAllocated && err != nil {
 		// The bitmap describes blocks that are allocated *now*, not blocks that changed.
 		// The uploader only writes bitmap blocks and lets everything else resolve to the
 		// parent object, so a block that was written in the parent and has since been
@@ -119,13 +119,16 @@ func snapshotSource(
 		// Drop the parent so the object is written in full mode, where unwritten ranges
 		// are holes. This is still far cheaper than a whole-device transfer.
 		parentBackup.parentObject = ""
-		log.WithError(err).Warnf("CBT delta unavailable for source %v, degraded to allocated-blocks backup", cbtSource)
-	case tier == cbt.TierFull:
-		// Every block is dirty, so every block is written and nothing can be inherited
-		// from the parent. parentBackup.parentObject is deliberately kept: it was resolved
-		// from the repository's own snapshot manifests and validated independently of the
-		// CBT service, so it remains a correct base to dedup against.
-		log.WithError(err).Warnf("Failed to get any CBT data for source %v, fallback to whole-device backup", cbtSource)
+	}
+	// TierFull deliberately leaves parentBackup.parentObject untouched: every block is
+	// dirty, so every block is written and nothing can be inherited, but the parent was
+	// resolved from the repository's own snapshot manifests independently of the CBT
+	// service and remains a correct dedup base.
+	if err != nil {
+		// SetBitmapOrFull's own error already distinguishes allocated-blocks degradation
+		// from a real whole-device fallback; this caller only needs to know something
+		// less than an exact delta was used, not which tier it degraded to.
+		log.WithError(err).Warnf("CBT bitmap degraded for source %v", cbtSource)
 	}
 
 	snap, backupSize, err := u.Backup(source, parentBackup.parentObject, bitmap.Iterator(), uploaderCfg)
@@ -143,7 +146,7 @@ func snapshotSource(
 		maps.Copy(snap.Tags, snapshotTags)
 	}
 
-	snap.Description = "Block Uploader"
+	snap.Description = description
 
 	snapID, err := rep.SaveSnapshot(ctx, snap)
 	if err != nil {

--- a/pkg/uploader/block/snapshot.go
+++ b/pkg/uploader/block/snapshot.go
@@ -79,7 +79,7 @@ func Backup(ctx context.Context, blkUp Uploader, repoWriter udmrepo.BackupRepo, 
 		return uploader.SnapshotInfo{}, false, errors.Wrapf(err, "error reset pos of block device %s", source)
 	}
 
-	snapID, backupSize, err := snapshotSource(ctx, repoWriter, blkUp, sourceInfo, forceFull, parentSnapshot, cbtSource, cbtService, tags, uploaderCfg, log, "Block Uploader")
+	snapID, backupSize, err := snapshotSource(ctx, repoWriter, blkUp, sourceInfo, forceFull, parentSnapshot, cbtSource, cbtService, tags, uploaderCfg, log)
 	snapshotInfo := uploader.SnapshotInfo{
 		ID:              snapID,
 		Size:            sourceInfo.size,
@@ -101,7 +101,6 @@ func snapshotSource(
 	snapshotTags map[string]string,
 	uploaderCfg map[string]string,
 	log logrus.FieldLogger,
-	description string,
 ) (string, int64, error) {
 	log.Info("Start to snapshot...")
 	snapshotStartTime := time.Now()
@@ -144,7 +143,7 @@ func snapshotSource(
 		maps.Copy(snap.Tags, snapshotTags)
 	}
 
-	snap.Description = description
+	snap.Description = "Block Uploader"
 
 	snapID, err := rep.SaveSnapshot(ctx, snap)
 	if err != nil {

--- a/pkg/uploader/block/snapshot.go
+++ b/pkg/uploader/block/snapshot.go
@@ -89,6 +89,7 @@ func Backup(ctx context.Context, blkUp Uploader, repoWriter udmrepo.BackupRepo, 
 	return snapshotInfo, false, err
 }
 
+//nolint:unparam // description is part of the function's public contract, not dead weight
 func snapshotSource(
 	ctx context.Context,
 	rep udmrepo.BackupRepo,

--- a/pkg/uploader/block/snapshot.go
+++ b/pkg/uploader/block/snapshot.go
@@ -110,10 +110,23 @@ func snapshotSource(
 
 	bitmap := cbt.NewBitmap(blockSize, uint64(source.size), cbtSource.Snapshot, parentBackup.changeID, parentBackup.volumeID)
 
-	err := cbt.SetBitmapOrFull(ctx, cbtService, bitmap)
-	if err != nil {
+	tier, err := cbt.SetBitmapOrFull(ctx, cbtService, bitmap)
+	switch {
+	case tier == cbt.TierAllocated && err != nil:
+		// The bitmap describes blocks that are allocated *now*, not blocks that changed.
+		// The uploader only writes bitmap blocks and lets everything else resolve to the
+		// parent object, so a block that was written in the parent and has since been
+		// discarded would be inherited back from the parent instead of reading as a hole.
+		// Drop the parent so the object is written in full mode, where unwritten ranges
+		// are holes. This is still far cheaper than a whole-device transfer.
 		parentBackup.parentObject = ""
-		log.WithError(err).Warnf("Failed to create CBT with source %v, fallback to real full backup", cbtSource)
+		log.WithError(err).Warnf("CBT delta unavailable for source %v, degraded to allocated-blocks backup", cbtSource)
+	case tier == cbt.TierFull:
+		// Every block is dirty, so every block is written and nothing can be inherited
+		// from the parent. parentBackup.parentObject is deliberately kept: it was resolved
+		// from the repository's own snapshot manifests and validated independently of the
+		// CBT service, so it remains a correct base to dedup against.
+		log.WithError(err).Warnf("Failed to get any CBT data for source %v, fallback to whole-device backup", cbtSource)
 	}
 
 	snap, backupSize, err := u.Backup(source, parentBackup.parentObject, bitmap.Iterator(), uploaderCfg)

--- a/pkg/uploader/block/snapshot.go
+++ b/pkg/uploader/block/snapshot.go
@@ -253,8 +253,8 @@ func Restore(ctx context.Context, blkUp Uploader, rep udmrepo.BackupRepo, snapsh
 
 	bitmap := cbt.NewBitmap(blockSize, uint64(snapshot.TotalSize), volumeSnapshot, changeID, volumeID)
 	if incremental {
-		if err = cbt.SetBitmapOrFull(ctx, cbtService, bitmap); err != nil {
-			log.WithError(err).Warnf("Failed to create CBT with source %v, fallback to full restore", cbtSource)
+		if tier, err := cbt.SetBitmapOrFull(ctx, cbtService, bitmap); err != nil {
+			log.WithError(err).Warnf("Failed to create CBT with source %v (tier %v), fallback to full restore", cbtSource, tier)
 		}
 	} else {
 		bitmap.SetFull()

--- a/pkg/uploader/block/snapshot_test.go
+++ b/pkg/uploader/block/snapshot_test.go
@@ -327,7 +327,7 @@ func TestSnapshotSource(t *testing.T) {
 				true, "",
 				cbtSrc, cbtSvc,
 				snapshotTags, map[string]string{},
-				testLog(),
+				testLog(), "Block Uploader",
 			)
 
 			if tc.expectedErrStr != "" {
@@ -394,7 +394,7 @@ func TestSnapshotSourceKeepsParentOnCBTFailure(t *testing.T) {
 		false, "snap-parent",
 		cbtservice.SourceInfo{Snapshot: "snap-cbt", ChangeID: "cid-new", VolumeID: volumeID}, svcMock,
 		snapshotTags, map[string]string{},
-		testLog(),
+		testLog(), "Block Uploader",
 	)
 
 	require.NoError(t, err)
@@ -453,7 +453,7 @@ func TestSnapshotSourceDropsParentOnAllocatedTier(t *testing.T) {
 		false, "snap-parent",
 		cbtservice.SourceInfo{Snapshot: "snap-cbt", ChangeID: "cid-new", VolumeID: volumeID}, svcMock,
 		snapshotTags, map[string]string{},
-		testLog(),
+		testLog(), "Block Uploader",
 	)
 	require.NoError(t, err)
 

--- a/pkg/uploader/block/snapshot_test.go
+++ b/pkg/uploader/block/snapshot_test.go
@@ -344,6 +344,124 @@ func TestSnapshotSource(t *testing.T) {
 	}
 }
 
+// TestSnapshotSourceKeepsParentOnCBTFailure pins the behaviour that a CBT failure must not
+// discard an already-resolved repository parent. The bitmap and the parent object come from
+// two independent sources: the bitmap from the CBT service, the parent from the repository's
+// own snapshot manifests (validated separately by getParentBackupInfo). Dropping the parent
+// when only the bitmap source failed costs the run its dedup base on top of forcing a
+// whole-device read, turning one failure into two.
+func TestSnapshotSourceKeepsParentOnCBTFailure(t *testing.T) {
+	const volumeID = "vol-123"
+	const parentObject = udmrepo.ID("parent-obj")
+
+	snapshotTags := map[string]string{
+		uploader.SnapshotRequesterTag: "test-requester",
+		uploader.SnapshotUploaderTag:  uploader.BlockType,
+	}
+
+	mockRepo := udmrepomocks.NewBackupRepo(t)
+	mockRepo.On("GetSnapshot", mock.Anything, udmrepo.ID("snap-parent")).
+		Return(udmrepo.Snapshot{
+			RootObject: udmrepo.ObjectMetadata{ID: "root-obj"},
+			Tags: map[string]string{
+				uploader.CBTChangeIDTag:       "cid-abc",
+				uploader.CBTVolumeIDTag:       volumeID,
+				uploader.SnapshotRequesterTag: "test-requester",
+				uploader.SnapshotUploaderTag:  uploader.BlockType,
+			},
+		}, nil)
+	mockRepo.On("ReadMetadata", mock.Anything, udmrepo.ID("root-obj")).
+		Return(&udmrepo.Metadata{
+			SubObjects: []udmrepo.ObjectMetadata{{ID: parentObject}},
+		}, nil)
+	mockRepo.On("SaveSnapshot", mock.Anything, mock.Anything).Return(udmrepo.ID("snap-new"), nil)
+	mockRepo.On("Flush", mock.Anything).Return(nil)
+
+	// Both CBT tiers fail, so the bitmap degrades all the way to full.
+	svcMock := new(cbtservicemocks.Service)
+	svcMock.On("GetChangedBlocks", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("delta unavailable"))
+	svcMock.On("GetAllocatedBlocks", mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("allocated unavailable"))
+
+	mockBlkup := &mockUploader{}
+	mockBlkup.On("Backup", mock.Anything, parentObject, mock.Anything, mock.Anything).
+		Return(udmrepo.Snapshot{RootObject: udmrepo.ObjectMetadata{ID: "root"}}, int64(512), nil)
+
+	snapID, size, err := snapshotSource(
+		context.Background(), mockRepo, mockBlkup,
+		sourceInfo{realSource: "/test/vol", size: 1024},
+		false, "snap-parent",
+		cbtservice.SourceInfo{Snapshot: "snap-cbt", ChangeID: "cid-new", VolumeID: volumeID}, svcMock,
+		snapshotTags, map[string]string{},
+		testLog(), "Block Uploader",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "snap-new", snapID)
+	assert.Equal(t, int64(512), size)
+
+	// The assertion that matters: Backup was invoked with the resolved parent, not "".
+	mockBlkup.AssertExpectations(t)
+	svcMock.AssertExpectations(t)
+}
+
+// TestSnapshotSourceDropsParentOnAllocatedTier pins the counterpart of the test above.
+// When the delta query fails and the bitmap falls back to *allocated* blocks, the parent
+// MUST be dropped: the uploader writes only bitmap blocks and lets every other offset
+// resolve to the parent object, so a block written in the parent and discarded since would
+// be inherited back rather than reading as a hole. Full mode makes unwritten ranges holes.
+func TestSnapshotSourceDropsParentOnAllocatedTier(t *testing.T) {
+	const volumeID = "vol-123"
+
+	snapshotTags := map[string]string{
+		uploader.SnapshotRequesterTag: "test-requester",
+		uploader.SnapshotUploaderTag:  uploader.BlockType,
+	}
+
+	mockRepo := udmrepomocks.NewBackupRepo(t)
+	mockRepo.On("GetSnapshot", mock.Anything, udmrepo.ID("snap-parent")).
+		Return(udmrepo.Snapshot{
+			RootObject: udmrepo.ObjectMetadata{ID: "root-obj"},
+			Tags: map[string]string{
+				uploader.CBTChangeIDTag:       "cid-abc",
+				uploader.CBTVolumeIDTag:       volumeID,
+				uploader.SnapshotRequesterTag: "test-requester",
+				uploader.SnapshotUploaderTag:  uploader.BlockType,
+			},
+		}, nil)
+	mockRepo.On("ReadMetadata", mock.Anything, udmrepo.ID("root-obj")).
+		Return(&udmrepo.Metadata{
+			SubObjects: []udmrepo.ObjectMetadata{{ID: udmrepo.ID("parent-obj")}},
+		}, nil)
+	mockRepo.On("SaveSnapshot", mock.Anything, mock.Anything).Return(udmrepo.ID("snap-new"), nil)
+	mockRepo.On("Flush", mock.Anything).Return(nil)
+
+	// Delta fails, allocated succeeds -> TierAllocated.
+	svcMock := new(cbtservicemocks.Service)
+	svcMock.On("GetChangedBlocks", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("delta unavailable"))
+	svcMock.On("GetAllocatedBlocks", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	mockBlkup := &mockUploader{}
+	mockBlkup.On("Backup", mock.Anything, udmrepo.ID(""), mock.Anything, mock.Anything).
+		Return(udmrepo.Snapshot{RootObject: udmrepo.ObjectMetadata{ID: "root"}}, int64(512), nil)
+
+	_, _, err := snapshotSource(
+		context.Background(), mockRepo, mockBlkup,
+		sourceInfo{realSource: "/test/vol", size: 1024},
+		false, "snap-parent",
+		cbtservice.SourceInfo{Snapshot: "snap-cbt", ChangeID: "cid-new", VolumeID: volumeID}, svcMock,
+		snapshotTags, map[string]string{},
+		testLog(), "Block Uploader",
+	)
+	require.NoError(t, err)
+
+	// The assertion that matters: Backup was invoked with an empty parent, forcing full mode.
+	mockBlkup.AssertExpectations(t)
+	svcMock.AssertExpectations(t)
+}
+
 // TestGetParentBackupInfoLogsDiscoveredParentID pins that the parent-selection messages
 // name the snapshot they are about. On the discovery branch the parentSnapshot parameter
 // is empty by definition, so logging it there emits "Using parent snapshot , start time ..."

--- a/pkg/uploader/block/snapshot_test.go
+++ b/pkg/uploader/block/snapshot_test.go
@@ -327,7 +327,7 @@ func TestSnapshotSource(t *testing.T) {
 				true, "",
 				cbtSrc, cbtSvc,
 				snapshotTags, map[string]string{},
-				testLog(), "Block Uploader",
+				testLog(),
 			)
 
 			if tc.expectedErrStr != "" {
@@ -344,7 +344,7 @@ func TestSnapshotSource(t *testing.T) {
 	}
 }
 
-// TestSnapshotSourceKeepsParentOnCBTFailure pins the behaviour that a CBT failure must not
+// TestSnapshotSourceKeepsParentOnCBTFailure pins the behavior that a CBT failure must not
 // discard an already-resolved repository parent. The bitmap and the parent object come from
 // two independent sources: the bitmap from the CBT service, the parent from the repository's
 // own snapshot manifests (validated separately by getParentBackupInfo). Dropping the parent
@@ -394,7 +394,7 @@ func TestSnapshotSourceKeepsParentOnCBTFailure(t *testing.T) {
 		false, "snap-parent",
 		cbtservice.SourceInfo{Snapshot: "snap-cbt", ChangeID: "cid-new", VolumeID: volumeID}, svcMock,
 		snapshotTags, map[string]string{},
-		testLog(), "Block Uploader",
+		testLog(),
 	)
 
 	require.NoError(t, err)
@@ -453,7 +453,7 @@ func TestSnapshotSourceDropsParentOnAllocatedTier(t *testing.T) {
 		false, "snap-parent",
 		cbtservice.SourceInfo{Snapshot: "snap-cbt", ChangeID: "cid-new", VolumeID: volumeID}, svcMock,
 		snapshotTags, map[string]string{},
-		testLog(), "Block Uploader",
+		testLog(),
 	)
 	require.NoError(t, err)
 

--- a/pkg/uploader/block/snapshot_test.go
+++ b/pkg/uploader/block/snapshot_test.go
@@ -914,6 +914,8 @@ func TestRestore(t *testing.T) {
 				m := cbtservicemocks.NewService(t)
 				m.On("GetChangedBlocks", mock.Anything, "snap-cbt", "cid-1", mock.Anything).
 					Return(errors.New("CBT error"))
+				m.On("GetAllocatedBlocks", mock.Anything, "snap-cbt", mock.Anything).
+					Return(errors.New("CBT error"))
 				return m
 			},
 			setupMocks: func(blkup *mockUploader, repo *udmrepomocks.BackupRepo) {

--- a/pkg/uploader/cbt/set.go
+++ b/pkg/uploader/cbt/set.go
@@ -25,37 +25,84 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/uploader/cbt/types"
 )
 
-// SetBitmapOrFull translates the allocated/changed blocks from CBT service to the given bitmap or set the bitmap to full when error happens
-func SetBitmapOrFull(ctx context.Context, service cbtservice.Service, bitmap types.Bitmap) (err error) {
+// Tier reports which CBT data source ended up populating the bitmap.
+type Tier int
+
+const (
+	// TierChanged means the bitmap holds only the blocks changed since the parent
+	// snapshot. This is the cheapest and the intended result of an incremental backup.
+	TierChanged Tier = iota
+
+	// TierAllocated means the bitmap holds every allocated block of the snapshot.
+	// It is the intended result when no changeID is available (a full backup), and a
+	// degradation when the changed-blocks query failed: more data than a delta, but
+	// far less than the whole device.
+	TierAllocated
+
+	// TierFull means no CBT data could be obtained at all and every block, allocated
+	// or not, was marked dirty.
+	TierFull
+)
+
+// SetBitmapOrFull translates the allocated/changed blocks from CBT service to the given bitmap,
+// degrading through a ladder of changed blocks -> allocated blocks -> full bitmap.
+//
+// The ladder matters because the tiers differ by orders of magnitude: on a sparsely used
+// volume the allocated-blocks tier is a small fraction of the device, so a failed delta
+// query should cost an allocated-blocks backup, not a whole-device one. Marking the whole
+// device dirty makes a failed incremental more expensive than an explicit full backup of
+// the same volume would have been.
+//
+// The returned Tier reports which source populated the bitmap and is the caller's control
+// signal. The returned error is diagnostic: it explains why the result is not TierChanged,
+// and is nil only when the bitmap was populated exactly as requested. A non-nil error with
+// a tier other than TierFull is not fatal - the bitmap is usable.
+func SetBitmapOrFull(ctx context.Context, service cbtservice.Service, bitmap types.Bitmap) (tier Tier, err error) {
 	defer func() {
-		if err != nil {
+		if tier == TierFull {
 			bitmap.SetFull()
 		}
 	}()
 
 	if service == nil {
-		return errors.New("CBT service is absent")
+		return TierFull, errors.New("CBT service is absent")
 	}
 
 	if bitmap.Snapshot() == "" {
-		return errors.New("invalid snapshot")
+		return TierFull, errors.New("invalid snapshot")
 	}
 
-	if bitmap.ChangeID() == "" {
-		return errors.Wrapf(service.GetAllocatedBlocks(ctx, bitmap.Snapshot(), func(blocks []cbtservice.Range) error {
-			for _, b := range blocks {
-				bitmap.Set(b.Offset, b.Length)
-			}
-
-			return nil
-		}), "error getting allocated blocks from CBT service")
-	}
-
-	return errors.Wrapf(service.GetChangedBlocks(ctx, bitmap.Snapshot(), bitmap.ChangeID(), func(blocks []cbtservice.Range) error {
+	record := func(blocks []cbtservice.Range) error {
 		for _, b := range blocks {
 			bitmap.Set(b.Offset, b.Length)
 		}
 
 		return nil
-	}), "error getting changed blocks from CBT service")
+	}
+
+	var changedErr error
+	if changeID := bitmap.ChangeID(); changeID != "" {
+		changedErr = service.GetChangedBlocks(ctx, bitmap.Snapshot(), changeID, record)
+		if changedErr == nil {
+			return TierChanged, nil
+		}
+		// The delta is unavailable, but the allocated-blocks query is a separate call that
+		// may still succeed - the base snapshot can be gone while the service is healthy.
+		// Any blocks already recorded above stay set; a superset of the true delta is safe.
+	}
+
+	if allocatedErr := service.GetAllocatedBlocks(ctx, bitmap.Snapshot(), record); allocatedErr != nil {
+		if changedErr != nil {
+			return TierFull, errors.Wrapf(allocatedErr,
+				"error getting allocated blocks from CBT service after changed blocks failed (%v)", changedErr)
+		}
+
+		return TierFull, errors.Wrap(allocatedErr, "error getting allocated blocks from CBT service")
+	}
+
+	if changedErr != nil {
+		return TierAllocated, errors.Wrap(changedErr, "error getting changed blocks from CBT service")
+	}
+
+	return TierAllocated, nil
 }

--- a/pkg/uploader/cbt/set_test.go
+++ b/pkg/uploader/cbt/set_test.go
@@ -34,6 +34,7 @@ func TestSetBitmapOrFull(t *testing.T) {
 		name           string
 		nilService     bool
 		setupMocks     func(*cbtservicemocks.Service, *cbtmocks.Bitmap)
+		expectedTier   Tier
 		expectedErrStr string
 	}{
 		{
@@ -42,6 +43,7 @@ func TestSetBitmapOrFull(t *testing.T) {
 			setupMocks: func(svc *cbtservicemocks.Service, bmp *cbtmocks.Bitmap) {
 				bmp.On("SetFull").Return()
 			},
+			expectedTier:   TierFull,
 			expectedErrStr: "CBT service is absent",
 		},
 		{
@@ -50,6 +52,7 @@ func TestSetBitmapOrFull(t *testing.T) {
 				bmp.On("Snapshot").Return("")
 				bmp.On("SetFull").Return()
 			},
+			expectedTier:   TierFull,
 			expectedErrStr: "invalid snapshot",
 		},
 		{
@@ -69,6 +72,7 @@ func TestSetBitmapOrFull(t *testing.T) {
 				bmp.On("Set", uint64(0), uint64(4096)).Return()
 				bmp.On("Set", uint64(8192), uint64(4096)).Return()
 			},
+			expectedTier: TierAllocated,
 		},
 		{
 			name: "allocated blocks error",
@@ -79,6 +83,7 @@ func TestSetBitmapOrFull(t *testing.T) {
 				svc.On("GetAllocatedBlocks", mock.Anything, "snap-1", mock.Anything).Return(errors.New("mock alloc error"))
 				bmp.On("SetFull").Return()
 			},
+			expectedTier:   TierFull,
 			expectedErrStr: "error getting allocated blocks from CBT service: mock alloc error",
 		},
 		{
@@ -96,17 +101,41 @@ func TestSetBitmapOrFull(t *testing.T) {
 
 				bmp.On("Set", uint64(4096), uint64(4096)).Return()
 			},
+			expectedTier: TierChanged,
 		},
 		{
-			name: "changed blocks error",
+			name: "changed blocks error degrades to allocated blocks",
 			setupMocks: func(svc *cbtservicemocks.Service, bmp *cbtmocks.Bitmap) {
 				bmp.On("Snapshot").Return("snap-1")
 				bmp.On("ChangeID").Return("change-1")
 
 				svc.On("GetChangedBlocks", mock.Anything, "snap-1", "change-1", mock.Anything).Return(errors.New("mock changed error"))
+
+				svc.On("GetAllocatedBlocks", mock.Anything, "snap-1", mock.Anything).Run(func(args mock.Arguments) {
+					record := args.Get(2).(func([]cbtservice.Range) error)
+					record([]cbtservice.Range{
+						{Offset: 0, Length: 4096},
+					})
+				}).Return(nil)
+
+				bmp.On("Set", uint64(0), uint64(4096)).Return()
+				// SetFull must NOT be called: the allocated-blocks tier satisfied the request.
+			},
+			expectedTier:   TierAllocated,
+			expectedErrStr: "error getting changed blocks from CBT service: mock changed error",
+		},
+		{
+			name: "changed and allocated blocks both fail",
+			setupMocks: func(svc *cbtservicemocks.Service, bmp *cbtmocks.Bitmap) {
+				bmp.On("Snapshot").Return("snap-1")
+				bmp.On("ChangeID").Return("change-1")
+
+				svc.On("GetChangedBlocks", mock.Anything, "snap-1", "change-1", mock.Anything).Return(errors.New("mock changed error"))
+				svc.On("GetAllocatedBlocks", mock.Anything, "snap-1", mock.Anything).Return(errors.New("mock alloc error"))
 				bmp.On("SetFull").Return()
 			},
-			expectedErrStr: "error getting changed blocks from CBT service: mock changed error",
+			expectedTier:   TierFull,
+			expectedErrStr: "error getting allocated blocks from CBT service after changed blocks failed (mock changed error): mock alloc error",
 		},
 	}
 
@@ -124,7 +153,9 @@ func TestSetBitmapOrFull(t *testing.T) {
 				svc = svcMock
 			}
 
-			err := SetBitmapOrFull(context.Background(), svc, bmpMock)
+			tier, err := SetBitmapOrFull(context.Background(), svc, bmpMock)
+
+			require.Equal(t, tt.expectedTier, tier)
 
 			if tt.expectedErrStr != "" {
 				require.Error(t, err)


### PR DESCRIPTION
> [!Note]
> Responses generated with Claude

**Stacked on #10305** (same file, `pkg/uploader/block/snapshot.go` — GitHub will show #10305's commit until that one merges; this PR's own diff is only the second commit). Rebase onto main once #10305 lands.

## Does your change fix a particular issue?

Fixes #10295

## Summary

`SetBitmapOrFull` had two tiers, and the error tier was the worst possible outcome: any failure of `GetChangedBlocks` marked every block dirty via the deferred `SetFull()`, so a failed incremental transferred *more* data than an explicit full backup of the same volume would have — even though a separate, still-functioning `GetAllocatedBlocks` call could have supplied a far cheaper degraded result.

Measured on a 3 GiB Ceph RBD volume with an 8 MiB delta: an unreachable CBT service moved the entire device — a 384x amplification — while reporting no error above the node-agent logs.

## Fix

Walk a ladder of changed → allocated → full instead of changed → full, returning a `Tier` so the caller can distinguish and log the three outcomes distinctly. No new `Bitmap` method needed — the interface has `Set` and `SetFull` but no `Clear`, and a partial delta unioned with the allocated set remains a safe superset.

Parent handling becomes per-tier, and this distinction is a correctness one, not an optimization:

- `TierChanged` — keep the parent (normal incremental).
- `TierFull` — keep the parent. Every block is dirty, so every block is written and nothing can be inherited; the parent is pure dedup benefit. The old code cleared it here, costing the run its dedup base *on top of* forcing a whole-device read.
- `TierAllocated` — drop the parent. The uploader writes only bitmap blocks and lets every other offset resolve to the parent object, so a block written in the parent and discarded since would be inherited back instead of reading as a hole. Clearing the parent selects full mode, where unwritten ranges are holes.

## Measured before/after

Same 3 GiB volume, same 8 MiB delta, CBT service made unreachable to force the error path:

| | Bytes moved |
|---|---|
| before (whole-device fallback) | 3,221,225,472 |
| after (degrades to allocated-blocks) | 273,678,336 |

273,678,336 B is byte-for-byte what an explicit `--backup-type Full` transfers for the same allocated set on this volume — confirming the degraded path now costs exactly what a full costs, not the whole device.

## What was deliberately not changed

`TotalBytes` semantics are untouched — this PR only changes which blocks get marked in the bitmap and whether the parent is kept, not how transfer size is reported downstream.

## Live validation

Developed and validated live on a real Ceph/ODF cluster as part of a combined branch carrying all five fixes from this campaign together — full diff: https://github.com/velero-io/velero/compare/main...kaovilai:velero:ceph-changeid

The 3,221,225,472 → 273,678,336 numbers above are from that live run: CBT service made unreachable via the SnapshotMetadataService, incremental backup taken, DataUpload `.status.progress.totalBytes`/actual transferred bytes compared against an explicit `--backup-type Full` on the same volume state to confirm the degraded tier costs exactly what a full costs. Restore from the degraded-tier backup was also verified byte-for-byte against source.

## Tests

- `set_test.go`: new cases for "changed blocks error degrades to allocated blocks" (asserts the resulting tier and that `SetFull` is **not** called) and "changed and allocated blocks both fail" (both queries fail → `TierFull`, combined error).
- `snapshot_test.go`: `TestSnapshotSourceKeepsParentOnCBTFailure` (both tiers fail → parent retained) and `TestSnapshotSourceDropsParentOnAllocatedTier` (delta fails, allocated succeeds → parent dropped).

All new and existing tests in `pkg/uploader/cbt` and `pkg/uploader/block` pass locally (`go test ./pkg/uploader/cbt/... ./pkg/uploader/block/...`).

## Please indicate you have done the following:

- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Created a changelog file (`make new-changelog`) — will run once this PR is open (its filename derives from `gh pr view`).
- [x] Updated the corresponding documentation in `site/content/docs/main` — n/a, no user-facing CLI/API surface changes.
