### PR TITLE
Re-process InProgress DeleteBackupRequests on retry

### DIFF
--- a/changelogs/unreleased/10354-PranjalManhgaye
+++ b/changelogs/unreleased/10354-PranjalManhgaye
@@ -1,0 +1,1 @@
+Re-process InProgress DeleteBackupRequests instead of skipping them when the final status patch fails

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -136,9 +136,9 @@ func (r *backupDeletionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Since we use the reconciler along with the PeriodicalEnqueueSource, there may be reconciliation triggered by
-	// stale requests.
-	if dbr.Status.Phase == velerov1api.DeleteBackupRequestPhaseProcessed ||
-		dbr.Status.Phase == velerov1api.DeleteBackupRequestPhaseInProgress {
+	// stale requests. Processed requests are terminal and can be cleaned up once expired. InProgress requests are
+	// re-processed so a failed final status patch does not leave the request stuck until expiry.
+	if dbr.Status.Phase == velerov1api.DeleteBackupRequestPhaseProcessed {
 		age := r.clock.Now().Sub(dbr.CreationTimestamp.Time)
 		if age >= deleteBackupRequestMaxAge { // delete the expired request
 			log.Debugf("The request is expired, status: %s, deleting it.", dbr.Status.Phase)

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -177,6 +177,33 @@ func (r *backupDeletionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		Namespace: dbr.Namespace,
 		Name:      dbr.Spec.BackupName,
 	}, backup); apierrors.IsNotFound(err) {
+		if dbr.Status.Phase == velerov1api.DeleteBackupRequestPhaseInProgress {
+			// The backup was already deleted in a prior reconcile attempt, but the final
+			// status patch may have failed. Treat this as successful completion.
+			log.Info("Backup already deleted, completing DeleteBackupRequest")
+			backupUID := dbr.Labels[velerov1api.BackupUIDLabel]
+			if _, patchErr := r.patchDeleteBackupRequest(ctx, dbr, func(r *velerov1api.DeleteBackupRequest) {
+				r.Status.Phase = velerov1api.DeleteBackupRequestPhaseProcessed
+				r.Status.Errors = nil
+			}); patchErr != nil {
+				return ctrl.Result{}, patchErr
+			}
+			r.metrics.RegisterBackupDeletionSuccess("")
+			if backupUID != "" {
+				labelSelector, selErr := labels.Parse(fmt.Sprintf("%s=%s,%s=%s", velerov1api.BackupNameLabel, label.GetValidName(dbr.Spec.BackupName), velerov1api.BackupUIDLabel, backupUID))
+				if selErr != nil {
+					r.logger.WithError(selErr).WithField("backup", dbr.Spec.BackupName).Error("error creating label selector for the backup for deleting DeleteBackupRequests")
+					return ctrl.Result{}, nil
+				}
+				alldbr := &velerov1api.DeleteBackupRequest{}
+				if delErr := r.DeleteAllOf(ctx, alldbr, client.MatchingLabelsSelector{
+					Selector: labelSelector,
+				}, client.InNamespace(dbr.Namespace)); delErr != nil {
+					r.logger.WithError(delErr).WithField("backup", dbr.Spec.BackupName).Error("error deleting all associated DeleteBackupRequests after successfully deleting the backup")
+				}
+			}
+			return ctrl.Result{}, nil
+		}
 		// Couldn't find backup - update status to Processed and record the not-found error
 		err = r.patchDeleteBackupRequestWithError(ctx, dbr, errors.New("backup not found"))
 		return ctrl.Result{}, err

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -48,6 +48,7 @@ import (
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	pkgbackup "github.com/vmware-tanzu/velero/pkg/backup"
 	"github.com/vmware-tanzu/velero/pkg/builder"
+	"github.com/vmware-tanzu/velero/pkg/label"
 	"github.com/vmware-tanzu/velero/pkg/metrics"
 	persistencemocks "github.com/vmware-tanzu/velero/pkg/persistence/mocks"
 	"github.com/vmware-tanzu/velero/pkg/plugin/clientmgmt"
@@ -789,6 +790,82 @@ func TestBackupDeletionControllerReconcile(t *testing.T) {
 		err = td.fakeClient.Get(ctx, td.req.NamespacedName, res)
 		assert.True(t, apierrors.IsNotFound(err), "Expected not found error, but actual value of error: %v", err)
 		td.backupStore.AssertNotCalled(t, "DeleteBackup", mock.Anything)
+	})
+
+	t.Run("InProgress request is re-processed instead of skipped", func(t *testing.T) {
+		input := defaultTestDbr()
+		input.Status.Phase = velerov1api.DeleteBackupRequestPhaseInProgress
+		input.Labels = map[string]string{
+			velerov1api.BackupNameLabel: label.GetValidName(input.Spec.BackupName),
+			velerov1api.BackupUIDLabel:  "uid",
+		}
+
+		backup := builder.ForBackup(velerov1api.DefaultNamespace, "foo").Result()
+		backup.UID = "uid"
+		backup.Spec.StorageLocation = "primary"
+
+		location := &velerov1api.BackupStorageLocation{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: backup.Namespace,
+				Name:      backup.Spec.StorageLocation,
+			},
+			Spec: velerov1api.BackupStorageLocationSpec{
+				Provider: "objStoreProvider",
+				StorageType: velerov1api.StorageType{
+					ObjectStorage: &velerov1api.ObjectStorageLocation{
+						Bucket: "bucket",
+					},
+				},
+			},
+			Status: velerov1api.BackupStorageLocationStatus{
+				Phase: velerov1api.BackupStorageLocationPhaseAvailable,
+			},
+		}
+
+		td := setupBackupDeletionControllerTest(t, input, backup, location)
+
+		pluginManager := &pluginmocks.Manager{}
+		pluginManager.On("GetDeleteItemActions").Return(nil, nil)
+		pluginManager.On("CleanupClients")
+		td.controller.newPluginManager = func(logrus.FieldLogger) clientmgmt.Manager { return pluginManager }
+
+		td.backupStore.On("GetBackupVolumeSnapshots", input.Spec.BackupName).Return(nil, nil)
+		td.backupStore.On("DeleteBackup", input.Spec.BackupName).Return(nil)
+
+		_, err := td.controller.Reconcile(t.Context(), td.req)
+		require.NoError(t, err)
+
+		res := &velerov1api.DeleteBackupRequest{}
+		err = td.fakeClient.Get(ctx, td.req.NamespacedName, res)
+		assert.True(t, apierrors.IsNotFound(err), "Expected DBR to be deleted after retrying InProgress request, but actual error: %v", err)
+
+		err = td.fakeClient.Get(t.Context(), types.NamespacedName{
+			Namespace: velerov1api.DefaultNamespace,
+			Name:      backup.Name,
+		}, &velerov1api.Backup{})
+		assert.True(t, apierrors.IsNotFound(err), "Expected backup CR to be deleted after retrying InProgress request, but actual error: %v", err)
+	})
+
+	t.Run("Expired InProgress request is re-processed instead of deleted", func(t *testing.T) {
+		expired := time.Date(2018, 4, 3, 12, 0, 0, 0, time.UTC)
+		input := defaultTestDbr()
+		input.CreationTimestamp = metav1.Time{
+			Time: expired,
+		}
+		input.Status.Phase = velerov1api.DeleteBackupRequestPhaseInProgress
+
+		td := setupBackupDeletionControllerTest(t, input)
+		td.backupStore.On("DeleteBackup", mock.Anything).Return(nil)
+
+		_, err := td.controller.Reconcile(t.Context(), td.req)
+		require.NoError(t, err)
+
+		res := &velerov1api.DeleteBackupRequest{}
+		err = td.fakeClient.Get(ctx, td.req.NamespacedName, res)
+		require.NoError(t, err)
+		assert.Equal(t, "Processed", string(res.Status.Phase))
+		assert.Len(t, res.Status.Errors, 1)
+		assert.Equal(t, "backup not found", res.Status.Errors[0])
 	})
 
 	t.Run("Expired request will not be deleted if the status is not processed", func(t *testing.T) {

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -846,6 +846,25 @@ func TestBackupDeletionControllerReconcile(t *testing.T) {
 		assert.True(t, apierrors.IsNotFound(err), "Expected backup CR to be deleted after retrying InProgress request, but actual error: %v", err)
 	})
 
+	t.Run("InProgress request with missing backup completes successfully on retry", func(t *testing.T) {
+		input := defaultTestDbr()
+		input.Status.Phase = velerov1api.DeleteBackupRequestPhaseInProgress
+		input.Labels = map[string]string{
+			velerov1api.BackupNameLabel: label.GetValidName(input.Spec.BackupName),
+			velerov1api.BackupUIDLabel:  "uid",
+		}
+
+		td := setupBackupDeletionControllerTest(t, input)
+
+		_, err := td.controller.Reconcile(t.Context(), td.req)
+		require.NoError(t, err)
+
+		res := &velerov1api.DeleteBackupRequest{}
+		err = td.fakeClient.Get(ctx, td.req.NamespacedName, res)
+		assert.True(t, apierrors.IsNotFound(err), "Expected DBR to be deleted after successful retry, but actual error: %v", err)
+		td.backupStore.AssertNotCalled(t, "DeleteBackup", mock.Anything)
+	})
+
 	t.Run("Expired InProgress request is re-processed instead of deleted", func(t *testing.T) {
 		expired := time.Date(2018, 4, 3, 12, 0, 0, 0, time.UTC)
 		input := defaultTestDbr()
@@ -853,19 +872,19 @@ func TestBackupDeletionControllerReconcile(t *testing.T) {
 			Time: expired,
 		}
 		input.Status.Phase = velerov1api.DeleteBackupRequestPhaseInProgress
+		input.Labels = map[string]string{
+			velerov1api.BackupNameLabel: label.GetValidName(input.Spec.BackupName),
+			velerov1api.BackupUIDLabel:  "uid",
+		}
 
 		td := setupBackupDeletionControllerTest(t, input)
-		td.backupStore.On("DeleteBackup", mock.Anything).Return(nil)
 
 		_, err := td.controller.Reconcile(t.Context(), td.req)
 		require.NoError(t, err)
 
 		res := &velerov1api.DeleteBackupRequest{}
 		err = td.fakeClient.Get(ctx, td.req.NamespacedName, res)
-		require.NoError(t, err)
-		assert.Equal(t, "Processed", string(res.Status.Phase))
-		assert.Len(t, res.Status.Errors, 1)
-		assert.Equal(t, "backup not found", res.Status.Errors[0])
+		assert.True(t, apierrors.IsNotFound(err), "Expected DBR to be deleted after successful retry, but actual error: %v", err)
 	})
 
 	t.Run("Expired request will not be deleted if the status is not processed", func(t *testing.T) {


### PR DESCRIPTION
Fixes #10169

## Summary
- InProgress delete requests are no longer skipped during reconciliation
- If the final status patch fails, the controller retries the deletion instead of leaving the request stuck for up to 24 hours
- Processed requests still skip as before and get cleaned up once expired

## Test plan
- [x] Added test for InProgress request re-processing to completion
- [x] Added test for expired InProgress request being retried instead of deleted
- [x] `go test ./pkg/controller -run TestBackupDeletionControllerReconcile`