### PR TITLE
Detect data path pod deletion via informer DeleteFunc

### DIFF
--- a/changelogs/unreleased/10327-kaovilai
+++ b/changelogs/unreleased/10327-kaovilai
@@ -1,0 +1,1 @@
+Detect data path pod deletion via informer DeleteFunc, so a force-deleted or node-controller-removed data path pod fails fast with a clear log instead of stalling until timeout.

--- a/pkg/datapath/micro_service_watcher.go
+++ b/pkg/datapath/micro_service_watcher.go
@@ -60,30 +60,31 @@ const (
 )
 
 type microServiceBRWatcher struct {
-	ctx                 context.Context
-	cancel              context.CancelFunc
-	log                 logrus.FieldLogger
-	client              client.Client
-	kubeClient          kubernetes.Interface
-	mgr                 manager.Manager
-	namespace           string
-	callbacks           Callbacks
-	taskName            string
-	taskType            string
-	thisPod             string
-	thisContainer       string
-	associatedObject    string
-	eventCh             chan *corev1api.Event
-	podCh               chan *corev1api.Pod
-	startedFromEvent    atomic.Bool
-	terminatedFromEvent atomic.Bool
-	wgWatcher           sync.WaitGroup
-	eventInformer       ctrlcache.Informer
-	podInformer         ctrlcache.Informer
-	eventHandler        cache.ResourceEventHandlerRegistration
-	podHandler          cache.ResourceEventHandlerRegistration
-	watcherLock         sync.Mutex
-	eventMessages       sync.Map
+	ctx                  context.Context
+	cancel               context.CancelFunc
+	log                  logrus.FieldLogger
+	client               client.Client
+	kubeClient           kubernetes.Interface
+	mgr                  manager.Manager
+	namespace            string
+	callbacks            Callbacks
+	taskName             string
+	taskType             string
+	thisPod              string
+	thisContainer        string
+	associatedObject     string
+	eventCh              chan *corev1api.Event
+	podCh                chan *corev1api.Pod
+	startedFromEvent     atomic.Bool
+	terminatedFromEvent  atomic.Bool
+	podDeletedByInformer bool
+	wgWatcher            sync.WaitGroup
+	eventInformer        ctrlcache.Informer
+	podInformer          ctrlcache.Informer
+	eventHandler         cache.ResourceEventHandlerRegistration
+	podHandler           cache.ResourceEventHandlerRegistration
+	watcherLock          sync.Mutex
+	eventMessages        sync.Map
 }
 
 func newMicroServiceBRWatcher(client client.Client, kubeClient kubernetes.Interface, mgr manager.Manager, taskType string, taskName string, namespace string,
@@ -155,6 +156,7 @@ func (ms *microServiceBRWatcher) Init(ctx context.Context, param any) error {
 					ms.podCh <- pod
 				}
 			},
