### PR TITLE
Document secretNames/configMapNames for backup/restore PVC config

### DIFF
--- a/site/content/docs/main/data-movement-backup-pvc-configuration.md
+++ b/site/content/docs/main/data-movement-backup-pvc-configuration.md
@@ -40,6 +40,16 @@ The users can specify the ConfigMap name during velero installation by CLI:
 - `annotations`: permits to set annotations on the backupPVC itself. typically useful for some CSI provider which cannot mount
   a VolumeSnapshot without a custom annotation.
 
+- `secretNames`: a list of secret names to copy from the source PVC's namespace to the Velero namespace before the backupPVC is
+  created, and delete after the DataUpload completes. This is needed for CSI drivers that require namespace-scoped secrets to
+  provision the volume, for example ODF/ceph-csi encrypted volumes that fetch a KMS token secret (`ceph-csi-kms-token`) from the
+  PVC's namespace. Without this, the backupPVC created in the Velero namespace fails to provision because the secret only exists
+  in the source namespace.
+
+- `configMapNames`: a list of configmap names to copy from the source PVC's namespace to the Velero namespace before the backupPVC
+  is created, and delete after the DataUpload completes. This is needed for CSI drivers that require namespace-scoped configmaps to
+  provision the volume, for example a tenant-specific ceph-csi KMS connection override configmap (`ceph-csi-kms-config`).
+
 A sample of `backupPVC` config as part of the ConfigMap would look like:
 ```json
 {
@@ -60,10 +70,19 @@ A sample of `backupPVC` config as part of the ConfigMap would look like:
         "storage-class-4": {
             "readOnly": true,
             "spcNoRelabeling": true
+        },
+        "ocs-storagecluster-ceph-rbd-encrypted": {
+            "secretNames": ["ceph-csi-kms-token"],
+            "configMapNames": ["ceph-csi-kms-config"]
         }
     }
 }
 ```
+
+**Note on encrypted volumes:** the copied secrets/configmaps are labeled `velero.io/backup-pvc-secret=<DataUpload UID>` and
+deleted when the DataUpload completes (or on failure). If concurrent DataUploads from different namespaces need a secret with the
+same name but different content in the Velero namespace, they conflict; for ceph-csi this can be avoided by configuring a
+per-namespace `tenantTokenName` so each namespace uses a unique secret name.
 
 **Note:** 
 - Users should make sure that the storage class specified in `backupPVC` config should exist in the cluster and can be used by the

