### PR TITLE
Surface EnableCSI requirement for snapshot-move-data backups

### DIFF
--- a/changelogs/unreleased/10355-PranjalManhgaye
+++ b/changelogs/unreleased/10355-PranjalManhgaye
@@ -1,0 +1,1 @@
+Warn and track skipped PVs when snapshot-move-data is used without EnableCSI

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1380,6 +1380,30 @@ func TestBackupItemActionsForSkippedPV(t *testing.T) {
 		expectNotSkippedPVs []string
 	}{
 		{
+			name: "CSI BIA skipped with EnableCSI off and no snapshot-move-data does not track PV",
+			backupReq: &Request{
+				Backup:           defaultBackup().Result(),
+				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
+				WorkerPool:       itemBlockPool,
+			},
+			apiResources: []*test.APIResource{
+				test.PVCs(
+					builder.ForPersistentVolumeClaim("ns-1", "pvc-1").VolumeName("pv-1").Phase(corev1api.ClaimBound).Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").CSI("driver.csi", "vol-1").Result(),
+				),
+			},
+			runtimeResources: []runtime.Object{
+				builder.ForPersistentVolumeClaim("ns-1", "pvc-1").VolumeName("pv-1").Phase(corev1api.ClaimBound).Result(),
+				builder.ForPersistentVolume("pv-1").CSI("driver.csi", "vol-1").Result(),
+			},
+			actions: []*recordResourcesAction{
+				new(recordResourcesAction).WithName(csiBIAPluginName).ForNamespace("ns-1").ForResource("persistentvolumeclaims"),
+			},
+		},
+		{
 			name: "snapshot-move-data with EnableCSI off skips CSI BIA and tracks the PVC's PV with EnableCSI reason",
 			backupReq: &Request{
 				Backup:           defaultBackup().SnapshotMoveData(true).Result(),
@@ -2973,6 +2997,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 	defer itemBlockPool.Stop()
 	tests := []struct {
 		name              string
+		enableCSI         bool
 		req               *Request
 		vsls              []*velerov1.VolumeSnapshotLocation
 		apiResources      []*test.APIResource
@@ -3345,6 +3370,44 @@ func TestBackupWithSnapshots(t *testing.T) {
 			wantSkippedPVs: []SkippedPV{},
 		},
 		{
+			name:      "non-CSI PV with snapshot-move-data and EnableCSI on falls back to native snapshot",
+			enableCSI: true,
+			req: &Request{
+				Backup: defaultBackup().SnapshotMoveData(true).Result(),
+				SnapshotLocations: []*velerov1.VolumeSnapshotLocation{
+					newSnapshotLocation("velero", "default", "default"),
+				},
+				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
+				WorkerPool:       itemBlockPool,
+			},
+			apiResources: []*test.APIResource{
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").Result(),
+				),
+			},
+			snapshotterGetter: map[string]vsv1.VolumeSnapshotter{
+				"default": new(fakeVolumeSnapshotter).WithVolume("pv-1", "vol-1", "", "type-1", 100, false),
+			},
+			want: []*volume.Snapshot{
+				{
+					Spec: volume.SnapshotSpec{
+						BackupName:           "backup-1",
+						Location:             "default",
+						PersistentVolumeName: "pv-1",
+						ProviderVolumeID:     "vol-1",
+						VolumeType:           "type-1",
+						VolumeIOPS:           int64Ptr(100),
+					},
+					Status: volume.SnapshotStatus{
+						Phase:              volume.SnapshotPhaseCompleted,
+						ProviderSnapshotID: "vol-1-snapshot",
+					},
+				},
+			},
+			wantSkippedPVs: []SkippedPV{},
+		},
+		{
 			name: "CSI PV with snapshot-move-data and EnableCSI off tracks EnableCSI skip reason",
 			req: &Request{
 				Backup: defaultBackup().SnapshotMoveData(true).Result(),
@@ -3382,6 +3445,9 @@ func TestBackupWithSnapshots(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			features.NewFeatureFlagSet("")
 			defer features.NewFeatureFlagSet("")
+			if tc.enableCSI {
+				features.Enable(velerov1.CSIFeatureFlag)
+			}
 
 			var (
 				h          = newHarness(t, itemBlockPool)

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1409,7 +1409,7 @@ func TestBackupItemActionsForSkippedPV(t *testing.T) {
 			},
 		},
 		{
-			name: "backup item action returns the 'not a CSI volume' error and the PV should be tracked as skippedPV",
+			name:      "backup item action returns the 'not a CSI volume' error and the PV should be tracked as skippedPV",
 			enableCSI: true,
 			backupReq: &Request{
 				Backup:           defaultBackup().SnapshotVolumes(false).Result(),
@@ -1450,7 +1450,7 @@ func TestBackupItemActionsForSkippedPV(t *testing.T) {
 			},
 		},
 		{
-			name: "backup item action named as CSI plugin executed successfully and the PV will be removed from the skipped PV tracker",
+			name:      "backup item action named as CSI plugin executed successfully and the PV will be removed from the skipped PV tracker",
 			enableCSI: true,
 			backupReq: &Request{
 				Backup: defaultBackup().Result(),

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1374,12 +1374,43 @@ func TestBackupItemActionsForSkippedPV(t *testing.T) {
 		runtimeResources []runtime.Object
 		actions          []*recordResourcesAction
 		resPolicies      *resourcepolicies.ResourcePolicies
+		enableCSI        bool
 		// {pvName:{approach: reason}}
 		expectSkippedPVs    map[string]map[string]string
 		expectNotSkippedPVs []string
 	}{
 		{
+			name: "snapshot-move-data with EnableCSI off skips CSI BIA and tracks the PVC's PV with EnableCSI reason",
+			backupReq: &Request{
+				Backup:           defaultBackup().SnapshotMoveData(true).Result(),
+				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
+				WorkerPool:       itemBlockPool,
+			},
+			apiResources: []*test.APIResource{
+				test.PVCs(
+					builder.ForPersistentVolumeClaim("ns-1", "pvc-1").VolumeName("pv-1").Phase(corev1api.ClaimBound).Result(),
+				),
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").CSI("driver.csi", "vol-1").Result(),
+				),
+			},
+			runtimeResources: []runtime.Object{
+				builder.ForPersistentVolumeClaim("ns-1", "pvc-1").VolumeName("pv-1").Phase(corev1api.ClaimBound).Result(),
+				builder.ForPersistentVolume("pv-1").CSI("driver.csi", "vol-1").Result(),
+			},
+			actions: []*recordResourcesAction{
+				new(recordResourcesAction).WithName(csiBIAPluginName).ForNamespace("ns-1").ForResource("persistentvolumeclaims"),
+			},
+			expectSkippedPVs: map[string]map[string]string{
+				"pv-1": {
+					csiSnapshotApproach: "snapshot-move-data requires EnableCSI feature, which is not enabled",
+				},
+			},
+		},
+		{
 			name: "backup item action returns the 'not a CSI volume' error and the PV should be tracked as skippedPV",
+			enableCSI: true,
 			backupReq: &Request{
 				Backup:           defaultBackup().SnapshotVolumes(false).Result(),
 				SkippedPVTracker: NewSkipPVTracker(),
@@ -1420,6 +1451,7 @@ func TestBackupItemActionsForSkippedPV(t *testing.T) {
 		},
 		{
 			name: "backup item action named as CSI plugin executed successfully and the PV will be removed from the skipped PV tracker",
+			enableCSI: true,
 			backupReq: &Request{
 				Backup: defaultBackup().Result(),
 				SkippedPVTracker: &skipPVTracker{
@@ -1457,6 +1489,12 @@ func TestBackupItemActionsForSkippedPV(t *testing.T) {
 	}()
 	for _, tc := range tests {
 		t.Run(tc.name, func(tt *testing.T) {
+			features.NewFeatureFlagSet("")
+			defer features.NewFeatureFlagSet("")
+			if tc.enableCSI {
+				features.Enable(velerov1.CSIFeatureFlag)
+			}
+
 			var (
 				h          = newHarness(t, itemBlockPool)
 				backupFile = bytes.NewBuffer([]byte{})
@@ -3306,10 +3344,45 @@ func TestBackupWithSnapshots(t *testing.T) {
 			},
 			wantSkippedPVs: []SkippedPV{},
 		},
+		{
+			name: "CSI PV with snapshot-move-data and EnableCSI off tracks EnableCSI skip reason",
+			req: &Request{
+				Backup: defaultBackup().SnapshotMoveData(true).Result(),
+				SnapshotLocations: []*velerov1.VolumeSnapshotLocation{
+					newSnapshotLocation("velero", "default", "default"),
+				},
+				SkippedPVTracker: NewSkipPVTracker(),
+				BackedUpItems:    NewBackedUpItemsMap(),
+				WorkerPool:       itemBlockPool,
+			},
+			apiResources: []*test.APIResource{
+				test.PVs(
+					builder.ForPersistentVolume("pv-1").CSI("driver.csi", "vol-1").Result(),
+				),
+			},
+			snapshotterGetter: map[string]vsv1.VolumeSnapshotter{
+				"default": new(fakeVolumeSnapshotter),
+			},
+			want: nil,
+			wantSkippedPVs: []SkippedPV{
+				{
+					Name: "pv-1",
+					Reasons: []PVSkipReason{
+						{
+							Approach: volumeSnapshotApproach,
+							Reason:   "snapshot-move-data requires EnableCSI feature, which is not enabled",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			features.NewFeatureFlagSet("")
+			defer features.NewFeatureFlagSet("")
+
 			var (
 				h          = newHarness(t, itemBlockPool)
 				backupFile = bytes.NewBuffer([]byte{})

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -424,8 +424,14 @@ func (ib *itemBackupper) executeActions(
 
 		// If the EnableCSI feature is not enabled, but the executing action is from CSI plugin, skip the action.
 		if csiutil.ShouldSkipAction(actionName) {
-			log.Infof("Skip action %s for resource %s:%s/%s, because the CSI feature is not enabled. Feature setting is %s.",
-				actionName, groupResource.String(), metadata.GetNamespace(), metadata.GetName(), features.Serialize())
+			if boolptr.IsSetToTrue(ib.backupRequest.Spec.SnapshotMoveData) {
+				log.Warnf("Skip action %s for resource %s:%s/%s because snapshot-move-data requires the %s feature flag, which is not enabled. Enable it with velero install --features=%s.",
+					actionName, groupResource.String(), metadata.GetNamespace(), metadata.GetName(), velerov1api.CSIFeatureFlag, velerov1api.CSIFeatureFlag)
+				ib.trackSkippedPV(obj, groupResource, csiSnapshotApproach, fmt.Sprintf("snapshot-move-data requires %s feature, which is not enabled", velerov1api.CSIFeatureFlag), log)
+			} else {
+				log.Infof("Skip action %s for resource %s:%s/%s, because the CSI feature is not enabled. Feature setting is %s.",
+					actionName, groupResource.String(), metadata.GetNamespace(), metadata.GetName(), features.Serialize())
+			}
 			continue
 		}
 
@@ -622,11 +628,16 @@ func (ib *itemBackupper) takePVSnapshot(obj runtime.Unstructured, log logrus.Fie
 	// Need to add a mechanism to choose running which plugin for resources.
 	// After that, this warning can be removed.
 	if boolptr.IsSetToTrue(ib.backupRequest.Spec.SnapshotMoveData) {
-		log.Warnf("VolumeSnapshotter plugin doesn't support data movement.")
+		if !features.IsEnabled(velerov1api.CSIFeatureFlag) {
+			log.Warnf("Snapshot-move-data requires the %s feature flag, which is not enabled. CSI volume data will not be moved. Enable it with velero install --features=%s.",
+				velerov1api.CSIFeatureFlag, velerov1api.CSIFeatureFlag)
+		} else {
+			log.Warnf("VolumeSnapshotter plugin doesn't support data movement.")
 
-		if features.IsEnabled(velerov1api.CSIFeatureFlag) && pv.Spec.CSI == nil {
-			log.Warn("Cannot use CSI data mover to handle PV, because PV doesn't contain CSI in spec.",
-				" Fall back to Velero native snapshot.")
+			if pv.Spec.CSI == nil {
+				log.Warn("Cannot use CSI data mover to handle PV, because PV doesn't contain CSI in spec.",
+					" Fall back to Velero native snapshot.")
+			}
 		}
 	}
 
@@ -701,9 +712,15 @@ func (ib *itemBackupper) takePVSnapshot(obj runtime.Unstructured, log logrus.Fie
 	}
 
 	if volumeSnapshotter == nil {
-		// the PV may still has change to be snapshotted by CSI plugin's `PVCBackupItemAction` in PVC backup logic
-		log.Info("Persistent volume is not a supported volume type for Velero-native volumeSnapshotter snapshot, skipping.")
-		ib.backupRequest.SkippedPVTracker.Track(pv.Name, volumeSnapshotApproach, "no applicable volumesnapshotter found")
+		reason := "no applicable volumesnapshotter found"
+		if boolptr.IsSetToTrue(ib.backupRequest.Spec.SnapshotMoveData) && pv.Spec.CSI != nil && !features.IsEnabled(velerov1api.CSIFeatureFlag) {
+			log.Warnf("Persistent volume %s cannot use snapshot-move-data because the %s feature flag is not enabled. Enable it with velero install --features=%s.",
+				pv.Name, velerov1api.CSIFeatureFlag, velerov1api.CSIFeatureFlag)
+			reason = fmt.Sprintf("snapshot-move-data requires %s feature, which is not enabled", velerov1api.CSIFeatureFlag)
+		} else {
+			log.Info("Persistent volume is not a supported volume type for Velero-native volumeSnapshotter snapshot, skipping.")
+		}
+		ib.backupRequest.SkippedPVTracker.Track(pv.Name, volumeSnapshotApproach, reason)
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #10299

## Summary
- When snapshot-move-data is used without EnableCSI, the backup now warns operators explicitly instead of showing a generic volumesnapshotter message
- Skipped CSI backup item actions and CSI persistent volumes are tracked with a clear reason naming the EnableCSI flag
- Non-snapshot-move-data backups keep the existing info-level CSI skip behavior

## Test plan
- [x] Added test for CSI BIA skip with snapshot-move-data and EnableCSI off
- [x] Added test for CSI PV skip reason in snapshot path
- [x] `go test ./pkg/backup -run 'TestBackupItemActionsForSkippedPV|TestBackupWithSnapshots'`