### PR TITLE
Fix LoadAffinity mutation accumulating OS node selector terms

### DIFF
--- a/changelogs/unreleased/10342-shubham-pampattiwar
+++ b/changelogs/unreleased/10342-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Fix issue #10341, avoid mutating the cached node-agent LoadAffinity so the OS node selector term is not appended repeatedly to data mover pods

--- a/pkg/util/kube/pod.go
+++ b/pkg/util/kube/pod.go
@@ -324,9 +324,26 @@ func ExitPodWithMessage(logger logrus.FieldLogger, succeed bool, message string,
 	funcExit(exitCode)
 }
 
+// deepCopy returns a deep copy of the LoadAffinity, so that the returned value
+// can be safely modified without affecting the source.
+func (a *LoadAffinity) deepCopy() *LoadAffinity {
+	if a == nil {
+		return nil
+	}
+
+	result := &LoadAffinity{
+		StorageClass: a.StorageClass,
+	}
+	a.NodeSelector.DeepCopyInto(&result.NodeSelector)
+
+	return result
+}
+
 // GetLoadAffinityByStorageClass retrieves the LoadAffinity from the parameter affinityList.
 // The function first try to find by the scName. If there is no such LoadAffinity,
 // it will try to get the LoadAffinity whose StorageClass has no value.
+// The returned LoadAffinity is a deep copy of the matched element, so that the
+// callers can modify it without corrupting the shared node-agent configuration.
 func GetLoadAffinityByStorageClass(
 	affinityList []*LoadAffinity,
 	scName string,
@@ -337,7 +354,7 @@ func GetLoadAffinityByStorageClass(
 	for _, affinity := range affinityList {
 		if affinity.StorageClass == scName {
 			logger.WithField("StorageClass", scName).Info("Found pod's affinity setting per StorageClass.")
-			return affinity
+			return affinity.deepCopy()
 		}
 
 		if affinity.StorageClass == "" && globalAffinity == nil {
@@ -351,5 +368,5 @@ func GetLoadAffinityByStorageClass(
 		logger.Info("No Affinity is found for pod.")
 	}
 
-	return globalAffinity
+	return globalAffinity.deepCopy()
 }

--- a/pkg/util/kube/pod_test.go
+++ b/pkg/util/kube/pod_test.go
@@ -1568,3 +1568,82 @@ func TestGetLoadAffinityByStorageClass(t *testing.T) {
 		})
 	}
 }
+
+func TestGetLoadAffinityByStorageClassReturnsCopy(t *testing.T) {
+	newAffinityList := func() []*LoadAffinity {
+		return []*LoadAffinity{
+			{
+				NodeSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"pool": "backup"},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      corev1api.LabelArchStable,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"amd64"},
+						},
+					},
+				},
+			},
+			{
+				NodeSelector: metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      corev1api.LabelArchStable,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"arm64"},
+						},
+					},
+				},
+				StorageClass: "storage-class-01",
+			},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		scName string
+	}{
+		{
+			name:   "global affinity",
+			scName: "no-such-storage-class",
+		},
+		{
+			name:   "affinity matched by StorageClass",
+			scName: "storage-class-01",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			affinityList := newAffinityList()
+
+			// Simulate the exposers, which append an OS related term to the returned
+			// affinity on every expose call. The source list must not be affected.
+			for range 3 {
+				result := GetLoadAffinityByStorageClass(affinityList, test.scName, velerotest.NewLogger())
+				require.NotNil(t, result)
+
+				result.NodeSelector.MatchExpressions = append(result.NodeSelector.MatchExpressions, metav1.LabelSelectorRequirement{
+					Key:      NodeOSLabel,
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{NodeOSWindows},
+				})
+
+				assert.Len(t, result.NodeSelector.MatchExpressions, 2)
+			}
+
+			assert.Equal(t, newAffinityList(), affinityList)
+
+			// The other fields must be copied as well.
+			result := GetLoadAffinityByStorageClass(affinityList, test.scName, velerotest.NewLogger())
+			require.NotNil(t, result)
+			result.StorageClass = "modified"
+			result.NodeSelector.MatchExpressions[0].Values[0] = "modified"
+			if result.NodeSelector.MatchLabels != nil {
+				result.NodeSelector.MatchLabels["pool"] = "modified"
+			}
+
+			assert.Equal(t, newAffinityList(), affinityList)
+		})
+	}
+}


### PR DESCRIPTION
## Thank you for contributing to Velero!

**Please add a summary of your change**

Fixes #10341.

The node-agent parses the `loadAffinity` configuration from its ConfigMap once at startup and holds it in memory for the life of the process. `GetLoadAffinityByStorageClass` returned a pointer to one of the elements of that cached list rather than a copy.

The exposers then append a `kubernetes.io/os` match expression to the returned affinity on every expose, so they were mutating the shared configuration in place. Each DataUpload/DataDownload added another copy of the OS term, and the reporter saw 26 duplicates on a single data mover pod. The pod spec keeps growing until a node-agent restart re-reads the ConfigMap, and in the worst case it could eventually push the pod object past the size limit and break data mover pod creation for that node-agent.

This only affects users who configure `loadAffinity`, since the `nil` case already allocated a fresh `LoadAffinity`.

The fix returns a deep copy from `GetLoadAffinityByStorageClass`, which covers both the backup (`csi_snapshot.go`) and restore (`generic_restore.go`) call sites and keeps future callers safe. A shallow struct copy would not be sufficient: `NodeSelector` is a `metav1.LabelSelector` whose `MatchExpressions` slice header would still be shared, so `append` could write into the same backing array when there is spare capacity, and concurrent exposes could overwrite each other's element.

**Does your change fix a particular issue?**

Fixes #10341

**Please indicate you've done the following:**

- [x] Accepted the [DCO](https://github.com/vmware-tanzu/velero/blob/main/CONTRIBUTING.md#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://github.com/vmware-tanzu/velero/blob/main/CONTRIBUTING.md#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