--- a/site/content/docs/main/data-movement-backup-pvc-configuration.md
+++ b/site/content/docs/main/data-movement-backup-pvc-configuration.md
@@ -80,9 +80,10 @@ A sample of `backupPVC` config as part of the ConfigMap would look like:
 ```
 
 **Note on encrypted volumes:** the copied secrets/configmaps are labeled `velero.io/backup-pvc-secret=<DataUpload UID>` and
-deleted when the DataUpload completes (or on failure). If concurrent DataUploads from different namespaces need a secret with the
-same name but different content in the Velero namespace, they conflict; for ceph-csi this can be avoided by configuring a
-per-namespace `tenantTokenName` so each namespace uses a unique secret name.
+deleted when the DataUpload completes (or on failure). If concurrent DataUploads from different namespaces need a secret with the same
+name but different content in the Velero namespace, they conflict. For ceph-csi,
+this can be avoided by configuring a unique
+[`tenantTokenName` per tenant](https://github.com/ceph/ceph-csi/blob/devel/docs/design/proposals/encryption-with-vault-tokens.md#example-of-the-kms-configuration-file-for-vault-tokens).
 
 **Note:** 
 - Users should make sure that the storage class specified in `backupPVC` config should exist in the cluster and can be used by the

--- a/site/content/docs/main/data-movement-restore-pvc-configuration.md
+++ b/site/content/docs/main/data-movement-restore-pvc-configuration.md
@@ -12,6 +12,10 @@ Velero introduces a new section in the node agent configuration ConfigMap (the n
 
 - `ignoreDelayBinding`: If this flag is set, the data movement restore will ignore the delay binding requirements from `WaitForFirstConsumer` mode, create the restore pod and provision the volume associated to an arbitrary node. When multiple volume restores happen in parallel, the restore pods will be spread evenly to all the nodes.
 
+- `secretNames`: a list of secret names to copy from the target (restore) namespace to the Velero namespace before the restorePVC is created, and delete after the DataDownload completes. This is needed for CSI drivers that require namespace-scoped secrets to provision the volume, for example ODF/ceph-csi encrypted volumes that fetch a KMS token secret (`ceph-csi-kms-token`) from the PVC's namespace. Without this, the restorePVC created in the Velero namespace fails to provision because the secret only exists in the target namespace.
+
+- `configMapNames`: a list of configmap names to copy from the target (restore) namespace to the Velero namespace before the restorePVC is created, and delete after the DataDownload completes. This is needed for CSI drivers that require namespace-scoped configmaps to provision the volume, for example a tenant-specific ceph-csi KMS connection override configmap (`ceph-csi-kms-config`).
+
 
 The users can specify the ConfigMap name during velero installation by CLI:
 `velero install --node-agent-configmap=<ConfigMap-Name>`
@@ -20,10 +24,14 @@ A sample of `restorePVC` config as part of the ConfigMap would look like:
 ```json
 {
     "restorePVC": {
-        "ignoreDelayBinding": true
+        "ignoreDelayBinding": true,
+        "secretNames": ["ceph-csi-kms-token"],
+        "configMapNames": ["ceph-csi-kms-config"]
     }
 }
 ```
+
+**Note on encrypted volumes:** unlike `backupPVC` (which is keyed per source storage class), `restorePVC` is a single config that applies to all restore PVCs. The copied secrets/configmaps are labeled `velero.io/backup-pvc-secret=<DataDownload UID>` and deleted when the DataDownload completes (or on failure).
 
 **Note:** 
 - If `ignoreDelayBinding` is set, the restored volume is provisioned in the storage areas associated to an arbitrary node, if the restored pod cannot be scheduled to that node, e.g., because of topology constraints, the data mover restore still completes, but the workload is not usable since the restored pod cannot mount the restored volume

--- a/site/content/docs/main/supported-configmaps/node-agent-configmap.md
+++ b/site/content/docs/main/supported-configmaps/node-agent-configmap.md
@@ -297,6 +297,8 @@ For detailed information, see [BackupPVC Configuration for Data Movement Backup]
 - **`storageClass`**: Alternative storage class for backup PVCs (defaults to source PVC's storage class)
 - **`readOnly`**: This is a boolean value. If set to `true` then `ReadOnlyMany` will be the only value set to the backupPVC's access modes. Otherwise `ReadWriteOnce` value will be used.
 - **`spcNoRelabeling`**: This is a boolean value. If set to true, then `pod.Spec.SecurityContext.SELinuxOptions.Type` will be set to `spc_t`. From the SELinux point of view, this will be considered a `Super Privileged Container` which means that selinux enforcement will be disabled and volume relabeling will not occur. This field is ignored if `readOnly` is `false`.
+- **`secretNames`**: List of secret names to copy from the source PVC's namespace to the Velero namespace before creating the backupPVC (deleted after the DataUpload completes). Needed for CSI drivers that require namespace-scoped secrets to provision the volume, e.g. ODF/ceph-csi encrypted volumes (`ceph-csi-kms-token`).
+- **`configMapNames`**: List of configmap names to copy from the source PVC's namespace to the Velero namespace before creating the backupPVC (deleted after the DataUpload completes). Needed for CSI drivers that require namespace-scoped configmaps to provision the volume, e.g. a tenant ceph-csi KMS config (`ceph-csi-kms-config`).
 
 **Use Cases:**
 - Use read-only volumes for faster snapshot-to-volume conversion
@@ -360,6 +362,8 @@ For detailed information, see [RestorePVC Configuration for Data Movement Restor
 
 #### Configuration Options
 - **`ignoreDelayBinding`**: Ignore `WaitForFirstConsumer` binding mode constraints
+- **`secretNames`**: List of secret names to copy from the target (restore) namespace to the Velero namespace before creating the restorePVC (deleted after the DataDownload completes). Needed for CSI drivers that require namespace-scoped secrets to provision the volume, e.g. ODF/ceph-csi encrypted volumes (`ceph-csi-kms-token`).
+- **`configMapNames`**: List of configmap names to copy from the target (restore) namespace to the Velero namespace before creating the restorePVC (deleted after the DataDownload completes). Needed for CSI drivers that require namespace-scoped configmaps to provision the volume, e.g. a tenant ceph-csi KMS config (`ceph-csi-kms-config`).
 
 **Use Cases:**
 - Improve restore parallelism by not waiting for pod scheduling

--- a/site/content/docs/v1.18/data-movement-backup-pvc-configuration.md
+++ b/site/content/docs/v1.18/data-movement-backup-pvc-configuration.md
@@ -40,6 +40,16 @@ The users can specify the ConfigMap name during velero installation by CLI:
 - `annotations`: permits to set annotations on the backupPVC itself. typically useful for some CSI provider which cannot mount
   a VolumeSnapshot without a custom annotation.
 
+- `secretNames`: a list of secret names to copy from the source PVC's namespace to the Velero namespace before the backupPVC is
+  created, and delete after the DataUpload completes. This is needed for CSI drivers that require namespace-scoped secrets to
+  provision the volume, for example ODF/ceph-csi encrypted volumes that fetch a KMS token secret (`ceph-csi-kms-token`) from the
+  PVC's namespace. Without this, the backupPVC created in the Velero namespace fails to provision because the secret only exists
+  in the source namespace.
+
+- `configMapNames`: a list of configmap names to copy from the source PVC's namespace to the Velero namespace before the backupPVC
+  is created, and delete after the DataUpload completes. This is needed for CSI drivers that require namespace-scoped configmaps to
+  provision the volume, for example a tenant-specific ceph-csi KMS connection override configmap (`ceph-csi-kms-config`).
+
 A sample of `backupPVC` config as part of the ConfigMap would look like:
 ```json
 {
@@ -60,10 +70,19 @@ A sample of `backupPVC` config as part of the ConfigMap would look like:
         "storage-class-4": {
             "readOnly": true,
             "spcNoRelabeling": true
+        },
+        "ocs-storagecluster-ceph-rbd-encrypted": {
+            "secretNames": ["ceph-csi-kms-token"],
+            "configMapNames": ["ceph-csi-kms-config"]
         }
     }
 }
 ```
+
+**Note on encrypted volumes:** the copied secrets/configmaps are labeled `velero.io/backup-pvc-secret=<DataUpload UID>` and
+deleted when the DataUpload completes (or on failure). If concurrent DataUploads from different namespaces need a secret with the
+same name but different content in the Velero namespace, they conflict; for ceph-csi this can be avoided by configuring a
+per-namespace `tenantTokenName` so each namespace uses a unique secret name.
 
 **Note:** 
 - Users should make sure that the storage class specified in `backupPVC` config should exist in the cluster and can be used by the

--- a/site/content/docs/v1.18/data-movement-backup-pvc-configuration.md
+++ b/site/content/docs/v1.18/data-movement-backup-pvc-configuration.md
@@ -80,9 +80,10 @@ A sample of `backupPVC` config as part of the ConfigMap would look like:
 ```
 
 **Note on encrypted volumes:** the copied secrets/configmaps are labeled `velero.io/backup-pvc-secret=<DataUpload UID>` and
