### PR TITLE
test(e2e): fix apiextensions typo in ginkgo description

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -392,7 +392,7 @@ var _ = Describe(
 	APIGroupVersionsTest,
 )
 var _ = Describe(
-	"CRD of apiextentions v1beta1 should be B/R successfully from cluster(k8s version < 1.22) to cluster(k8s version >= 1.22)",
+	"CRD of apiextensions v1beta1 should be B/R successfully from cluster(k8s version < 1.22) to cluster(k8s version >= 1.22)",
 	Label("APIGroup", "APIExtensions", "SKIP_KIND"),
 	APIExtensionsVersionsTest,
 )


### PR DESCRIPTION
Tiny fix in the Ginkgo test description for the APIExtensions versions test.

The describe string said `apiextentions` instead of `apiextensions`. No test logic changed.

Signed-off-by: Pranjal Manhgaye <manhgayepranjal@gmail.com>