### PR TITLE
Report a measured zero incremental instead of erasing it

### DIFF
--- a/changelogs/unreleased/10309-kaovilai
+++ b/changelogs/unreleased/10309-kaovilai
@@ -1,0 +1,1 @@
+Report a measured zero-byte incremental instead of erasing it from status

--- a/config/crd/v1/bases/velero.io_podvolumebackups.yaml
+++ b/config/crd/v1/bases/velero.io_podvolumebackups.yaml
@@ -205,8 +205,12 @@ spec:
                 nullable: true
                 type: string
               incrementalBytes:
-                description: IncrementalBytes holds the number of bytes new or changed
-                  since the last backup
+                description: |-
+                  IncrementalBytes holds the number of bytes new or changed since the last backup.
+                  A nil value means the uploader did not report a figure; a pointer to 0 means it
+                  reported zero, i.e. nothing changed and nothing was transferred. The two are
+                  distinct: erasing a measured zero makes a perfect incremental indistinguishable
+                  from a full transfer in every downstream report.
                 format: int64
                 type: integer
               message:

--- a/config/crd/v2alpha1/bases/velero.io_datauploads.yaml
+++ b/config/crd/v2alpha1/bases/velero.io_datauploads.yaml
@@ -192,8 +192,12 @@ spec:
                 nullable: true
                 type: object
               incrementalBytes:
-                description: IncrementalBytes holds the number of bytes new or changed
-                  since the last backup
+                description: |-
+                  IncrementalBytes holds the number of bytes new or changed since the last backup.
+                  A nil value means the uploader did not report a figure; a pointer to 0 means it
+                  reported zero, i.e. nothing changed and nothing was transferred. The two are
+                  distinct: erasing a measured zero makes a perfect incremental indistinguishable
+                  from a full transfer in every downstream report.
                 format: int64
                 type: integer
               message:

