### PR TITLE
Detect block uploader cancellation through wrapped errors

### DIFF
--- a/changelogs/unreleased/10308-kaovilai
+++ b/changelogs/unreleased/10308-kaovilai
@@ -1,0 +1,1 @@
+Fix block data mover cancellation being reported as a backup failure

--- a/pkg/uploader/provider/block.go
+++ b/pkg/uploader/provider/block.go
@@ -134,7 +134,11 @@ func (bp *blockProvider) RunBackup(
 
 	snapshotInfo, _, err := blockBackupFunc(ctx, blkUploader, bp.bkRepo, path, realSource, cbtParam.Source, forceFull, parentSnapshot, cbtParam.Service, uploaderCfg, tags, log)
 
-	if err == block.ErrCanceled {
+	// errors.Is, not ==: the sentinel is wrapped twice on its way here, by
+	// block/uploader.go ("error backing up bdev %s") and again by
+	// block/snapshot.go ("Failed to run uploader backup for si %v"), so an
+	// equality check never matches and cancellation gets reported as a failure.
+	if errors.Is(err, block.ErrCanceled) {
 		log.Warn("Block backup is canceled")
 		return snapshotInfo.ID, false, snapshotInfo.Size, snapshotInfo.IncrementalSize, ErrorCanceled
 	}
@@ -176,7 +180,8 @@ func (bp *blockProvider) RunRestore(
 
 	size, err := blockRestoreFunc(ctx, blkUploader, bp.bkRepo, snapshotID, volumePath, uploaderCfg, log)
 
-	if err == block.ErrCanceled {
+	// errors.Is, not ==: see the equivalent comment on the backup path above.
+	if errors.Is(err, block.ErrCanceled) {
 		log.Warn("Block restore is canceled")
 		return 0, ErrorCanceled
 	}

--- a/pkg/uploader/provider/block_test.go
+++ b/pkg/uploader/provider/block_test.go
@@ -372,6 +372,63 @@ func TestBlockProviderRunBackup(t *testing.T) {
 	}
 }
 
+// TestBlockProviderCancelThroughWrappedError pins that cancellation is recognised
+// after the sentinel has been wrapped, which is the only way it ever arrives in
+// production: block/uploader.go wraps it with "error backing up bdev %s" and
+// block/snapshot.go wraps that with "Failed to run uploader backup for si %v".
+//
+// Asserting on the message is useless here — provider.ErrorCanceled and
+// block.ErrCanceled carry the *same* text ("uploader is canceled"), so a substring
+// check passes whether or not the sentinel was actually recognised. The assertion
+// has to be on identity.
+func TestBlockProviderCancelThroughWrappedError(t *testing.T) {
+	t.Run("backup", func(t *testing.T) {
+		orig := blockBackupFunc
+		defer func() { blockBackupFunc = orig }()
+		blockBackupFunc = func(_ context.Context, _ block.Uploader, _ udmrepo.BackupRepo, _ string, _ string, _ cbtservice.SourceInfo, _ bool, _ string, _ cbtservice.Service, _ map[string]string, _ map[string]string, _ logrus.FieldLogger) (uploader.SnapshotInfo, bool, error) {
+			return uploader.SnapshotInfo{ID: "snap-cancel", Size: 2048, IncrementalSize: 1024}, false,
+				errors.Wrapf(
+					errors.Wrapf(block.ErrCanceled, "error backing up bdev %s", "ns/pvc"),
+					"Failed to run uploader backup for si %v", "si")
+		}
+
+		bp := &blockProvider{
+			requestorType: "test",
+			bkRepo:        udmrepomocks.NewBackupRepo(t),
+			log:           logrus.New(),
+		}
+
+		_, _, _, _, err := bp.RunBackup(
+			t.Context(), "/dev/sda", "ns/pvc", map[string]string{}, false, "",
+			CBTParam{}, uploader.PersistentVolumeBlock, map[string]string{},
+			&FakeBackupProgressUpdater{},
+		)
+
+		require.ErrorIs(t, err, ErrorCanceled,
+			"a wrapped block.ErrCanceled must surface as provider.ErrorCanceled; otherwise the "+
+				"DataUpload is marked Failed and the Backup PartiallyFailed for a user-requested cancel")
+	})
+
+	t.Run("restore", func(t *testing.T) {
+		orig := blockRestoreFunc
+		defer func() { blockRestoreFunc = orig }()
+		blockRestoreFunc = func(_ context.Context, _ block.Uploader, _ udmrepo.BackupRepo, _ string, _ string, _ map[string]string, _ logrus.FieldLogger) (int64, error) {
+			return 0, errors.Wrap(block.ErrCanceled, "error restoring bdev")
+		}
+
+		bp := &blockProvider{
+			requestorType: "test",
+			bkRepo:        udmrepomocks.NewBackupRepo(t),
+			log:           logrus.New(),
+		}
+
+		_, err := bp.RunRestore(t.Context(), "snap-1", "/dev/sda",
+			uploader.PersistentVolumeBlock, map[string]string{}, &blockMockProgressUpdater{})
+
+		require.ErrorIs(t, err, ErrorCanceled)
+	})
+}
+
 func TestBlockProviderRunRestore(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/pkg/uploader/provider/block_test.go
+++ b/pkg/uploader/provider/block_test.go
@@ -372,14 +372,14 @@ func TestBlockProviderRunBackup(t *testing.T) {
 	}
 }
 
-// TestBlockProviderCancelThroughWrappedError pins that cancellation is recognised
+// TestBlockProviderCancelThroughWrappedError pins that cancellation is recognized
 // after the sentinel has been wrapped, which is the only way it ever arrives in
 // production: block/uploader.go wraps it with "error backing up bdev %s" and
 // block/snapshot.go wraps that with "Failed to run uploader backup for si %v".
 //
 // Asserting on the message is useless here — provider.ErrorCanceled and
 // block.ErrCanceled carry the *same* text ("uploader is canceled"), so a substring
-// check passes whether or not the sentinel was actually recognised. The assertion
+// check passes whether or not the sentinel was actually recognized. The assertion
 // has to be on identity.
 func TestBlockProviderCancelThroughWrappedError(t *testing.T) {
 	t.Run("backup", func(t *testing.T) {


### PR DESCRIPTION
> [!Note]
> Responses generated with Claude

## Does your change fix a particular issue?

Fixes #10296

## Summary

Cancelling a block data mover backup (`.spec.cancel = true`) stops the uploader correctly, but the outcome was reported as a failure — `PartiallyFailed` Backup, `Failed` DataUpload with an error message — because the cancel sentinel was compared with `==` against an error that is always wrapped:

```go
// before, pkg/uploader/provider/block.go:137 (and :179 for restore)
if err == block.ErrCanceled {   // never true — err is always wrapped by cockroachdb/errors
    ...
}
```

The comparison could never match, so the correct `ErrorCanceled` return path was unreachable dead code, and every cancellation fell through to the generic error path.

## Fix

`errors.Is(err, block.ErrCanceled)` at both the backup and restore call sites — `cockroachdb/errors` wrapping preserves the chain, so `errors.Is` traverses it correctly where `==` cannot. Mirrors the pattern the filesystem/kopia provider already uses correctly (it asks the uploader for its **state** via `IsCanceled()` rather than inspecting the error at all — immune to wrapping by construction).

## Why existing tests missed it

Two compounding reasons:
1. The existing test injected the **bare** sentinel (`mockBackupErr: block.ErrCanceled`) — a shape production code never actually produces, so `==` matched only in the test.
2. The assertion used `require.ErrorContains(t, err, "uploader is canceled")`, and the two distinct sentinel errors involved have identical message text, so a substring assertion passed whether or not the sentinel was actually recognised.

## Live validation

Developed and validated live on a real Ceph/ODF cluster as part of a combined branch carrying all five fixes from this campaign together — full diff: https://github.com/velero-io/velero/compare/main...kaovilai:velero:ceph-changeid

Reproduced pre-fix (`.spec.cancel = true` on an in-flight block backup → `Failed` DataUpload, `PartiallyFailed` Backup, exact error text matching the snippet above from live node-agent logs), then re-ran the identical cancellation after deploying this fix: DataUpload correctly reached `Canceled`.

## Test

Regression test asserts `errors.Is` recognition against a **wrapped** cancellation error (the shape production actually produces), not the old bare-sentinel injection, and asserts identity (`require.ErrorIs`) rather than a message substring.

## Please indicate you have done the following:

- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Created a changelog file (`make new-changelog`) — will run once this PR is open.
- [x] Updated the corresponding documentation in `site/content/docs/main` — n/a, bug fix restoring documented cancel behavior, no new surface.
