### PR TITLE
Issue 10321: fill the error to the corresponding CR when data mover pod is evicted

### DIFF
--- a/changelogs/unreleased/10322-Lyndon-Li
+++ b/changelogs/unreleased/10322-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #10321, when data mover pod is evicted get the message from the data mover pod instead of the terminal message

--- a/pkg/datapath/micro_service_watcher.go
+++ b/pkg/datapath/micro_service_watcher.go
@@ -326,8 +326,10 @@ func (ms *microServiceBRWatcher) startWatch() {
 		} else {
 			if strings.HasSuffix(terminateMessage, ErrCancelled) {
 				ms.callbacks.OnCancelled(ms.ctx, ms.namespace, ms.taskName)
-			} else {
+			} else if terminateMessage != "" {
 				ms.callbacks.OnFailed(ms.ctx, ms.namespace, ms.taskName, errors.New(terminateMessage))
+			} else {
+				ms.callbacks.OnFailed(ms.ctx, ms.namespace, ms.taskName, errors.New(lastPod.Status.Message))
 			}
 		}
 

--- a/pkg/datapath/micro_service_watcher.go
+++ b/pkg/datapath/micro_service_watcher.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -72,8 +73,8 @@ type microServiceBRWatcher struct {
 	associatedObject    string
 	eventCh             chan *corev1api.Event
 	podCh               chan *corev1api.Pod
-	startedFromEvent    bool
-	terminatedFromEvent bool
+	startedFromEvent    atomic.Bool
+	terminatedFromEvent atomic.Bool
 	wgWatcher           sync.WaitGroup
 	eventInformer       ctrlcache.Informer
 	podInformer         ctrlcache.Informer
@@ -285,7 +286,7 @@ func (ms *microServiceBRWatcher) startWatch() {
 		}
 
 	epilogLoop:
-		for !ms.startedFromEvent || !ms.terminatedFromEvent {
+		for !ms.startedFromEvent.Load() || !ms.terminatedFromEvent.Load() {
 			select {
 			case <-ms.ctx.Done():
 				ms.log.Warn("Watch loop is canceled on waiting final event")
@@ -303,11 +304,11 @@ func (ms *microServiceBRWatcher) startWatch() {
 
 		logger.Infof("Finish waiting data path pod, phase %s, message %s", lastPod.Status.Phase, terminateMessage)
 
-		if !ms.startedFromEvent {
+		if !ms.startedFromEvent.Load() {
 			logger.Warn("VGDP seems not started")
 		}
 
-		if ms.startedFromEvent && !ms.terminatedFromEvent {
+		if ms.startedFromEvent.Load() && !ms.terminatedFromEvent.Load() {
 			logger.Warn("VGDP started but termination event is not received")
 		}
 
@@ -340,7 +341,7 @@ func (ms *microServiceBRWatcher) startWatch() {
 func (ms *microServiceBRWatcher) onEvent(evt *corev1api.Event) {
 	switch evt.Reason {
 	case EventReasonStarted:
-		ms.startedFromEvent = true
+		ms.startedFromEvent.Store(true)
 		ms.log.Infof("Received data path start message: %s", evt.Message)
 	case EventReasonProgress:
 		ms.callbacks.OnProgress(ms.ctx, ms.namespace, ms.taskName, funcGetProgressFromMessage(evt.Message, ms.log))
@@ -353,7 +354,7 @@ func (ms *microServiceBRWatcher) onEvent(evt *corev1api.Event) {
 	case EventReasonCancelling:
 		ms.log.Infof("Received data path canceling message: %s", evt.Message)
 	case EventReasonStopped:
-		ms.terminatedFromEvent = true
+		ms.terminatedFromEvent.Store(true)
 		ms.log.Infof("Received data path stop message: %s", evt.Message)
 	default:
 		ms.log.Infof("Received event for data path %s, reason: %s, message: %s", ms.taskName, evt.Reason, evt.Message)

--- a/pkg/datapath/micro_service_watcher.go
+++ b/pkg/datapath/micro_service_watcher.go
@@ -19,6 +19,7 @@ package datapath
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -55,6 +56,7 @@ const (
 	EventReasonProgress   = "Data-Path-Progress"
 	EventReasonCancelling = "Data-Path-Canceling"
 	EventReasonStopped    = "Data-Path-Stopped"
+	EventReasonEvicted    = "Evicted"
 )
 
 type microServiceBRWatcher struct {
@@ -81,6 +83,7 @@ type microServiceBRWatcher struct {
 	eventHandler        cache.ResourceEventHandlerRegistration
 	podHandler          cache.ResourceEventHandlerRegistration
 	watcherLock         sync.Mutex
+	eventMessages       sync.Map
 }
 
 func newMicroServiceBRWatcher(client client.Client, kubeClient kubernetes.Interface, mgr manager.Manager, taskType string, taskName string, namespace string,
@@ -329,6 +332,8 @@ func (ms *microServiceBRWatcher) startWatch() {
 				ms.callbacks.OnCancelled(ms.ctx, ms.namespace, ms.taskName)
 			} else if terminateMessage != "" {
 				ms.callbacks.OnFailed(ms.ctx, ms.namespace, ms.taskName, errors.New(terminateMessage))
+			} else if msg, evicted := ms.eventMessages.Load(EventReasonEvicted); evicted {
+				ms.callbacks.OnFailed(ms.ctx, ms.namespace, ms.taskName, errors.New(msg.(string)))
 			} else {
 				ms.callbacks.OnFailed(ms.ctx, ms.namespace, ms.taskName, errors.New(lastPod.Status.Message))
 			}
@@ -356,6 +361,9 @@ func (ms *microServiceBRWatcher) onEvent(evt *corev1api.Event) {
 	case EventReasonStopped:
 		ms.terminatedFromEvent.Store(true)
 		ms.log.Infof("Received data path stop message: %s", evt.Message)
+	case EventReasonEvicted:
+		ms.eventMessages.Store(EventReasonEvicted, fmt.Sprintf("data path pod was evicted, message: %s", evt.Message))
+		ms.log.Infof("Pod was evicted for data path %s, message: %s", ms.taskName, evt.Message)
 	default:
 		ms.log.Infof("Received event for data path %s, reason: %s, message: %s", ms.taskName, evt.Reason, evt.Message)
 	}

--- a/pkg/datapath/micro_service_watcher_test.go
+++ b/pkg/datapath/micro_service_watcher_test.go
@@ -437,8 +437,8 @@ func TestStartWatch(t *testing.T) {
 
 			ms.wgWatcher.Wait()
 
-			assert.Equal(t, test.expectStartEvent, ms.startedFromEvent)
-			assert.Equal(t, test.expectTerminateEvent, ms.terminatedFromEvent)
+			assert.Equal(t, test.expectStartEvent, ms.startedFromEvent.Load())
+			assert.Equal(t, test.expectTerminateEvent, ms.terminatedFromEvent.Load())
 			assert.Equal(t, test.expectComplete, sw.complete)
 			assert.Equal(t, test.expectCancel, sw.canceled)
 			assert.Equal(t, test.expectFail, sw.failed)

--- a/pkg/datapath/micro_service_watcher_test.go
+++ b/pkg/datapath/micro_service_watcher_test.go
@@ -120,6 +120,7 @@ type startWatchFake struct {
 	redirectErr        error
 	complete           bool
 	failed             bool
+	failedErr          error
 	canceled           bool
 	progress           int
 }
@@ -142,6 +143,7 @@ func (sw *startWatchFake) OnCompleted(ctx context.Context, namespace string, tas
 
 func (sw *startWatchFake) OnFailed(ctx context.Context, namespace string, task string, err error) {
 	sw.failed = true
+	sw.failedErr = err
 }
 
 func (sw *startWatchFake) OnCancelled(ctx context.Context, namespace string, task string) {
@@ -175,6 +177,7 @@ func TestStartWatch(t *testing.T) {
 		expectComplete       bool
 		expectCancel         bool
 		expectFail           bool
+		expectFailMsg        string
 		expectProgress       int
 	}{
 		{
@@ -370,6 +373,27 @@ func TestStartWatch(t *testing.T) {
 			expectTerminateEvent: true,
 			expectCancel:         true,
 		},
+		{
+			name:          "evicted",
+			thisPod:       "fak-pod-1",
+			thisContainer: "fake-container-1",
+			insertPod:     builder.ForPod("velero", "fake-pod-1").Phase(corev1api.PodFailed).Result(),
+			insertEventsBefore: []insertEvent{
+				{
+					event: &corev1api.Event{Reason: EventReasonStarted},
+				},
+				{
+					event: &corev1api.Event{Reason: EventReasonEvicted, Message: "fake-evicted-message"},
+				},
+				{
+					event: &corev1api.Event{Reason: EventReasonStopped},
+				},
+			},
+			expectStartEvent:     true,
+			expectTerminateEvent: true,
+			expectFail:           true,
+			expectFailMsg:        "data path pod was evicted, message: fake-evicted-message",
+		},
 	}
 
 	for _, test := range tests {
@@ -442,6 +466,9 @@ func TestStartWatch(t *testing.T) {
 			assert.Equal(t, test.expectComplete, sw.complete)
 			assert.Equal(t, test.expectCancel, sw.canceled)
 			assert.Equal(t, test.expectFail, sw.failed)
+			if test.expectFailMsg != "" {
+				require.EqualError(t, sw.failedErr, test.expectFailMsg)
+			}
 			assert.Equal(t, test.expectProgress, sw.progress)
 
 			cancel()


### PR DESCRIPTION
Fix issue #10321, when data mover pod is evicted get the message from the data mover pod instead of the terminal message

fixes #10321 