--- a/internal/volume/volumes_information.go
+++ b/internal/volume/volumes_information.go
@@ -174,8 +174,11 @@ type SnapshotDataMovementInfo struct {
 	// Moved snapshot data size.
 	Size int64 `json:"size"`
 
-	// Moved snapshot incremental size.
-	IncrementalSize int64 `json:"incrementalSize,omitempty"`
+	// Moved snapshot incremental size, i.e. the bytes actually transferred. Nil means
+	// the uploader reported no figure (including backups taken before this was
+	// recorded); a pointer to 0 means it transferred nothing, which is the ideal
+	// incremental and must stay distinguishable from "unknown".
+	IncrementalSize *int64 `json:"incrementalSize,omitempty"`
 
 	// The DataUpload's Status.Phase value
 	Phase velerov2alpha1.DataUploadPhase
@@ -224,8 +227,9 @@ type PodVolumeInfo struct {
 	// The snapshot corresponding volume size.
 	Size int64 `json:"size,omitempty"`
 
-	// The incremental snapshot size.
-	IncrementalSize int64 `json:"incrementalSize,omitempty"`
+	// The incremental snapshot size, i.e. the bytes actually transferred. Nil means
+	// the uploader reported no figure; a pointer to 0 means it transferred nothing.
+	IncrementalSize *int64 `json:"incrementalSize,omitempty"`
 
 	// The type of the uploader that uploads the data. The valid values are `kopia` and `restic`.
 	UploaderType string `json:"uploaderType"`

--- a/pkg/apis/velero/v1/pod_volume_backup_types.go
+++ b/pkg/apis/velero/v1/pod_volume_backup_types.go
@@ -124,9 +124,13 @@ type PodVolumeBackupStatus struct {
 	// +optional
 	Progress shared.DataMoveOperationProgress `json:"progress,omitempty"`
 
-	// IncrementalBytes holds the number of bytes new or changed since the last backup
+	// IncrementalBytes holds the number of bytes new or changed since the last backup.
+	// A nil value means the uploader did not report a figure; a pointer to 0 means it
+	// reported zero, i.e. nothing changed and nothing was transferred. The two are
+	// distinct: erasing a measured zero makes a perfect incremental indistinguishable
+	// from a full transfer in every downstream report.
 	// +optional
-	IncrementalBytes int64 `json:"incrementalBytes,omitempty"`
+	IncrementalBytes *int64 `json:"incrementalBytes,omitempty"`
 
 	// AcceptedTimestamp records the time the pod volume backup is to be prepared.
 	// The server's time is used for AcceptedTimestamp

--- a/pkg/apis/velero/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/velero/v1/zz_generated.deepcopy.go
@@ -1055,6 +1055,11 @@ func (in *PodVolumeBackupStatus) DeepCopyInto(out *PodVolumeBackupStatus) {
 		*out = (*in).DeepCopy()
 	}
 	out.Progress = in.Progress
+	if in.IncrementalBytes != nil {
+		in, out := &in.IncrementalBytes, &out.IncrementalBytes
+		*out = new(int64)
+		**out = **in
+	}
 	if in.AcceptedTimestamp != nil {
 		in, out := &in.AcceptedTimestamp, &out.AcceptedTimestamp
 		*out = (*in).DeepCopy()

--- a/pkg/apis/velero/v2alpha1/data_upload_types.go
+++ b/pkg/apis/velero/v2alpha1/data_upload_types.go
@@ -165,9 +165,13 @@ type DataUploadStatus struct {
 	// +optional
 	Progress shared.DataMoveOperationProgress `json:"progress,omitempty"`
 
-	// IncrementalBytes holds the number of bytes new or changed since the last backup
+	// IncrementalBytes holds the number of bytes new or changed since the last backup.
+	// A nil value means the uploader did not report a figure; a pointer to 0 means it
+	// reported zero, i.e. nothing changed and nothing was transferred. The two are
+	// distinct: erasing a measured zero makes a perfect incremental indistinguishable
+	// from a full transfer in every downstream report.
 	// +optional
-	IncrementalBytes int64 `json:"incrementalBytes,omitempty"`
+	IncrementalBytes *int64 `json:"incrementalBytes,omitempty"`
 
 	// Node is name of the node where the DataUpload is processed.
 	// +optional

--- a/pkg/apis/velero/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/velero/v2alpha1/zz_generated.deepcopy.go
@@ -270,6 +270,11 @@ func (in *DataUploadStatus) DeepCopyInto(out *DataUploadStatus) {
 		*out = (*in).DeepCopy()
 	}
 	out.Progress = in.Progress
+	if in.IncrementalBytes != nil {
+		in, out := &in.IncrementalBytes, &out.IncrementalBytes
+		*out = new(int64)
+		**out = **in
+	}
 	if in.AcceptedTimestamp != nil {
 		in, out := &in.AcceptedTimestamp, &out.AcceptedTimestamp
 		*out = (*in).DeepCopy()

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -39,6 +39,7 @@ import (
 	corev1api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -5681,7 +5682,7 @@ func TestUpdateVolumeInfos(t *testing.T) {
 						RetainedSnapshot: "vs-1",
 						SnapshotHandle:   "snapshot-id",
 						Size:             1000,
-						IncrementalSize:  500,
+						IncrementalSize:  ptr.To(int64(500)),
 						Phase:            velerov2alpha1.DataUploadPhaseFailed,
 					},
 				},
@@ -5721,7 +5722,7 @@ func TestUpdateVolumeInfos(t *testing.T) {
 						RetainedSnapshot: "vs-1",
 						SnapshotHandle:   "snapshot-id",
 						Size:             1000,
-						IncrementalSize:  500,
+						IncrementalSize:  ptr.To(int64(500)),
 						Phase:            velerov2alpha1.DataUploadPhaseCompleted,
 					},
 				},

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -39,11 +39,11 @@ import (
 	corev1api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 
 	"github.com/vmware-tanzu/velero/internal/resourcepolicies"
 	"github.com/vmware-tanzu/velero/internal/volume"

--- a/pkg/builder/data_upload_builder.go
+++ b/pkg/builder/data_upload_builder.go
@@ -147,7 +147,7 @@ func (d *DataUploadBuilder) Progress(progress shared.DataMoveOperationProgress) 
 
 // IncrementalBytes sets the DataUpload's IncrementalBytes.
 func (d *DataUploadBuilder) IncrementalBytes(incrementalBytes int64) *DataUploadBuilder {
-	d.object.Status.IncrementalBytes = incrementalBytes
+	d.object.Status.IncrementalBytes = &incrementalBytes
 	return d
 }
 

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -739,8 +739,12 @@ func describeDataMovement(d *Describer, details bool, info *volume.BackupVolumeI
 		d.Printf("\t\t\t\tData Mover: %s\n", dataMover)
 		d.Printf("\t\t\t\tUploader Type: %s\n", info.SnapshotDataMovementInfo.UploaderType)
 		d.Printf("\t\t\t\tMoved data Size (bytes): %d\n", info.SnapshotDataMovementInfo.Size)
-		if info.SnapshotDataMovementInfo.IncrementalSize > 0 {
-			d.Printf("\t\t\t\tIncremental data Size (bytes): %d\n", info.SnapshotDataMovementInfo.IncrementalSize)
+		// Print whenever the uploader measured a figure, including zero. A zero-delta
+		// incremental transfers nothing, which is the whole point of CBT; hiding it
+		// leaves only the volume size on display and makes the best possible result
+		// indistinguishable from a full transfer.
+		if info.SnapshotDataMovementInfo.IncrementalSize != nil {
+			d.Printf("\t\t\t\tIncremental data Size (bytes): %d\n", *info.SnapshotDataMovementInfo.IncrementalSize)
 		}
 		d.Printf("\t\t\t\tResult: %s\n", info.Result)
 	} else {
@@ -915,7 +919,7 @@ type volumesByPod struct {
 // Add adds a pod volume with the specified pod namespace, name
 // and volume to the appropriate group.
 // Used for both backup and restore
-func (v *volumesByPod) Add(namespace, name, volume, phase string, progress veleroapishared.DataMoveOperationProgress, incrementalBytes int64) {
+func (v *volumesByPod) Add(namespace, name, volume, phase string, progress veleroapishared.DataMoveOperationProgress, incrementalBytes *int64) {
 	if v.volumesByPodMap == nil {
 		v.volumesByPodMap = make(map[string]*podVolumeGroup)
 	}
@@ -925,8 +929,12 @@ func (v *volumesByPod) Add(namespace, name, volume, phase string, progress veler
 	// append backup progress percentage if backup is in progress
 	if phase == "In Progress" && progress.TotalBytes != 0 {
 		volume = fmt.Sprintf("%s (%.2f%%)", volume, float64(progress.BytesDone)/float64(progress.TotalBytes)*100)
-	} else if phase == string(velerov1api.PodVolumeBackupPhaseCompleted) && incrementalBytes > 0 {
-		volume = fmt.Sprintf("%s (size: %v, incremental size: %v)", volume, progress.TotalBytes, incrementalBytes)
+	} else if phase == string(velerov1api.PodVolumeBackupPhaseCompleted) && incrementalBytes != nil {
+		// Report the incremental figure whenever it was measured, including zero. Zero is
+		// the best possible outcome - nothing changed, so nothing was transferred - and
+		// suppressing it leaves only the volume size on display, which reads as a full
+		// transfer.
+		volume = fmt.Sprintf("%s (size: %v, incremental size: %v)", volume, progress.TotalBytes, *incrementalBytes)
 	} else if (phase == string(velerov1api.PodVolumeBackupPhaseCompleted) ||
 		phase == string(velerov1api.PodVolumeRestorePhaseCompleted)) &&
 		progress.TotalBytes > 0 {

--- a/pkg/cmd/util/output/backup_describer_test.go
+++ b/pkg/cmd/util/output/backup_describer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1api "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/vmware-tanzu/velero/internal/volume"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -629,7 +630,7 @@ func TestCSISnapshots(t *testing.T) {
 						SnapshotHandle:  "fake-repo-id-5",
 						OperationID:     "fake-operation-5",
 						Size:            100,
-						IncrementalSize: 50,
+						IncrementalSize: ptr.To(int64(50)),
 						Phase:           velerov2alpha1.DataUploadPhaseFailed,
 					},
 				},

--- a/pkg/cmd/util/output/backup_structured_describer.go
+++ b/pkg/cmd/util/output/backup_structured_describer.go
@@ -467,9 +467,13 @@ func describeDataMovementInSF(details bool, info *volume.BackupVolumeInfo, snaps
 
 		dataMovement["uploaderType"] = info.SnapshotDataMovementInfo.UploaderType
 		dataMovement["result"] = string(info.Result)
-		if info.SnapshotDataMovementInfo.Size > 0 || info.SnapshotDataMovementInfo.IncrementalSize > 0 {
+		if info.SnapshotDataMovementInfo.Size > 0 {
 			dataMovement["size"] = info.SnapshotDataMovementInfo.Size
-			dataMovement["incrementalSize"] = info.SnapshotDataMovementInfo.IncrementalSize
+		}
+		// Emit whenever measured, including zero - a zero-delta incremental transferred
+		// nothing, and that has to be reportable rather than absent.
+		if info.SnapshotDataMovementInfo.IncrementalSize != nil {
+			dataMovement["incrementalSize"] = *info.SnapshotDataMovementInfo.IncrementalSize
 		}
 
 		snapshotDetail["dataMovement"] = dataMovement

--- a/pkg/cmd/util/output/restore_describer.go
+++ b/pkg/cmd/util/output/restore_describer.go
@@ -417,7 +417,7 @@ func describePodVolumeRestores(d *Describer, restores []velerov1api.PodVolumeRes
 		restoresByPod := new(volumesByPod)
 
 		for _, restore := range restoresByPhase[phase] {
-			restoresByPod.Add(restore.Spec.Pod.Namespace, restore.Spec.Pod.Name, restore.Spec.Volume, phase, restore.Status.Progress, 0)
+			restoresByPod.Add(restore.Spec.Pod.Namespace, restore.Spec.Pod.Name, restore.Spec.Volume, phase, restore.Status.Progress, nil)
 		}
 
 		d.Printf("\t%s:\n", phase)

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clocks "k8s.io/utils/clock"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -514,7 +513,7 @@ func (r *DataUploadReconciler) OnDataUploadCompleted(ctx context.Context, namesp
 		du.Status.Path = result.Backup.Source.ByPath
 		du.Status.Phase = velerov2alpha1api.DataUploadPhaseCompleted
 		du.Status.SnapshotID = result.Backup.SnapshotID
-		du.Status.IncrementalBytes = ptr.To(result.Backup.IncrementalBytes)
+		du.Status.IncrementalBytes = result.Backup.IncrementalBytes
 		du.Status.CompletionTimestamp = &metav1.Time{Time: r.Clock.Now()}
 		if result.Backup.EmptySnapshot {
 			du.Status.Message = "volume was empty so no data was upload"

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clocks "k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -513,7 +514,7 @@ func (r *DataUploadReconciler) OnDataUploadCompleted(ctx context.Context, namesp
 		du.Status.Path = result.Backup.Source.ByPath
 		du.Status.Phase = velerov2alpha1api.DataUploadPhaseCompleted
 		du.Status.SnapshotID = result.Backup.SnapshotID
-		du.Status.IncrementalBytes = result.Backup.IncrementalBytes
+		du.Status.IncrementalBytes = ptr.To(result.Backup.IncrementalBytes)
 		du.Status.CompletionTimestamp = &metav1.Time{Time: r.Clock.Now()}
 		if result.Backup.EmptySnapshot {
 			du.Status.Message = "volume was empty so no data was upload"

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clocks "k8s.io/utils/clock"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -551,7 +550,7 @@ func (r *PodVolumeBackupReconciler) OnDataPathCompleted(ctx context.Context, nam
 		pvb.Status.Phase = velerov1api.PodVolumeBackupPhaseCompleted
 		pvb.Status.SnapshotID = result.Backup.SnapshotID
 		pvb.Status.CompletionTimestamp = &completionTime
-		pvb.Status.IncrementalBytes = ptr.To(result.Backup.IncrementalBytes)
+		pvb.Status.IncrementalBytes = result.Backup.IncrementalBytes
 		if result.Backup.EmptySnapshot {
 			pvb.Status.Message = "volume was empty so no snapshot was taken"
 		}

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clocks "k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -550,7 +551,7 @@ func (r *PodVolumeBackupReconciler) OnDataPathCompleted(ctx context.Context, nam
 		pvb.Status.Phase = velerov1api.PodVolumeBackupPhaseCompleted
 		pvb.Status.SnapshotID = result.Backup.SnapshotID
 		pvb.Status.CompletionTimestamp = &completionTime
-		pvb.Status.IncrementalBytes = result.Backup.IncrementalBytes
+		pvb.Status.IncrementalBytes = ptr.To(result.Backup.IncrementalBytes)
 		if result.Backup.EmptySnapshot {
 			pvb.Status.Message = "volume was empty so no snapshot was taken"
 		}

--- a/pkg/datamover/backup_micro_service_test.go
+++ b/pkg/datamover/backup_micro_service_test.go
@@ -152,7 +152,7 @@ func TestOnDataUploadCompleted(t *testing.T) {
 		{
 			name:        "marshal fail",
 			marshalErr:  errors.New("fake-marshal-error"),
-			expectedErr: "Failed to marshal backup result { false { } 0 0}: fake-marshal-error",
+			expectedErr: "Failed to marshal backup result { false { } 0 <nil>}: fake-marshal-error",
 		},
 		{
 			name:                "succeed",

--- a/pkg/datapath/data_path.go
+++ b/pkg/datapath/data_path.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/velero/internal/credentials"
@@ -220,7 +221,7 @@ func (dp *generalDataPath) StartBackup(source AccessPoint, uploaderConfig map[st
 			}
 			dp.callbacks.OnFailed(context.Background(), dp.namespace, dp.jobName, dataPathErr)
 		} else {
-			dp.callbacks.OnCompleted(context.Background(), dp.namespace, dp.jobName, Result{Backup: BackupResult{snapshotID, emptySnapshot, source, totalBytes, incrementalBytes}})
+			dp.callbacks.OnCompleted(context.Background(), dp.namespace, dp.jobName, Result{Backup: BackupResult{snapshotID, emptySnapshot, source, totalBytes, ptr.To(incrementalBytes)}})
 		}
 	}()
 

--- a/pkg/datapath/data_path_test.go
+++ b/pkg/datapath/data_path_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
 	"github.com/vmware-tanzu/velero/pkg/uploader/provider"
@@ -82,10 +83,11 @@ func TestAsyncBackup(t *testing.T) {
 			},
 			result: Result{
 				Backup: BackupResult{
-					SnapshotID:    "fake-snapshot",
-					EmptySnapshot: false,
-					Source:        AccessPoint{ByPath: "fake-path"},
-					TotalBytes:    1000,
+					SnapshotID:       "fake-snapshot",
+					EmptySnapshot:    false,
+					Source:           AccessPoint{ByPath: "fake-path"},
+					TotalBytes:       1000,
+					IncrementalBytes: ptr.To(int64(0)),
 				},
 			},
 			path: "fake-path",
@@ -96,7 +98,11 @@ func TestAsyncBackup(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dp := newGeneralDataPath("job-1", "test", nil, "velero", Callbacks{}, velerotest.NewLogger()).(*generalDataPath)
 			mockProvider := providerMock.NewProvider(t)
-			mockProvider.On("RunBackup", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(test.result.Backup.SnapshotID, test.result.Backup.EmptySnapshot, test.result.Backup.TotalBytes, test.result.Backup.IncrementalBytes, test.err)
+			var incrementalBytes int64
+			if test.result.Backup.IncrementalBytes != nil {
+				incrementalBytes = *test.result.Backup.IncrementalBytes
+			}
+			mockProvider.On("RunBackup", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(test.result.Backup.SnapshotID, test.result.Backup.EmptySnapshot, test.result.Backup.TotalBytes, incrementalBytes, test.err)
 			mockProvider.On("Close", mock.Anything).Return(nil)
 			dp.uploaderProv = mockProvider
 			dp.initialized = true

--- a/pkg/datapath/micro_service_watcher_test.go
+++ b/pkg/datapath/micro_service_watcher_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	kubeclientfake "k8s.io/client-go/kubernetes/fake"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/vmware-tanzu/velero/pkg/builder"
@@ -507,6 +508,42 @@ func TestGetResultFromMessage(t *testing.T) {
 						ByPath:  "fake-path-1",
 						VolMode: uploader.PersistentVolumeBlock,
 					},
+				},
+			},
+		},
+		{
+			// An old data mover (release-1.17 and earlier) predates IncrementalBytes and
+			// never writes the key at all -- this pins that its absence unmarshals to nil
+			// ("not measured"), not a zero value.
+			name:     "old mover message omits incrementalBytes -> nil",
+			taskType: TaskTypeBackup,
+			message:  "{\"snapshotID\":\"fake-snapshot-id\",\"emptySnapshot\":false,\"source\":{\"byPath\":\"fake-path-1\",\"volumeMode\":\"Block\"}}",
+			expectResult: Result{
+				Backup: BackupResult{
+					SnapshotID: "fake-snapshot-id",
+					Source: AccessPoint{
+						ByPath:  "fake-path-1",
+						VolMode: uploader.PersistentVolumeBlock,
+					},
+					IncrementalBytes: nil,
+				},
+			},
+		},
+		{
+			// A current mover reports a genuine zero explicitly -- this pins that the key
+			// being present with value 0 unmarshals to a non-nil pointer to 0 ("measured
+			// zero"), distinguishing it from the omitted-key case above.
+			name:     "current mover reports measured zero incrementalBytes -> non-nil zero",
+			taskType: TaskTypeBackup,
+			message:  "{\"snapshotID\":\"fake-snapshot-id\",\"emptySnapshot\":false,\"source\":{\"byPath\":\"fake-path-1\",\"volumeMode\":\"Block\"},\"incrementalBytes\":0}",
+			expectResult: Result{
+				Backup: BackupResult{
+					SnapshotID: "fake-snapshot-id",
+					Source: AccessPoint{
+						ByPath:  "fake-path-1",
+						VolMode: uploader.PersistentVolumeBlock,
+					},
+					IncrementalBytes: ptr.To(int64(0)),
 				},
 			},
 		},

--- a/pkg/datapath/types.go
+++ b/pkg/datapath/types.go
@@ -30,11 +30,16 @@ type Result struct {
 
 // BackupResult represents the result of a backup
 type BackupResult struct {
-	SnapshotID       string      `json:"snapshotID"`
-	EmptySnapshot    bool        `json:"emptySnapshot"`
-	Source           AccessPoint `json:"source,omitempty"`
-	TotalBytes       int64       `json:"totalBytes,omitempty"`
-	IncrementalBytes int64       `json:"incrementalBytes,omitempty"`
+	SnapshotID    string      `json:"snapshotID"`
+	EmptySnapshot bool        `json:"emptySnapshot"`
+	Source        AccessPoint `json:"source,omitempty"`
+	TotalBytes    int64       `json:"totalBytes,omitempty"`
+	// IncrementalBytes deliberately carries no omitempty. This struct crosses a JSON
+	// boundary from the data mover pod to the controller (see
+	// micro_service_watcher.go), and every uploader always reports a figure here, so
+	// 0 means "nothing was transferred" rather than "not measured". Omitting it would
+	// erase that measurement and make a perfect incremental look like an unmeasured one.
+	IncrementalBytes int64 `json:"incrementalBytes"`
 }
 
 // RestoreResult represents the result of a restore

--- a/pkg/datapath/types.go
+++ b/pkg/datapath/types.go
@@ -34,12 +34,11 @@ type BackupResult struct {
 	EmptySnapshot bool        `json:"emptySnapshot"`
 	Source        AccessPoint `json:"source,omitempty"`
 	TotalBytes    int64       `json:"totalBytes,omitempty"`
-	// IncrementalBytes deliberately carries no omitempty. This struct crosses a JSON
-	// boundary from the data mover pod to the controller (see
-	// micro_service_watcher.go), and every uploader always reports a figure here, so
-	// 0 means "nothing was transferred" rather than "not measured". Omitting it would
-	// erase that measurement and make a perfect incremental look like an unmeasured one.
-	IncrementalBytes int64 `json:"incrementalBytes"`
+	// IncrementalBytes is a pointer so an old data mover (release-1.17 and earlier,
+	// which predates this field) that omits it unmarshals to nil -- "not measured" --
+	// while a current mover reporting a genuine zero still serializes the key and
+	// unmarshals to a non-nil zero, distinguishing "measured zero" from "not measured".
+	IncrementalBytes *int64 `json:"incrementalBytes,omitempty"`
 }
 
 // RestoreResult represents the result of a restore

--- a/pkg/podvolume/backup_micro_service_test.go
+++ b/pkg/podvolume/backup_micro_service_test.go
@@ -156,7 +156,7 @@ func TestOnDataPathCompleted(t *testing.T) {
 		{
 			name:        "marshal fail",
 			marshalErr:  errors.New("fake-marshal-error"),
-			expectedErr: "Failed to marshal backup result { false { } 0 0}: fake-marshal-error",
+			expectedErr: "Failed to marshal backup result { false { } 0 <nil>}: fake-marshal-error",
 		},
 		{
 			name:                "succeed",


### PR DESCRIPTION
## Does your change fix a particular issue?

Fixes #10297

## Summary

When a CBT incremental has an **exactly zero** delta, velero reported it identically to a backup that moved the entire device — `Moved data Size (bytes): ` with no incremental line at all. The cause: `IncrementalBytes` was a non-pointer `int64` with `json:"incrementalBytes,omitempty"`, so a measured `0` was erased from the serialized object exactly like an unset field. A genuine zero-byte delta and "this backup predates incremental accounting" became indistinguishable on the wire.

## Fix

`DataUploadStatus.IncrementalBytes` and `PodVolumeBackupStatus.IncrementalBytes` change from `int64` to `*int64`, dropping `omitempty` in favor of an explicit nil-means-unmeasured / zero-means-measured-and-empty distinction. Plumbed through `internal/volume/volumes_information.go`, the data upload and pod-volume-backup controllers, and the describer output (both text and structured/JSON), with a `!= nil` guard replacing the old truthiness check.

**Correction to how this was described in the source commit's message:** the `pkg/datapath/types.go` change in this diff is neutral, not itself a fix — `omitempty` on a non-pointer `int64` is lossless for zero (marshal omits it, unmarshal restores `0`); that file's change doesn't change behavior on its own. The actual fix is the three things above: the two API status fields becoming `*int64`, the plumbing through `volumes_information.go`, and the describer guard changing to `!= nil`. Flagging this so review doesn't spend time looking for a bug in `datapath/types.go` that isn't there.

## Measured before/after

- Before: a run with a genuine zero-byte delta rendered as `` on `status.incrementalBytes` (`oc get ... -o custom-columns` prints ``, not `0`) and no incremental line in `describe` output — identical to a never-measured backup.
- After: `describe` output distinguishes `Incremental data Size (bytes): 0` from the absent case. A backward-compatibility check confirmed an old backup (created before this field existed, so genuinely `nil`) still renders with no incremental line, as before — the pointer change doesn't retroactively claim zero for backups that never measured it.

## Live validation

Developed and validated live on a real Ceph/ODF cluster as part of a combined branch carrying all five fixes from this campaign together — full diff: https://github.com/velero-io/velero/compare/main...kaovilai:velero:ceph-changeid

The before/after above is from that live run: two back-to-back incrementals with zero writes in between produced a genuine zero-byte delta, confirmed via node-agent logs showing the CBT service reported no changed blocks, then compared `status.incrementalBytes` and `describe --details` output pre-fix vs. post-fix on the same backup object. The backward-compatibility check against an older, pre-field backup was also done live against real stored data on that cluster, not synthesized.

## Scope beyond block

Not block-only: the same `omitempty` erasure existed on `PodVolumeBackupStatus`, so this affects the filesystem/kopia path too, not just the block data mover.

## Docs

No `site/content/docs/main` page currently documents `velero backup describe`'s field-by-field output, so there's nothing to update there for this change — the new `Incremental data Size` line is self-explanatory in the existing describe format. Flagging this explicitly since a prior revision of this description incorrectly claimed a docs update was included.

## Please indicate you have done the following:

- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Created a changelog file (`make new-changelog`) — will run once this PR is open.
- [ ] Updated the corresponding documentation in `site/content/docs/main` — n/a, see Docs section above.
