### PR TITLE
assert expected errors from the test case rather than the returned error

### DIFF
--- a/changelogs/unreleased/10312-samay43
+++ b/changelogs/unreleased/10312-samay43
@@ -1,0 +1,1 @@
+Assert expected errors from the test case rather than the returned error in pkg/util/csi tests

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -202,7 +202,7 @@ func TestWaitVolumeSnapshotReady(t *testing.T) {
 			fakeClient := snapshotFake.NewSimpleClientset(test.clientObj...)
 
 			vs, err := WaitVolumeSnapshotReady(t.Context(), fakeClient.SnapshotV1(), test.vsName, test.namespace, time.Millisecond, velerotest.NewLogger())
-			if err != nil {
+			if test.err != "" {
 				require.EqualError(t, err, test.err)
 			} else {
 				require.NoError(t, err)
@@ -288,7 +288,7 @@ func TestGetVolumeSnapshotContentForVolumeSnapshot(t *testing.T) {
 			fakeClient := snapshotFake.NewSimpleClientset(test.clientObj...)
 
 			vs, err := GetVolumeSnapshotContentForVolumeSnapshot(context.TODO(), test.snapshotObj, fakeClient.SnapshotV1())
-			if err != nil {
+			if test.err != "" {
 				require.EqualError(t, err, test.err)
 			} else {
 				require.NoError(t, err)
@@ -417,7 +417,7 @@ func TestEnsureDeleteVS(t *testing.T) {
 			}
 
 			err := EnsureDeleteVS(t.Context(), fakeSnapshotClient.SnapshotV1(), test.vsName, test.namespace, time.Millisecond)
-			if err != nil {
+			if test.err != "" {
 				assert.EqualError(t, err, test.err)
 			} else {
 				assert.NoError(t, err)


### PR DESCRIPTION
# Please add a summary of your change

Three of the table-driven tests in `pkg/util/csi/volume_snapshot_test.go` decide whether to assert an error based on what the function returned, rather than on what the test case expects:

```go
if err != nil {
	require.EqualError(t, err, test.err)
} else {
	require.NoError(t, err)
}
```

If a case sets `err` but the function returns `nil`, this takes the `else` branch and `require.NoError` passes. The expected error is never checked, so the test passes even though the behaviour is wrong.

Keying the branch off `test.err` instead means the assertion follows what the test expects:

```go
if test.err != "" {
	require.EqualError(t, err, test.err)
} else {
	require.NoError(t, err)
}
```

Changed in three places:

- `TestWaitVolumeSnapshotReady`
- `TestGetVolumeSnapshotContentForVolumeSnapshot`
- `TestEnsureDeleteVS`

`TestEnsureDeleteVSC`, just below these, already does it this way, so this also makes the file consistent with itself.

To be clear about the scope: no test is currently failing because of this, and all of them still pass after the change. It doesn't fix a live bug — it removes a way for future cases added to these tables to pass when they shouldn't.

# Does your change fix a particular issue?

No issue for this one. It carries forward the one part of #10187 that's still relevant — the rest of that PR threaded `ctx` through `GetVolumeSnapshotContentForVolumeSnapshot`, which has since landed via #10247, so I'm closing #10187 and bringing just this piece across.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
