### PR TITLE
Add volumeName condition to VolumePolicy resource filtering

### DIFF
--- a/changelogs/unreleased/10356-PranjalManhgaye
+++ b/changelogs/unreleased/10356-PranjalManhgaye
@@ -1,0 +1,1 @@
+Add volumeName condition to VolumePolicy resource filtering

--- a/internal/resourcepolicies/resource_policies.go
+++ b/internal/resourcepolicies/resource_policies.go
@@ -299,6 +299,11 @@ func unmarshalResourcePolicies(yamlData *string) (*ResourcePolicies, error) {
 				return nil, err
 			}
 		}
+		if raw, ok := vp.Conditions["volumeName"]; ok {
+			if err := validateStringSliceCondition("volumeName", raw); err != nil {
+				return nil, err
+			}
+		}
 	}
 	return resPolicies, nil
 }
@@ -332,6 +337,9 @@ func (p *Policies) BuildPolicy(resPolicies *ResourcePolicies) error {
 		volP.action = vp.Action
 		volP.conditions = append(volP.conditions, &capacityCondition{capacity: *volCap})
 		volP.conditions = append(volP.conditions, &storageClassCondition{storageClass: con.StorageClass})
+		if len(con.VolumeName) > 0 {
+			volP.conditions = append(volP.conditions, &volumeNameCondition{volumeNames: con.VolumeName})
+		}
 		volP.conditions = append(volP.conditions, &nfsCondition{nfs: con.NFS})
 		volP.conditions = append(volP.conditions, &csiCondition{csi: con.CSI})
 		volP.conditions = append(volP.conditions, &volumeTypeCondition{volumeTypes: con.VolumeTypes})

--- a/internal/resourcepolicies/resource_policies_test.go
+++ b/internal/resourcepolicies/resource_policies_test.go
@@ -84,6 +84,42 @@ func TestLoadResourcePolicies(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "error format of volumeName",
+			yamlData: `version: v1
+	volumePolicies:
+	- conditions:
+		capacity: "0,100Gi"
+		volumeName: pv-1
+	  action:
+		type: skip`,
+			wantErr: true,
+		},
+		{
+			name: "error format of volumeName (list with non-string)",
+			yamlData: `version: v1
+volumePolicies:
+  - conditions:
+      volumeName:
+        - 123
+    action:
+      type: skip
+`,
+			wantErr: true,
+		},
+		{
+			name: "supported format volumeName",
+			yamlData: `version: v1
+volumePolicies:
+  - conditions:
+      volumeName:
+        - pv-1
+        - data
+    action:
+      type: skip
+`,
+			wantErr: false,
+		},
+		{
 			name: "error format of csi",
 			yamlData: `version: v1
 	volumePolicies:
@@ -1781,6 +1817,58 @@ volumePolicies:
 				},
 			},
 			skip: true,
+		},
+		{
+			name: "volume name matching - PV name should snapshot",
+			yamlData: `version: v1
+volumePolicies:
+- conditions:
+    volumeName:
+      - pv-1
+  action:
+    type: snapshot`,
+			vol: &corev1api.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pv-1",
+				},
+			},
+			podVol: nil,
+			pvc:    nil,
+			skip:   false,
+		},
+		{
+			name: "volume name matching - pod volume name should snapshot",
+			yamlData: `version: v1
+volumePolicies:
+- conditions:
+    volumeName:
+      - data
+  action:
+    type: snapshot`,
+			vol: nil,
+			podVol: &corev1api.Volume{
+				Name: "data",
+			},
+			pvc:  nil,
+			skip: false,
+		},
+		{
+			name: "volume name matching - unmatched name should not snapshot",
+			yamlData: `version: v1
+volumePolicies:
+- conditions:
+    volumeName:
+      - pv-1
+  action:
+    type: snapshot`,
+			vol: &corev1api.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pv-2",
+				},
+			},
+			podVol: nil,
+			pvc:    nil,
+			skip:   false,
 		},
 	}
 	for _, tc := range testCases {

--- a/internal/resourcepolicies/volume_resources.go
+++ b/internal/resourcepolicies/volume_resources.go
@@ -49,6 +49,9 @@ type capacity struct {
 type structuredVolume struct {
 	capacity       resource.Quantity
 	storageClass   string
+	pvName         string
+	podVolumeName  string
+	pvcName        string
 	nfs            *nFSVolumeSource
 	csi            *csiVolumeSource
 	volumeType     SupportedVolume
@@ -61,6 +64,7 @@ type structuredVolume struct {
 func (s *structuredVolume) parsePV(pv *corev1api.PersistentVolume) {
 	s.capacity = *pv.Spec.Capacity.Storage()
 	s.storageClass = pv.Spec.StorageClassName
+	s.pvName = pv.Name
 	nfs := pv.Spec.NFS
 	if nfs != nil {
 		s.nfs = &nFSVolumeSource{Server: nfs.Server, Path: nfs.Path}
@@ -76,6 +80,7 @@ func (s *structuredVolume) parsePV(pv *corev1api.PersistentVolume) {
 
 func (s *structuredVolume) parsePVC(pvc *corev1api.PersistentVolumeClaim) {
 	if pvc != nil {
+		s.pvcName = pvc.Name
 		if len(pvc.GetLabels()) > 0 {
 			s.pvcLabels = pvc.Labels
 		}
@@ -93,6 +98,7 @@ func (s *structuredVolume) parsePVC(pvc *corev1api.PersistentVolumeClaim) {
 }
 
 func (s *structuredVolume) parsePodVolume(vol *corev1api.Volume) {
+	s.podVolumeName = vol.Name
 	nfs := vol.NFS
 	if nfs != nil {
 		s.nfs = &nFSVolumeSource{Server: nfs.Server, Path: nfs.Path}
@@ -212,6 +218,38 @@ func (s *storageClassCondition) match(v *structuredVolume) bool {
 
 	for _, sc := range s.storageClass {
 		if v.storageClass == sc {
+			return true
+		}
+	}
+
+	return false
+}
+
+type volumeNameCondition struct {
+	volumeNames []string
+}
+
+func (v *volumeNameCondition) match(s *structuredVolume) bool {
+	if len(v.volumeNames) == 0 {
+		return true
+	}
+
+	candidates := make([]string, 0, 3)
+	if s.pvName != "" {
+		candidates = append(candidates, s.pvName)
+	}
+	if s.podVolumeName != "" {
+		candidates = append(candidates, s.podVolumeName)
+	}
+	if s.pvcName != "" {
+		candidates = append(candidates, s.pvcName)
+	}
+	if len(candidates) == 0 {
+		return false
+	}
+
+	for _, name := range v.volumeNames {
+		if slices.Contains(candidates, name) {
 			return true
 		}
 	}

--- a/internal/resourcepolicies/volume_resources_test.go
+++ b/internal/resourcepolicies/volume_resources_test.go
@@ -239,6 +239,76 @@ func TestStorageClassConditionMatch(t *testing.T) {
 	}
 }
 
+func TestVolumeNameConditionMatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		condition     *volumeNameCondition
+		volume        *structuredVolume
+		expectedMatch bool
+	}{
+		{
+			name:          "match persistent volume name",
+			condition:     &volumeNameCondition{volumeNames: []string{"pv-1"}},
+			volume:        &structuredVolume{pvName: "pv-1"},
+			expectedMatch: true,
+		},
+		{
+			name:          "match pod volume name",
+			condition:     &volumeNameCondition{volumeNames: []string{"data"}},
+			volume:        &structuredVolume{podVolumeName: "data"},
+			expectedMatch: true,
+		},
+		{
+			name:          "match pvc name",
+			condition:     &volumeNameCondition{volumeNames: []string{"pvc-1"}},
+			volume:        &structuredVolume{pvcName: "pvc-1"},
+			expectedMatch: true,
+		},
+		{
+			name:          "match any configured name when multiple names are available",
+			condition:     &volumeNameCondition{volumeNames: []string{"pvc-1"}},
+			volume:        &structuredVolume{pvName: "pv-1", podVolumeName: "data", pvcName: "pvc-1"},
+			expectedMatch: true,
+		},
+		{
+			name:          "match one of multiple configured names",
+			condition:     &volumeNameCondition{volumeNames: []string{"pv-1", "data"}},
+			volume:        &structuredVolume{podVolumeName: "data"},
+			expectedMatch: true,
+		},
+		{
+			name:          "mismatch volume name",
+			condition:     &volumeNameCondition{volumeNames: []string{"pv-1"}},
+			volume:        &structuredVolume{pvName: "pv-2"},
+			expectedMatch: false,
+		},
+		{
+			name:          "empty configured names always match",
+			condition:     &volumeNameCondition{volumeNames: []string{}},
+			volume:        &structuredVolume{pvName: "pv-1"},
+			expectedMatch: true,
+		},
+		{
+			name:          "no available names to match",
+			condition:     &volumeNameCondition{volumeNames: []string{"pv-1"}},
+			volume:        &structuredVolume{},
+			expectedMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match := tt.condition.match(tt.volume)
+			assert.Equal(t, tt.expectedMatch, match)
+		})
+	}
+}
+
+func TestVolumeNameConditionValidate(t *testing.T) {
+	condition := &volumeNameCondition{volumeNames: []string{"pv-1"}}
+	assert.NoError(t, condition.validate())
+}
+
 func TestNFSConditionMatch(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/resourcepolicies/volume_resources_validator.go
+++ b/internal/resourcepolicies/volume_resources_validator.go
@@ -44,6 +44,7 @@ type nFSVolumeSource struct {
 type volumeConditions struct {
 	Capacity       string            `yaml:"capacity,omitempty"`
 	StorageClass   []string          `yaml:"storageClass,omitempty"`
+	VolumeName     []string          `yaml:"volumeName,omitempty"`
 	NFS            *nFSVolumeSource  `yaml:"nfs,omitempty"`
 	CSI            *csiVolumeSource  `yaml:"csi,omitempty"`
 	VolumeTypes    []SupportedVolume `yaml:"volumeTypes,omitempty"`
@@ -66,6 +67,11 @@ func (c *capacityCondition) validate() error {
 }
 
 func (s *storageClassCondition) validate() error {
+	// validate by yamlv3
+	return nil
+}
+
+func (v *volumeNameCondition) validate() error {
 	// validate by yamlv3
 	return nil
 }

--- a/internal/resourcepolicies/volume_resources_validator_test.go
+++ b/internal/resourcepolicies/volume_resources_validator_test.go
@@ -149,6 +149,22 @@ func TestValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "error format of volumeName",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{Type: "skip"},
+						Conditions: map[string]any{
+							"capacity":   "0,10Gi",
+							"volumeName": "pv-1",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "error format of csi",
 			res: &ResourcePolicies{
 				Version: "v1",
@@ -432,6 +448,21 @@ func TestValidate(t *testing.T) {
 								"environment": "production",
 								"app":         "database",
 							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "supported format volume policies with volumeName",
+			res: &ResourcePolicies{
+				Version: "v1",
+				VolumePolicies: []VolumePolicy{
+					{
+						Action: Action{Type: "snapshot"},
+						Conditions: map[string]any{
+							"volumeName": []string{"pv-1", "data"},
 						},
 					},
 				},

--- a/site/content/docs/main/resource-filtering.md
+++ b/site/content/docs/main/resource-filtering.md
@@ -321,6 +321,9 @@ volumePolicies:
       storageClass:
         - gp2
         - standard
+      volumeName:
+        - data
+        - pv-1
       pvcPhase:
         - Pending
       pvcVolumeMode: Block
@@ -418,6 +421,7 @@ Currently, Velero supports the volume attributes listed below:
   - "5Gi," which means capacity or size matches larger than 5Gi, including value 5Gi
   - "5Gi" which is not supported and will be failed in validating the configuration
 - storageClass: matching volumes those with specified `storageClass`, such as `gp2`, `ebs-sc` in eks
+- volumeName: matching volumes by PersistentVolume name, pod volume name, or PersistentVolumeClaim name
 - volume sources: matching volumes that used specified volume sources. Currently we support nfs or csi backend volume source
 - pvcPhase: matching volumes based on the phase of their associated PVCs (Pending, Bound, Lost)
 - pvcVolumeMode: matching volumes based on the volume mode of their associated PVCs (Filesystem, Block)
@@ -435,6 +439,13 @@ Velero supported conditions and format listed below:
   storageClass:
     - gp2
     - ebs-sc
+  ```
+- volumeName
+  ```yaml
+  # match volume by PV name, pod volume name, or PVC name
+  volumeName:
+    - data
+    - pv-1
   ```
 - volume sources (currently only support below format and attributes)
 1. Specify the volume source name, the name could be `nfs`, `rbd`, `iscsi`, `csi` etc, but Velero only support `nfs` and `csi` currently.
@@ -510,6 +521,36 @@ Velero supported conditions and format listed below:
           pvcLabels:
             environment: production
             app: frontend
+        action:
+          type: skip
+      ```
+
+- volume Name
+
+  This condition filters volumes by name. The condition is specified as a list of names to match. A volume matches if any configured name matches the PersistentVolume name, the pod volume name, or the associated PersistentVolumeClaim name. This is useful for opt-in snapshot behavior similar to the `backup.velero.io/backup-volumes` pod annotation.
+    ```yaml
+    volumeName:
+      - data
+      - pv-1
+    ```
+
+    Some examples:
+  - Snapshot specific pod volumes by name:
+      ```yaml
+      volumePolicies:
+      - conditions:
+          volumeName:
+            - data
+            - logs
+        action:
+          type: snapshot
+      ```
+  - Skip a specific PersistentVolume:
+      ```yaml
+      volumePolicies:
+      - conditions:
+          volumeName:
+            - pv-to-skip
         action:
           type: skip
       ```


### PR DESCRIPTION
## Summary
- Add a `volumeName` condition to VolumePolicy so backups can target volumes by PersistentVolume name, pod volume name, or PVC name
- Follows the existing `storageClass` / `pvcPhase` pattern in `internal/resourcepolicies`
- Document the new condition in resource-filtering docs with opt-in snapshot examples

Fixes #8363

## Test plan
- [x] `go test ./internal/resourcepolicies/...`
- [x] Unit tests for `volumeNameCondition` match logic (PV, pod volume, and PVC names)
- [x] YAML validation tests for invalid `volumeName` format
- [x] `GetMatchAction` integration tests for matched and unmatched volume names