### PR TITLE
Cleanup: Remove deprecated --wait flag from velero uninstall

### DIFF
--- a/changelogs/unreleased/10317-opbot-xd
+++ b/changelogs/unreleased/10317-opbot-xd
@@ -1,0 +1,1 @@
+Cleanup: Remove deprecated --wait flag from velero uninstall

--- a/pkg/cmd/cli/uninstall/uninstall.go
+++ b/pkg/cmd/cli/uninstall/uninstall.go
@@ -57,13 +57,11 @@ var resToDelete = []kbclient.ObjectList{}
 
 // uninstallOptions collects all the options for uninstalling Velero from a Kubernetes cluster.
 type uninstallOptions struct {
-	wait  bool // deprecated
 	force bool
 }
 
 // BindFlags adds command line values to the options struct.
 func (o *uninstallOptions) BindFlags(flags *pflag.FlagSet) {
-	flags.BoolVar(&o.wait, "wait", o.wait, "Wait for Velero uninstall to be ready. Optional. Deprecated.")
 	flags.BoolVar(&o.force, "force", o.force, "Forces the Velero uninstall. Optional.")
 }
 
@@ -81,10 +79,6 @@ Use '--force' to skip the prompt confirming if you want to uninstall Velero.
 		`,
 		Example: ` # velero uninstall --namespace staging`,
 		Run: func(c *cobra.Command, args []string) {
-			if o.wait {
-				fmt.Println("Warning: the \"--wait\" option is deprecated and will be removed in a future release. The uninstall command always waits for the uninstall to complete.")
-			}
-
 			// Confirm if not asked to force-skip confirmation
 			if !o.force {
 				fmt.Println("You are about to uninstall Velero.")


### PR DESCRIPTION
# Please add a summary of your change

This PR removes the deprecated `--wait` flag from the `velero uninstall` command as it natively waits for the uninstall process to complete without requiring the flag.

Specifically, this PR:
- Removes the `wait` boolean field from the `uninstallOptions` struct in `pkg/cmd/cli/uninstall/uninstall.go`.
- Removes the flag binding for `--wait`.
- Removes the warning print statement about the deprecated flag.

# Does your change fix a particular issue?

Fixes #10316

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.