### PR TITLE
fix(cli): show n/a for expiration on stalled New backups

### DIFF
--- a/pkg/cmd/util/output/backup_printer.go
+++ b/pkg/cmd/util/output/backup_printer.go
@@ -90,8 +90,12 @@ func printBackup(backup *velerov1api.Backup) []metav1.TableRow {
 	if backup.Status.Expiration != nil {
 		expiration = backup.Status.Expiration.Time
 	}
-	if expiration.IsZero() && backup.Spec.TTL.Duration > 0 {
-		expiration = backup.CreationTimestamp.Add(backup.Spec.TTL.Duration)
+	// Only estimate expiration from TTL after the backup has started. Backups
+	// stalled in New have no Status.Expiration yet; using CreationTimestamp
+	// would incorrectly show them as already expired (issue #3555).
+	if expiration.IsZero() && backup.Spec.TTL.Duration > 0 &&
+		backup.Status.StartTimestamp != nil && !backup.Status.StartTimestamp.Time.IsZero() {
+		expiration = backup.Status.StartTimestamp.Time.Add(backup.Spec.TTL.Duration)
 	}
 
 	status := string(backup.Status.Phase)

--- a/pkg/cmd/util/output/printer_timestamp_test.go
+++ b/pkg/cmd/util/output/printer_timestamp_test.go
@@ -76,6 +76,26 @@ func TestPrintBackupWithoutStartTimestamp(t *testing.T) {
 	assert.Equal(t, string(velerov1api.BackupPhaseFailedValidation), rows[0].Cells[1])
 }
 
+func TestPrintBackupExpiresForStalledNewBackup(t *testing.T) {
+	created := metav1.NewTime(time.Now().Add(-20 * 24 * time.Hour))
+	backup := &velerov1api.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "clusterstate-20210128123759",
+			CreationTimestamp: created,
+		},
+		Spec: velerov1api.BackupSpec{
+			TTL: metav1.Duration{Duration: 10 * 24 * time.Hour},
+		},
+		Status: velerov1api.BackupStatus{
+			Phase: velerov1api.BackupPhaseNew,
+		},
+	}
+
+	rows := printBackup(backup)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "n/a", rows[0].Cells[5], "stalled New backup should not show expiration in the past")
+}
+
 func TestPrintBackupWithStartTimestamp(t *testing.T) {
 	started := metav1.NewTime(time.Date(2026, 8, 8, 21, 6, 28, 0, time.UTC))
 	backup := &velerov1api.Backup{


### PR DESCRIPTION
## Summary

Fixes #3555

When `velero get backups` lists a backup that has been stuck in `New` state, the `EXPIRES` column incorrectly showed a time in the past (e.g. `10d ago`). This happened because the CLI estimated expiration as `CreationTimestamp + TTL` when `Status.Expiration` was unset.

Backups only get `Status.Expiration` set once they actually start processing. For stalled backups, expiration should be `n/a` until then.

## Changes

- Only estimate expiration from TTL when `StartTimestamp` is set (use `StartTimestamp + TTL` instead of `CreationTimestamp + TTL`)
- Add regression test for a stalled `New` backup with TTL

## Test plan

- [x] `go test ./pkg/cmd/util/output/... -run 'TestPrintBackup|TestFormatTimestamp|TestSortBackups' -v`
- [x] `go test ./pkg/cmd/util/output/...`