-deleted when the DataUpload completes (or on failure). If concurrent DataUploads from different namespaces need a secret with the
-same name but different content in the Velero namespace, they conflict; for ceph-csi this can be avoided by configuring a
-per-namespace `tenantTokenName` so each namespace uses a unique secret name.
+deleted when the DataUpload completes (or on failure). If concurrent DataUploads from different namespaces need a secret with the same
+name but different content in the Velero namespace, they conflict. For ceph-csi,
+this can be avoided by configuring a unique
+[`tenantTokenName` per tenant](https://github.com/ceph/ceph-csi/blob/devel/docs/design/proposals/encryption-with-vault-tokens.md#example-of-the-kms-configuration-file-for-vault-tokens).
 
 **Note:** 
 - Users should make sure that the storage class specified in `backupPVC` config should exist in the cluster and can be used by the

--- a/site/content/docs/v1.18/data-movement-restore-pvc-configuration.md
+++ b/site/content/docs/v1.18/data-movement-restore-pvc-configuration.md
@@ -12,6 +12,10 @@ Velero introduces a new section in the node agent configuration ConfigMap (the n
 
 - `ignoreDelayBinding`: If this flag is set, the data movement restore will ignore the delay binding requirements from `WaitForFirstConsumer` mode, create the restore pod and provision the volume associated to an arbitrary node. When multiple volume restores happen in parallel, the restore pods will be spread evenly to all the nodes.
 
+- `secretNames`: a list of secret names to copy from the target (restore) namespace to the Velero namespace before the restorePVC is created, and delete after the DataDownload completes. This is needed for CSI drivers that require namespace-scoped secrets to provision the volume, for example ODF/ceph-csi encrypted volumes that fetch a KMS token secret (`ceph-csi-kms-token`) from the PVC's namespace. Without this, the restorePVC created in the Velero namespace fails to provision because the secret only exists in the target namespace.
+
+- `configMapNames`: a list of configmap names to copy from the target (restore) namespace to the Velero namespace before the restorePVC is created, and delete after the DataDownload completes. This is needed for CSI drivers that require namespace-scoped configmaps to provision the volume, for example a tenant-specific ceph-csi KMS connection override configmap (`ceph-csi-kms-config`).
+
 
 The users can specify the ConfigMap name during velero installation by CLI:
 `velero install --node-agent-configmap=<ConfigMap-Name>`
@@ -20,10 +24,14 @@ A sample of `restorePVC` config as part of the ConfigMap would look like:
 ```json
 {
     "restorePVC": {
-        "ignoreDelayBinding": true
+        "ignoreDelayBinding": true,
+        "secretNames": ["ceph-csi-kms-token"],
+        "configMapNames": ["ceph-csi-kms-config"]
     }
 }
 ```
+
+**Note on encrypted volumes:** unlike `backupPVC` (which is keyed per source storage class), `restorePVC` is a single config that applies to all restore PVCs. The copied secrets/configmaps are labeled `velero.io/backup-pvc-secret=<DataDownload UID>` and deleted when the DataDownload completes (or on failure).
 
 **Note:** 
 - If `ignoreDelayBinding` is set, the restored volume is provisioned in the storage areas associated to an arbitrary node, if the restored pod cannot be scheduled to that node, e.g., because of topology constraints, the data mover restore still completes, but the workload is not usable since the restored pod cannot mount the restored volume

--- a/site/content/docs/v1.18/supported-configmaps/node-agent-configmap.md
+++ b/site/content/docs/v1.18/supported-configmaps/node-agent-configmap.md
@@ -295,6 +295,8 @@ For detailed information, see [BackupPVC Configuration for Data Movement Backup]
 - **`storageClass`**: Alternative storage class for backup PVCs (defaults to source PVC's storage class)
 - **`readOnly`**: This is a boolean value. If set to `true` then `ReadOnlyMany` will be the only value set to the backupPVC's access modes. Otherwise `ReadWriteOnce` value will be used.
 - **`spcNoRelabeling`**: This is a boolean value. If set to true, then `pod.Spec.SecurityContext.SELinuxOptions.Type` will be set to `spc_t`. From the SELinux point of view, this will be considered a `Super Privileged Container` which means that selinux enforcement will be disabled and volume relabeling will not occur. This field is ignored if `readOnly` is `false`.
+- **`secretNames`**: List of secret names to copy from the source PVC's namespace to the Velero namespace before creating the backupPVC (deleted after the DataUpload completes). Needed for CSI drivers that require namespace-scoped secrets to provision the volume, e.g. ODF/ceph-csi encrypted volumes (`ceph-csi-kms-token`).
+- **`configMapNames`**: List of configmap names to copy from the source PVC's namespace to the Velero namespace before creating the backupPVC (deleted after the DataUpload completes). Needed for CSI drivers that require namespace-scoped configmaps to provision the volume, e.g. a tenant ceph-csi KMS config (`ceph-csi-kms-config`).
 
 **Use Cases:**
 - Use read-only volumes for faster snapshot-to-volume conversion
@@ -358,6 +360,8 @@ For detailed information, see [RestorePVC Configuration for Data Movement Restor
 
 #### Configuration Options
 - **`ignoreDelayBinding`**: Ignore `WaitForFirstConsumer` binding mode constraints
+- **`secretNames`**: List of secret names to copy from the target (restore) namespace to the Velero namespace before creating the restorePVC (deleted after the DataDownload completes). Needed for CSI drivers that require namespace-scoped secrets to provision the volume, e.g. ODF/ceph-csi encrypted volumes (`ceph-csi-kms-token`).
+- **`configMapNames`**: List of configmap names to copy from the target (restore) namespace to the Velero namespace before creating the restorePVC (deleted after the DataDownload completes). Needed for CSI drivers that require namespace-scoped configmaps to provision the volume, e.g. a tenant ceph-csi KMS config (`ceph-csi-kms-config`).
 
 **Use Cases:**
 - Improve restore parallelism by not waiting for pod scheduling


### PR DESCRIPTION
# Summary

Documents the `backupPVC`/`restorePVC` `secretNames` and `configMapNames` node-agent config options added in #9920. These copy namespace-scoped secrets/configmaps into the Velero namespace before creating the intermediate PVC, so datamover can back up and restore CSI volumes that need them for provisioning (e.g. ODF/ceph-csi encrypted volumes with Vault KMS).

Updates:
- `data-movement-backup-pvc-configuration.md` (field docs + sample + encrypted-volume note)
- `data-movement-restore-pvc-configuration.md` (field docs + sample + note)
- `supported-configmaps/node-agent-configmap.md` (reference entries for both sections)

Applied to both `docs/main` and `docs/v1.18` (the feature is backported to release-1.18 in #10335).

## Related

- Feature PR: #9920
- Backport: #10335
- Issue: #9879

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off).
- [x] Created a changelog file / `/kind changelog-not-required` (docs-only).