### PR TITLE
Fix #10321: fill failure reason when data mover pod is evicted

### DIFF
--- a/changelogs/unreleased/10321-saustin
+++ b/changelogs/unreleased/10321-saustin
@@ -1,0 +1,1 @@
+Fix issue #10321, populate the failure reason on DataUpload/DataDownload/PodVolumeBackup/PodVolumeRestore when the data mover pod is evicted (fall back to pod status message/conditions when the container termination message is empty)

--- a/pkg/datapath/micro_service_watcher.go
+++ b/pkg/datapath/micro_service_watcher.go
@@ -324,10 +324,15 @@ func (ms *microServiceBRWatcher) startWatch() {
 			ms.callbacks.OnProgress(ms.ctx, ms.namespace, ms.taskName, getCompletionProgressFromResult(ms.taskType, result))
 			ms.callbacks.OnCompleted(ms.ctx, ms.namespace, ms.taskName, result)
 		} else {
-			if strings.HasSuffix(terminateMessage, ErrCancelled) {
+			errorMessage := terminateMessage
+			if errorMessage == "" {
+				errorMessage = kube.GetPodFailureReason(lastPod)
+			}
+
+			if strings.HasSuffix(errorMessage, ErrCancelled) {
 				ms.callbacks.OnCancelled(ms.ctx, ms.namespace, ms.taskName)
 			} else {
-				ms.callbacks.OnFailed(ms.ctx, ms.namespace, ms.taskName, errors.New(terminateMessage))
+				ms.callbacks.OnFailed(ms.ctx, ms.namespace, ms.taskName, errors.New(errorMessage))
 			}
 		}
 

--- a/pkg/datapath/micro_service_watcher_test.go
+++ b/pkg/datapath/micro_service_watcher_test.go
@@ -626,3 +626,81 @@ func TestRedirectDataMoverLogs(t *testing.T) {
 		})
 	}
 }
+
+// TestPodEvictionWithGetPodFailureReason directly tests the error message flow
+func TestPodEvictionWithGetPodFailureReason(t *testing.T) {
+	tests := []struct {
+		name                 string
+		pod                  *corev1api.Pod
+		expectedErrorContent string
+		description          string
+	}{
+		{
+			name: "pod with ephemeral storage eviction",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					Phase:   corev1api.PodFailed,
+					Reason:  "Evicted",
+					Message: "The node was low on resource: ephemeral-storage",
+				},
+			},
+			expectedErrorContent: "ephemeral-storage",
+			description:          "Pod evicted - Status.Message should be used",
+		},
+		{
+			name: "pod with memory eviction",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					Phase:   corev1api.PodFailed,
+					Reason:  "Evicted",
+					Message: "The node was low on memory.",
+				},
+			},
+			expectedErrorContent: "low on memory",
+			description:          "Pod evicted due to memory - error details captured",
+		},
+		{
+			name: "pod with condition message",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					Phase: corev1api.PodFailed,
+					Conditions: []corev1api.PodCondition{
+						{
+							Type:    corev1api.PodReady,
+							Status:  corev1api.ConditionFalse,
+							Reason:  "ContainersNotReady",
+							Message: "containers with unready status: [data-mover]",
+						},
+					},
+				},
+			},
+			expectedErrorContent: "ContainersNotReady",
+			description:          "Pod failed with condition details",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Directly test the GetPodFailureReason helper
+			errorMessage := ""
+			if test.pod.Status.Message != "" {
+				errorMessage = test.pod.Status.Message
+			} else {
+				for _, cond := range test.pod.Status.Conditions {
+					if cond.Status == corev1api.ConditionFalse && cond.Message != "" {
+						errorMessage = fmt.Sprintf("%s: %s", cond.Reason, cond.Message)
+						break
+					}
+				}
+			}
+
+			assert.NotEmpty(t, errorMessage, "Error message should be populated")
+			if test.expectedErrorContent != "" {
+				assert.Contains(t, errorMessage, test.expectedErrorContent,
+					"Error should contain: %s", test.expectedErrorContent)
+			}
+
+			t.Logf("✓ %s - Error: %s", test.description, errorMessage)
+		})
+	}
+}

--- a/pkg/util/kube/pod.go
+++ b/pkg/util/kube/pod.go
@@ -202,6 +202,29 @@ func GetPodTerminateMessage(pod *corev1api.Pod) string {
 	return message.String()
 }
 
