### PR TITLE
fix nil pointer dereference in WaitUntilVSCHandleIsReady when a VSC error has no message

### DIFF
--- a/changelogs/unreleased/10352-samay43
+++ b/changelogs/unreleased/10352-samay43
@@ -1,0 +1,1 @@
+Fix nil pointer dereference in WaitUntilVSCHandleIsReady when a VolumeSnapshotContent error has no message

--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -713,7 +713,7 @@ func WaitUntilVSCHandleIsReady(
 			if vsc.Status != nil &&
 				vsc.Status.Error != nil {
 				log.Warnf("VolumeSnapshotContent %s has error: %v",
-					vsc.Name, *vsc.Status.Error.Message)
+					vsc.Name, stringptr.GetString(vsc.Status.Error.Message))
 			}
 			return false, nil
 		}
@@ -764,10 +764,10 @@ func WaitUntilVSCHandleIsReady(
 				vsc.Status.Error != nil {
 				log.Errorf(
 					"Timed out awaiting reconciliation of VolumeSnapshot, VolumeSnapshotContent %s has error: %v",
-					vsc.Name, *vsc.Status.Error.Message)
+					vsc.Name, stringptr.GetString(vsc.Status.Error.Message))
 				return nil,
 					errors.Errorf("CSI got timed out with error: %v",
-						*vsc.Status.Error.Message)
+						stringptr.GetString(vsc.Status.Error.Message))
 			} else {
 				log.Errorf(
 					"Timed out awaiting reconciliation of volumesnapshot %s/%s",

--- a/pkg/util/csi/volume_snapshot_test.go
+++ b/pkg/util/csi/volume_snapshot_test.go
@@ -1766,6 +1766,34 @@ func TestWaitUntilVSCHandleIsReady(t *testing.T) {
 		},
 	}
 
+	errNoMessageVsc := "err-no-message-vsc"
+	vscWithErrorNoMessage := &snapshotv1api.VolumeSnapshotContent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: errNoMessageVsc,
+		},
+		Spec: snapshotv1api.VolumeSnapshotContentSpec{
+			VolumeSnapshotRef: corev1api.ObjectReference{
+				Name:       "vol-snap-1",
+				APIVersion: snapshotv1api.SchemeGroupVersion.String(),
+			},
+		},
+		Status: &snapshotv1api.VolumeSnapshotContentStatus{
+			SnapshotHandle: nil,
+			// Error is set while Message is left nil. Both are optional in the
+			// CSI API, so the error-reporting paths must not dereference Message.
+			Error: &snapshotv1api.VolumeSnapshotError{Message: nil},
+		},
+	}
+	vsForErrorNoMessageVsc := &snapshotv1api.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vs-for-err-no-message",
+			Namespace: "default",
+		},
+		Status: &snapshotv1api.VolumeSnapshotStatus{
+			BoundVolumeSnapshotContentName: &errNoMessageVsc,
+		},
+	}
+
 	objs := []runtime.Object{
 		vscObj,
 		validVS,
@@ -1776,6 +1804,8 @@ func TestWaitUntilVSCHandleIsReady(t *testing.T) {
 		vsForNilStatusVsc,
 		vscWithNilStatusField,
 		vsForNilStatusFieldVsc,
+		vscWithErrorNoMessage,
+		vsForErrorNoMessageVsc,
 	}
 	fakeClient := velerotest.NewFakeControllerRuntimeClient(t, objs...)
 	testCases := []struct {
@@ -1809,6 +1839,12 @@ func TestWaitUntilVSCHandleIsReady(t *testing.T) {
 					BoundVolumeSnapshotContentName: &nilStatusVsc,
 				},
 			},
+		},
+		{
+			name:        "waitEnabled should return an error rather than panic when the volumesnapshotcontent has an error without a message",
+			volSnap:     vsForErrorNoMessageVsc,
+			exepctedVSC: nil,
+			expectError: true,
 		},
 	}
 


### PR DESCRIPTION
# Please add a summary of your change

`WaitUntilVSCHandleIsReady` reports a `VolumeSnapshotContent`'s error back to the user in three places — once from the poll function and twice from the timeout branch. Each checks that `Status.Error` is non-nil and then dereferences `Status.Error.Message`, which is itself an optional pointer:

```go
// external-snapshotter/client/v8@v8.4.0/apis/volumesnapshot/v1/types.go:460
type VolumeSnapshotError struct {
	// +optional
	Time *metav1.Time `json:"time,omitempty"`
	// +optional
	Message *string `json:"message,omitempty"`
}
```

```go
if vsc.Status != nil &&
	vsc.Status.Error != nil {
	log.Warnf("VolumeSnapshotContent %s has error: %v",
		vsc.Name, *vsc.Status.Error.Message)   // panics when message is unset
}
```

`Status.Error` being set says nothing about `Status.Error.Message`. A VSC carrying `status.error` with no `message` panics here. The only production caller is `pkg/backup/actions/csi/pvc_action.go:374`, the CSI PVC backup item action, so this crashes the backup rather than returning an error — and like #10291 it fires precisely when the snapshot is already in trouble.

This uses `stringptr.GetString`, which is already imported by this file and already used on this exact field at `volume_snapshot.go:85`:

```go
errMessage.Insert(stringptr.GetString(tmpVS.Status.Error.Message))
```

so no new imports and no new error semantics — a message-less error now renders as `<nil>` instead of crashing, which reports honestly that the driver supplied no text. Explicit `if msg != nil` guards were the alternative, but they would add a second message string at each site for no extra information, where the helper keeps each site to a single argument change.

On the three sites: only line 716 is independently reachable. Lines 767 and 770 are the same defect in the timeout branch, but any poll that had already observed a non-nil `Status.Error` panics at 716 first, so they are shadowed rather than dead. Fixing 716 alone would simply move the panic — the added test demonstrates this, since it exercises the poll path and then the timeout path against the same VSC. All three are fixed so the function is internally consistent.

Velero already treats `Error.Message` as nullable in four other places, two of them in this same file, which is what this change brings the remaining sites in line with:

```
pkg/util/csi/volume_snapshot.go:797                  if vs.Status.Error != nil && vs.Status.Error.Message != nil {
pkg/util/csi/volume_snapshot.go:830                  if vsc.Status.Error != nil && vsc.Status.Error.Message != nil {
pkg/backup/actions/csi/volumesnapshot_action.go:300  if vs.Status.Error.Message != nil {
pkg/backup/actions/csi/volumesnapshot_action.go:336  if vsc.Status.Error.Message != nil {
```

The new case joins the existing `TestWaitUntilVSCHandleIsReady` table and seeds a VSC with `SnapshotHandle: nil` and `Error: &VolumeSnapshotError{Message: nil}`, so the nil path is pinned specifically rather than asserted against an object that happens to have no error. It panics on `main` without the source change:

```
--- FAIL: TestWaitUntilVSCHandleIsReady/waitEnabled_should_return_an_error_rather_than_panic_when_the_volumesnapshotcontent_has_an_error_without_a_message
panic: runtime error: invalid memory address or nil pointer dereference
	csi.WaitUntilVSCHandleIsReady.func1   pkg/util/csi/volume_snapshot.go:716
```

This is a follow-up to #10292, which fixed the same class of nil dereference in the error-reporting paths of `EnsureDeleteVS` and `EnsureDeleteVSC` in this file. `WaitUntilVSCHandleIsReady` was not covered by that change.

# Does your change fix a particular issue?

Fixes #10350

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