+			DeleteFunc: ms.handlePodDelete,
 		},
 	)
 	if err != nil {
@@ -257,6 +259,37 @@ var funcGetProgressFromMessage = getProgressFromMessage
 
 var eventWaitTimeout = time.Minute
 
+// handlePodDelete is the pod informer's DeleteFunc. It exists because nothing else
+// detects the data path pod disappearing: a force-delete, or the node controller
+// force-removing an orphaned pod once its node is confirmed gone, produces neither a
+// Succeeded/Failed status update (the UpdateFunc handler's only trigger) nor any event
+// the reconciler's own watch would catch.
+func (ms *microServiceBRWatcher) handlePodDelete(obj any) {
+	pod, ok := obj.(*corev1api.Pod)
+	if !ok {
+		// A watch that misses the delete event (e.g. a relist after a disconnect)
+		// surfaces it as a DeletedFinalStateUnknown wrapping the last known object
+		// instead of the object itself.
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		pod, ok = tombstone.Obj.(*corev1api.Pod)
+		if !ok {
+			return
+		}
+	}
+
+	if pod.Namespace != ms.namespace || pod.Name != ms.thisPod {
+		return
+	}
+
+	ms.watcherLock.Lock()
+	ms.podDeletedByInformer = true
+	ms.watcherLock.Unlock()
+	ms.podCh <- pod
+}
+
 func (ms *microServiceBRWatcher) startWatch() {
 	ms.wgWatcher.Add(1)
 
@@ -301,9 +334,22 @@ func (ms *microServiceBRWatcher) startWatch() {
 			}
 		}
 
-		terminateMessage := funcGetPodTerminationMessage(lastPod, ms.thisContainer)
-
 		logger := ms.log.WithField("data path pod", lastPod.Name)
+
+		ms.watcherLock.Lock()
+		podDeleted := ms.podDeletedByInformer
+		ms.watcherLock.Unlock()
+
+		var terminateMessage string
+		if podDeleted {
+			// The pod's last cached state is typically still Running with no container
+			// termination reported -- funcGetPodTerminationMessage would return "" here,
+			// which is exactly the blank error message this synthesizes past.
+			terminateMessage = fmt.Sprintf("data path pod %s was deleted before reaching a terminal phase", lastPod.Name)
+			logger.Warn("data path pod was deleted before a terminal phase was observed; treating as failed")
+		} else {
+			terminateMessage = funcGetPodTerminationMessage(lastPod, ms.thisContainer)
+		}
 
 		logger.Infof("Finish waiting data path pod, phase %s, message %s", lastPod.Status.Phase, terminateMessage)
 
@@ -323,12 +369,12 @@ func (ms *microServiceBRWatcher) startWatch() {
 
 		logger.Info("Calling callback on data path pod termination")
 
-		if lastPod.Status.Phase == corev1api.PodSucceeded {
+		if !podDeleted && lastPod.Status.Phase == corev1api.PodSucceeded {
 			result := funcGetResultFromMessage(ms.taskType, terminateMessage, ms.log)
 			ms.callbacks.OnProgress(ms.ctx, ms.namespace, ms.taskName, getCompletionProgressFromResult(ms.taskType, result))
 			ms.callbacks.OnCompleted(ms.ctx, ms.namespace, ms.taskName, result)
 		} else {
-			if strings.HasSuffix(terminateMessage, ErrCancelled) {
+			if !podDeleted && strings.HasSuffix(terminateMessage, ErrCancelled) {
 				ms.callbacks.OnCancelled(ms.ctx, ms.namespace, ms.taskName)
 			} else if terminateMessage != "" {
 				ms.callbacks.OnFailed(ms.ctx, ms.namespace, ms.taskName, errors.New(terminateMessage))

--- a/pkg/datapath/micro_service_watcher_test.go
+++ b/pkg/datapath/micro_service_watcher_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	kubeclientfake "k8s.io/client-go/kubernetes/fake"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -163,23 +164,25 @@ type insertEvent struct {
 
 func TestStartWatch(t *testing.T) {
 	tests := []struct {
-		name                 string
-		namespace            string
-		thisPod              string
-		thisContainer        string
-		terminationMessage   string
-		redirectLogErr       error
-		insertPod            *corev1api.Pod
-		insertEventsBefore   []insertEvent
-		insertEventsAfter    []insertEvent
-		ctxCancel            bool
-		expectStartEvent     bool
-		expectTerminateEvent bool
-		expectComplete       bool
-		expectCancel         bool
-		expectFail           bool
-		expectFailMsg        string
-		expectProgress       int
+		name                  string
+		namespace             string
+		thisPod               string
+		thisContainer         string
+		terminationMessage    string
+		redirectLogErr        error
+		insertPod             *corev1api.Pod
+		podDeleted            bool
+		insertEventsBefore    []insertEvent
+		insertEventsAfter     []insertEvent
+		ctxCancel             bool
+		expectStartEvent      bool
+		expectTerminateEvent  bool
+		expectComplete        bool
+		expectCancel          bool
+		expectFail            bool
+		expectFailMsg         string
+		expectFailMsgContains string
+		expectProgress        int
 	}{
 		{
 			name:          "exit from ctx",
@@ -354,6 +357,21 @@ func TestStartWatch(t *testing.T) {
 			expectFail:         true,
 		},
 		{
+			// GAP-15 fix1: the pod is force-deleted (or force-removed by the node
+			// controller once its node is confirmed gone) before ever reporting a
+			// terminal phase. Its last cached state is still Running, and
+			// funcGetPodTerminationMessage would return "" for it -- this pins that
+			// handlePodDelete's synthetic message is used instead of that blank one.
+			name:                  "pod deleted before terminal phase",
+			thisPod:               "fak-pod-1",
+			thisContainer:         "fake-container-1",
+			insertPod:             builder.ForPod("velero", "fake-pod-1").Phase(corev1api.PodRunning).Result(),
+			podDeleted:            true,
+			terminationMessage:    "",
+			expectFail:            true,
+			expectFailMsgContains: "was deleted before reaching a terminal phase",
+		},
+		{
 			name:          "canceled",
 			thisPod:       "fak-pod-1",
 			thisContainer: "fake-container-1",
@@ -445,6 +463,11 @@ func TestStartWatch(t *testing.T) {
 			}
 
 			if test.insertPod != nil {
+				if test.podDeleted {
+					ms.watcherLock.Lock()
+					ms.podDeletedByInformer = true
+					ms.watcherLock.Unlock()
+				}
 				ms.podCh <- test.insertPod
 			}
 
@@ -472,7 +495,56 @@ func TestStartWatch(t *testing.T) {
 			}
 			assert.Equal(t, test.expectProgress, sw.progress)
 
+			if test.expectFailMsgContains != "" {
+				require.Error(t, sw.failedErr)
+				assert.Contains(t, sw.failedErr.Error(), test.expectFailMsgContains)
+			}
+
 			cancel()
+		})
+	}
+}
+
+// TestHandlePodDelete pins the pod informer's DeleteFunc: both a direct delete and one
+// observed only as a DeletedFinalStateUnknown tombstone (client-go's shape for a delete
+// event missed and recovered via relist) must be recognized as this watcher's own pod and
+// forwarded to podCh with podDeletedByInformer set, so a real informer registration can't
+// silently regress into the pre-fix no-DeleteFunc behavior for either shape.
+func TestHandlePodDelete(t *testing.T) {
+	matchingPod := builder.ForPod("velero", "fake-pod-1").Result()
+	otherPod := builder.ForPod("velero", "other-pod").Result()
+
+	tests := []struct {
+		name       string
+		obj        any
+		expectSent bool
+	}{
+		{name: "direct pod delete for this watcher's pod", obj: matchingPod, expectSent: true},
+		{name: "DeletedFinalStateUnknown wrapping this watcher's pod", obj: cache.DeletedFinalStateUnknown{Key: "velero/fake-pod-1", Obj: matchingPod}, expectSent: true},
+		{name: "direct pod delete for a different pod is ignored", obj: otherPod, expectSent: false},
+		{name: "DeletedFinalStateUnknown wrapping a different pod is ignored", obj: cache.DeletedFinalStateUnknown{Key: "velero/other-pod", Obj: otherPod}, expectSent: false},
+		{name: "DeletedFinalStateUnknown wrapping a non-pod object is ignored", obj: cache.DeletedFinalStateUnknown{Key: "velero/fake-pod-1", Obj: "not-a-pod"}, expectSent: false},
+		{name: "unexpected object type is ignored", obj: "not-a-pod", expectSent: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ms := &microServiceBRWatcher{
+				namespace: "velero",
+				thisPod:   "fake-pod-1",
+				podCh:     make(chan *corev1api.Pod, 1),
+			}
+			ms.handlePodDelete(test.obj)
+			ms.watcherLock.Lock()
+			flagged := ms.podDeletedByInformer
+			ms.watcherLock.Unlock()
+			assert.Equal(t, test.expectSent, flagged)
+			select {
+			case <-ms.podCh:
+				assert.True(t, test.expectSent, "pod was sent to podCh but expectSent was false")
+			default:
+				assert.False(t, test.expectSent, "expected pod to be sent to podCh but nothing was received")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Related to #10303.

## Problem

The pod informer registered by `microServiceBRWatcher.Init` only had `AddFunc`/`UpdateFunc` handlers. If the data path pod is force-deleted (e.g. `kubectl delete --grace-period=0 --force`), or force-removed by the node controller once its node is confirmed gone (PodGC-style orphan cleanup), the pod disappears without ever reporting a terminal phase:

- No `Succeeded`/`Failed` status update fires, so `UpdateFunc` never triggers.
- No event exists for the reconciler's own watch loop to catch.

The `DataUpload`/`DataDownload` then hangs until the operation timeout, with no clear log explaining why.

## Fix ("fix1")

This implements the "fix 1" approach @Lyndon-Li approved in a comment on #10303 ("I don't see any side effect ... feel free to reopen it to apply fix 1 ... just make sure there is clear log"):

- Add a `DeleteFunc` (`handlePodDelete`) to the pod informer's event handlers.
- It handles both a direct pod delete and a `cache.DeletedFinalStateUnknown`-wrapped delete (the shape client-go uses when a delete event is missed and recovered via relist).
- When the deleted object matches this watcher's pod, it sets `podDeletedByInformer` and forwards the pod to `podCh`, so the existing wait loop in `startWatch` picks it up immediately instead of stalling until timeout.
- `startWatch` uses that flag to synthesize a clear log message ("data path pod %s was deleted before reaching a terminal phase") instead of calling `funcGetPodTerminationMessage`, which would return an empty string for a pod whose last cached state is still `Running`, and routes unconditionally to `OnFailed` rather than checking `PodSucceeded` or the cancellation-message suffix against a message the pod never wrote.

## Scope verified, not assumed

Both `DataUploadReconciler` and `DataDownloadReconciler` call `r.dataPathMgr.GetAsyncBR(...)`, and the sole factory behind `datapath.AsyncBR` is `MicroServiceBRWatcherCreator = newMicroServiceBRWatcher` (`pkg/datapath/manager.go`). So this fix covers both DataUpload and DataDownload through the shared watcher, without any separate change needed per-controller. Confirmed via:

```
pkg/controller/data_download_controller.go: r.dataPathMgr.GetAsyncBR(dd.Name)
pkg/controller/data_upload_controller.go:   r.dataPathMgr.GetAsyncBR(du.Name)
pkg/datapath/manager.go:32: var MicroServiceBRWatcherCreator = newMicroServiceBRWatcher
```

The manual `--grace-period=0 --force` deletion and the node-controller force-remove-on-node-gone scenario are both covered identically, since both surface to the informer as the same delete event shape.

## Tests

Added to `pkg/datapath/micro_service_watcher_test.go`:

- `TestStartWatch/pod_deleted_before_terminal_phase`: pins that a pod flagged via `podDeletedByInformer` produces the synthetic "was deleted before reaching a terminal phase" message and routes to `OnFailed`, even though its last cached phase is `Running` (where `funcGetPodTerminationMessage` would return `""`).
- `TestHandlePodDelete`: covers `handlePodDelete` directly — a direct-object delete for this watcher's pod, a `DeletedFinalStateUnknown`-wrapped delete for this watcher's pod, and the not-this-pod/wrong-type cases that must be ignored.
- Regression coverage: the existing `TestStartWatch` cases for `PodSucceeded`/`PodFailed` (`completed`, `failed`, `pod crash`, `canceled`, etc.) all still pass unchanged, confirming this doesn't alter the pre-existing UpdateFunc-driven behavior.

## Note

This is a draft PR for review — issue #10303 is not being reopened or commented on by this PR; that's a decision for the issue owner.

> [!Note]
> Responses generated with Claude
