### PR TITLE
Enforce namespace of the "musthave" resources in restore

### DIFF
--- a/changelogs/unreleased/10333-reasonerjt
+++ b/changelogs/unreleased/10333-reasonerjt
@@ -1,0 +1,1 @@
+Enforce namespace of the "musthave" resources in restore

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1004,6 +1004,19 @@ func (ctx *restoreContext) processSelectedResource(
 					targetNS = namespace
 				}
 			}
+
+			// Make sure the resource in the "resourceMustHave" set will always be created in the namespace where velero is installed.
+			if ctx.resourceMustHave.Has(groupResource.String()) && targetNS != "" && targetNS != ctx.restore.Namespace {
+				err := fmt.Errorf("resource %s/%s is must-have per velero internal setting, and is namespace-scoped, but its target namespace %q is not Velero's namespace %q", groupResource.String(), selectedItem.name, targetNS, ctx.restore.Namespace)
+				ctx.log.WithFields(logrus.Fields{
+					"resource":        groupResource.String(),
+					"name":            selectedItem.name,
+					"targetNamespace": targetNS,
+					"veleroNamespace": ctx.restore.Namespace,
+				}).Error(err.Error())
+				errs.Add(targetNS, err)
+				continue
+			}
 			// If we don't know whether this namespace exists yet, attempt to create
 			// it in order to ensure it exists. Try to get it from the backup tarball
 			// (in order to get any backed-up metadata), but if we don't find it there,

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -813,6 +813,87 @@ func TestRestoreResourceFiltering(t *testing.T) {
 	}
 }
 
+func TestRestoreMustHaveResourceNamespaceEnforcement(t *testing.T) {
+	tests := []struct {
+		name         string
+		restore      *velerov1api.Restore
+		backup       *velerov1api.Backup
+		apiResources []*test.APIResource
+		tarball      io.Reader
+		want         map[*test.APIResource][]string
+		expectError  bool
+	}{
+		{
+			name:    "resourceMustHave item in velero namespace is restored",
+			restore: defaultRestore().IncludedNamespaces("velero").Result(),
+			backup:  defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("datauploads.velero.io",
+					builder.ForDataUpload("velero", "du-1").Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.DataUploads(),
+			},
+			want: map[*test.APIResource][]string{
+				test.DataUploads(): {"velero/du-1"},
+			},
+			expectError: false,
+		},
+		{
+			name:    "resourceMustHave item outside velero namespace is rejected and produces error",
+			restore: defaultRestore().IncludedNamespaces("app-foo").Result(),
+			backup:  defaultBackup().Result(),
+			tarball: test.NewTarWriter(t).
+				AddItems("datauploads.velero.io",
+					builder.ForDataUpload("attacker-ns", "du-2").Result(),
+				).
+				Done(),
+			apiResources: []*test.APIResource{
+				test.DataUploads(),
+			},
+			want: map[*test.APIResource][]string{
+				test.DataUploads(): {},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+
+			for _, r := range tc.apiResources {
+				h.DiscoveryClient.WithAPIResource(r)
+			}
+			require.NoError(t, h.restorer.discoveryHelper.Refresh())
+
+			resPolicies, err := resourcepolicies.GetResourcePoliciesFromRestore(t.Context(), tc.restore, h.restorer.kbClient, h.log)
+			require.NoError(t, err)
+
+			data := &Request{
+				Log:          h.log,
+				Restore:      tc.restore,
+				Backup:       tc.backup,
+				BackupReader: tc.tarball,
+				ResPolicies:  resPolicies,
+			}
+			_, errs := h.restorer.Restore(
+				data,
+				nil,
+				nil,
+			)
+
+			if tc.expectError {
+				assert.False(t, errs.IsEmpty(), "expected errors but got empty")
+			} else {
+				assert.True(t, errs.IsEmpty(), "expected no errors but got %v", errs)
+			}
+			assertAPIContents(t, h, tc.want)
+		})
+	}
+}
+
 // TestRestoreNamespaceMapping runs restores with namespace mappings specified,
 // and verifies that the set of items created in the API are in the correct
 // namespaces. Validation is done by looking at the namespaces/names of the items


### PR DESCRIPTION
This commit ensures the resources in the set "resourceMustHave" can only be created in the namespace of velero deployment if it's not empty.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