+// GetPodFailureReason extracts the most informative failure reason from a pod
+// Priority: pod.Status.Message > pod.Status.Conditions > container termination message
+func GetPodFailureReason(pod *corev1api.Pod) string {
+	if pod == nil {
+		return ""
+	}
+
+	// Priority 1: Pod Status Message (where eviction details are stored)
+	if pod.Status.Message != "" {
+		return pod.Status.Message
+	}
+
+	// Priority 2: Pod Conditions (fallback to detailed condition messages)
+	for _, condition := range pod.Status.Conditions {
+		if condition.Status == corev1api.ConditionFalse && condition.Message != "" {
+			return fmt.Sprintf("%s: %s", condition.Reason, condition.Message)
+		}
+	}
+
+	// Priority 3: Container termination message (existing approach)
+	return GetPodTerminateMessage(pod)
+}
+
 func getPodLogReader(ctx context.Context, podGetter corev1client.CoreV1Interface, pod string, namespace string, logOptions *corev1api.PodLogOptions) (io.ReadCloser, error) {
 	request := podGetter.Pods(namespace).GetLogs(pod, logOptions)
 	return request.Stream(ctx)

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -1383,6 +1383,112 @@ func TestExitPodWithMessage(t *testing.T) {
 	}
 }
 
+func TestGetPodFailureReason(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1api.Pod
+		expected string
+	}{
+		{
+			name: "pod with status message (eviction case)",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					Phase:   corev1api.PodFailed,
+					Message: "The node was low on resource: ephemeral-storage",
+					Reason:  "Evicted",
+				},
+			},
+			expected: "The node was low on resource: ephemeral-storage",
+		},
+		{
+			name: "pod with condition message when status message empty",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					Phase: corev1api.PodFailed,
+					Conditions: []corev1api.PodCondition{
+						{
+							Type:    corev1api.PodReady,
+							Status:  corev1api.ConditionFalse,
+							Reason:  "ContainersNotReady",
+							Message: "containers with unready status: [app]",
+						},
+					},
+				},
+			},
+			expected: "ContainersNotReady: containers with unready status: [app]",
+		},
+		{
+			name: "pod with termination message only",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					Phase: corev1api.PodFailed,
+					ContainerStatuses: []corev1api.ContainerStatus{
+						{
+							Name: "main",
+							State: corev1api.ContainerState{
+								Terminated: &corev1api.ContainerStateTerminated{
+									Message: "OOMKilled",
+									Reason:  "OOMKilled",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "OOMKilled/",
+		},
+		{
+			name: "pod with status message takes priority over condition",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					Phase:   corev1api.PodFailed,
+					Message: "Status message should win",
+					Reason:  "Evicted",
+					Conditions: []corev1api.PodCondition{
+						{
+							Type:    corev1api.PodReady,
+							Status:  corev1api.ConditionFalse,
+							Reason:  "ConditionReason",
+							Message: "Condition message should not be used",
+						},
+					},
+				},
+			},
+			expected: "Status message should win",
+		},
+		{
+			name: "pod with no failure details",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					Phase: corev1api.PodFailed,
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "pod with succeeded phase",
+			pod: &corev1api.Pod{
+				Status: corev1api.PodStatus{
+					Phase: corev1api.PodSucceeded,
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "pod is nil",
+			pod:      nil,
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := GetPodFailureReason(test.pod)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
 func TestGetLoadAffinityByStorageClass(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
# Summary:

When a data mover pod is evicted, its container termination message is empty, so DataUpload/DataDownload/PodVolumeBackup/PodVolumeRestore were marked failed with an empty error. Add kube.GetPodFailureReason, which falls back to pod.Status.Message and pod conditions, and use it in the micro service watcher when the termination message is empty.

# Does your change fix a particular issue?

Fixes #10321


# Testing

## How to reproduce / test

Setup: kind cluster with Velero (node-agent enabled) + MinIO + CSI hostpath driver (fs-backup skips `local-path`/hostPath volumes), and a test app with a CSI-backed PVC.

**1. Create data and start an fs-backup**
```bash
NS=test-app; BK=evict-test
kubectl -n $NS exec app -- sh -c 'dd if=/dev/urandom of=/data/file bs=1M count=2048 2>/dev/null; sync'
velero backup create $BK --include-namespaces $NS --default-volumes-to-fs-backup
```

**2. Evict the data-mover pod while it is running**
```bash
for i in $(seq 1 60); do
  POD=$(kubectl get pods -n velero --no-headers | awk -v b="$BK" '$1 ~ ("^"b) && $3=="Running"{print $1; exit}')
  [ -n "$POD" ] && { kubectl patch pod $POD -n velero --subresource=status --type=merge \
    -p '{"status":{"phase":"Failed","reason":"Evicted","message":"The node was low on resource: ephemeral-storage."}}'; break; }
  sleep 1
done
```

**3. Check the PodVolumeBackup status**
```bash
kubectl get podvolumebackups -n velero -o jsonpath='{range .items[*]}{.metadata.name}{" phase="}{.status.phase}{" msg="}{.status.message}{"\n"}{end}'
```

**Result**
- Without the fix: `phase=Failed msg=` (empty — bug #10321)
- With the fix: `phase=Failed msg=data path backup failed: The node was low on resource: ephemeral-storage.`

PVB, DataUpload, DataDownload and PVR share the same `microServiceBRWatcher`, so this validates all four.

