### PR TITLE
translate parent snapshot "auto" to an empty parent snapshot in both data mover micro services

### DIFF
--- a/changelogs/unreleased/10357-samay43
+++ b/changelogs/unreleased/10357-samay43
@@ -1,0 +1,1 @@
+translate parent snapshot "auto" to an empty parent snapshot in both data mover micro services

--- a/pkg/datamover/backup_micro_service.go
+++ b/pkg/datamover/backup_micro_service.go
@@ -204,12 +204,17 @@ func (r *BackupMicroService) RunCancelableDataPath(ctx context.Context) (string,
 		velerov1api.AsyncOperationIDLabel: du.Labels[velerov1api.AsyncOperationIDLabel],
 	}
 
-	// Modify the ParentSnapshot to "" and ForceFull to true when ParentSnapshot is "none".
+	// "none" requests a full backup. "auto" requests that the data mover finds the most
+	// recent backup of the same volume as parent, which is what an empty ParentSnapshot
+	// already does, so both map to "".
 	parentSnapshot := du.Spec.ParentSnapshot
 	forceFull := false
-	if du.Spec.ParentSnapshot == veleroshared.ParentSnapshotNone {
+	switch du.Spec.ParentSnapshot {
+	case veleroshared.ParentSnapshotNone:
 		parentSnapshot = ""
 		forceFull = true
+	case veleroshared.ParentSnapshotAuto:
+		parentSnapshot = ""
 	}
 
 	if err := dp.StartBackup(r.sourceTargetPath, du.Spec.DataMoverConfig, &datapath.BackupStartParam{

--- a/pkg/datamover/backup_micro_service_test.go
+++ b/pkg/datamover/backup_micro_service_test.go
@@ -32,6 +32,7 @@ import (
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	veleroshared "github.com/vmware-tanzu/velero/pkg/apis/velero/shared"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 	"github.com/vmware-tanzu/velero/pkg/builder"
@@ -444,4 +445,90 @@ func TestRunCancelableDataPath(t *testing.T) {
 	}
 
 	cancel()
+}
+
+func TestRunCancelableDataPathParentSnapshot(t *testing.T) {
+	dataUploadName := "fake-data-upload"
+
+	tests := []struct {
+		name                   string
+		parentSnapshot         string
+		expectedParentSnapshot string
+		expectedForceFull      bool
+	}{
+		{
+			name:                   "empty lets the data mover search for a parent",
+			parentSnapshot:         "",
+			expectedParentSnapshot: "",
+			expectedForceFull:      false,
+		},
+		{
+			name:                   "auto lets the data mover search for a parent",
+			parentSnapshot:         veleroshared.ParentSnapshotAuto,
+			expectedParentSnapshot: "",
+			expectedForceFull:      false,
+		},
+		{
+			name:                   "none forces a full backup",
+			parentSnapshot:         veleroshared.ParentSnapshotNone,
+			expectedParentSnapshot: "",
+			expectedForceFull:      true,
+		},
+		{
+			name:                   "a specific snapshot ID is passed through unchanged",
+			parentSnapshot:         "fake-parent-snapshot-id",
+			expectedParentSnapshot: "fake-parent-snapshot-id",
+			expectedForceFull:      false,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	velerov2alpha1api.AddToScheme(scheme)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			duInProgress := builder.ForDataUpload(velerov1api.DefaultNamespace, dataUploadName).
+				Phase(velerov2alpha1api.DataUploadPhaseInProgress).
+				CSISnapshot(&velerov2alpha1api.CSISnapshotSpec{VolumeSnapshot: "fake-snapshot"}).
+				Result()
+			duInProgress.Spec.ParentSnapshot = test.parentSnapshot
+
+			fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).
+				WithRuntimeObjects(duInProgress).Build()
+
+			bs := &BackupMicroService{
+				namespace:      velerov1api.DefaultNamespace,
+				dataUploadName: dataUploadName,
+				ctx:            t.Context(),
+				client:         fakeClient,
+				dataPathMgr:    datapath.NewManager(1),
+				eventRecorder:  &backupMsTestHelper{},
+				resultSignal:   make(chan dataPathResult),
+				logger:         velerotest.NewLogger(),
+			}
+
+			var startParam *datapath.BackupStartParam
+			datapath.VGDPCreator = func(string, string, kbclient.Client, string, datapath.Callbacks, logrus.FieldLogger) datapath.AsyncBR {
+				fsBR := datapathmockes.NewAsyncBR(t)
+				fsBR.On("Init", mock.Anything, mock.Anything).Return(nil)
+				fsBR.On("StartBackup", mock.Anything, mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						startParam = args.Get(2).(*datapath.BackupStartParam)
+					}).Return(nil)
+				return fsBR
+			}
+
+			go func() {
+				time.Sleep(time.Millisecond * 500)
+				bs.resultSignal <- dataPathResult{result: "fake-succeed-result"}
+			}()
+
+			_, err := bs.RunCancelableDataPath(t.Context())
+			require.NoError(t, err)
+
+			require.NotNil(t, startParam)
+			assert.Equal(t, test.expectedParentSnapshot, startParam.ParentSnapshot)
+			assert.Equal(t, test.expectedForceFull, startParam.ForceFull)
+		})
+	}
 }

--- a/pkg/podvolume/backup_micro_service.go
+++ b/pkg/podvolume/backup_micro_service.go
@@ -193,12 +193,17 @@ func (r *BackupMicroService) RunCancelableDataPath(ctx context.Context) (string,
 
 	tags := map[string]string{}
 
-	// Modify the ParentSnapshot to "" and ForceFull to true when ParentSnapshot is "none".
+	// "none" requests a full backup. "auto" requests that the data mover finds the most
+	// recent backup of the same volume as parent, which is what an empty ParentSnapshot
+	// already does, so both map to "".
 	parentSnapshot := pvb.Spec.ParentSnapshot
 	forceFull := false
-	if pvb.Spec.ParentSnapshot == veleroshared.ParentSnapshotNone {
+	switch pvb.Spec.ParentSnapshot {
+	case veleroshared.ParentSnapshotNone:
 		parentSnapshot = ""
 		forceFull = true
+	case veleroshared.ParentSnapshotAuto:
+		parentSnapshot = ""
 	}
 
 	if err := fsBackup.StartBackup(r.sourceTargetPath, pvb.Spec.UploaderSettings, &datapath.BackupStartParam{

--- a/pkg/podvolume/backup_micro_service_test.go
+++ b/pkg/podvolume/backup_micro_service_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/datapath"
 	"github.com/vmware-tanzu/velero/pkg/uploader"
 
+	veleroshared "github.com/vmware-tanzu/velero/pkg/apis/velero/shared"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -445,4 +446,89 @@ func TestRunCancelableDataPath(t *testing.T) {
 	}
 
 	cancel()
+}
+
+func TestRunCancelableDataPathParentSnapshot(t *testing.T) {
+	pvbName := "fake-pvb"
+
+	tests := []struct {
+		name                   string
+		parentSnapshot         string
+		expectedParentSnapshot string
+		expectedForceFull      bool
+	}{
+		{
+			name:                   "empty lets the data mover search for a parent",
+			parentSnapshot:         "",
+			expectedParentSnapshot: "",
+			expectedForceFull:      false,
+		},
+		{
+			name:                   "auto lets the data mover search for a parent",
+			parentSnapshot:         veleroshared.ParentSnapshotAuto,
+			expectedParentSnapshot: "",
+			expectedForceFull:      false,
+		},
+		{
+			name:                   "none forces a full backup",
+			parentSnapshot:         veleroshared.ParentSnapshotNone,
+			expectedParentSnapshot: "",
+			expectedForceFull:      true,
+		},
+		{
+			name:                   "a specific snapshot ID is passed through unchanged",
+			parentSnapshot:         "fake-parent-snapshot-id",
+			expectedParentSnapshot: "fake-parent-snapshot-id",
+			expectedForceFull:      false,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	velerov1api.AddToScheme(scheme)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pvbInProgress := builder.ForPodVolumeBackup(velerov1api.DefaultNamespace, pvbName).
+				Phase(velerov1api.PodVolumeBackupPhaseInProgress).
+				Result()
+			pvbInProgress.Spec.ParentSnapshot = test.parentSnapshot
+
+			fakeClient := clientFake.NewClientBuilder().WithScheme(scheme).
+				WithRuntimeObjects(pvbInProgress).Build()
+
+			bs := &BackupMicroService{
+				namespace:     velerov1api.DefaultNamespace,
+				pvbName:       pvbName,
+				ctx:           t.Context(),
+				client:        fakeClient,
+				dataPathMgr:   datapath.NewManager(1),
+				eventRecorder: &backupMsTestHelper{},
+				resultSignal:  make(chan dataPathResult),
+				logger:        velerotest.NewLogger(),
+			}
+
+			var startParam *datapath.BackupStartParam
+			datapath.VGDPCreator = func(string, string, kbclient.Client, string, datapath.Callbacks, logrus.FieldLogger) datapath.AsyncBR {
+				fsBR := datapathmockes.NewAsyncBR(t)
+				fsBR.On("Init", mock.Anything, mock.Anything).Return(nil)
+				fsBR.On("StartBackup", mock.Anything, mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						startParam = args.Get(2).(*datapath.BackupStartParam)
+					}).Return(nil)
+				return fsBR
+			}
+
+			go func() {
+				time.Sleep(time.Millisecond * 500)
+				bs.resultSignal <- dataPathResult{result: "fake-succeed-result"}
+			}()
+
+			_, err := bs.RunCancelableDataPath(t.Context())
+			require.NoError(t, err)
+
+			require.NotNil(t, startParam)
+			assert.Equal(t, test.expectedParentSnapshot, startParam.ParentSnapshot)
+			assert.Equal(t, test.expectedForceFull, startParam.ForceFull)
+		})
+	}
 }


### PR DESCRIPTION
# Please add a summary of your change

The `parentSnapshot` field on `DataUpload` and `PodVolumeBackup` documents three special values, but `"auto"` is not implemented anywhere. `ParentSnapshotAuto` (`pkg/apis/velero/shared/constants.go:21`) has zero references — `grep -rn ParentSnapshotAuto` returns only the declaration.

Both micro services special-case `"none"` and nothing else:

```go
parentSnapshot := du.Spec.ParentSnapshot
forceFull := false
if du.Spec.ParentSnapshot == veleroshared.ParentSnapshotNone {
	parentSnapshot = ""
	forceFull = true
}
```

so `"auto"` is passed down as if it were a literal snapshot ID. `SnapshotSource` (`pkg/uploader/kopia/snapshot.go:247`) then takes the `parentSnapshot != ""` branch, `manifest.ID("auto")` fails to load, and it logs a warning and falls back to a full backup:

```go
mani, err := loadSnapshotFunc(ctx, rep, manifest.ID(parentSnapshot))
if err != nil {
	log.WithError(err).Warnf("Failed to load previous snapshot %v from kopia, fallback to full backup", parentSnapshot)
}
```

The documented value therefore produces the opposite of what it documents — a full backup instead of an incremental one — with nothing surfaced on the CR.

This maps `"auto"` to `""` alongside the existing `"none"` handling, so the documented contract holds. The `if` becomes a `switch` over the same value, which keeps the three cases visually parallel and makes it obvious that `"auto"` and `"none"` differ only in `ForceFull`:

```go
switch du.Spec.ParentSnapshot {
case veleroshared.ParentSnapshotNone:
	parentSnapshot = ""
	forceFull = true
case veleroshared.ParentSnapshotAuto:
	parentSnapshot = ""
}
```

Applied identically in `pkg/datamover/backup_micro_service.go` and `pkg/podvolume/backup_micro_service.go`.

There was no test coverage for any of this. Both packages mocked `StartBackup` with `mock.Anything` for every argument, so even the existing `"none"` translation was unasserted. The new table tests capture the real `BackupStartParam` via testify's `Run` hook and assert `ParentSnapshot` and `ForceFull` for all four inputs — `""`, `"auto"`, `"none"`, and a literal snapshot ID — so the whole documented contract is pinned rather than just the new value.

The tests fail on `main` only for the `auto` case, which confirms they target the bug and that the change leaves the other three behaviours untouched:

```
--- FAIL: TestRunCancelableDataPathParentSnapshot/auto_lets_the_data_mover_search_for_a_parent
    expected: ""
    actual  : "auto"
```

@Lyndon-Li — this is option 1 from the issue. As I said there, I am equally happy to do the opposite and strip `"auto"` from the constant and the doc comments on both API types if you would rather not carry the behaviour; the code is here so there is something concrete to react to, not to pre-empt that call. Since `PodVolumeBackup.spec.parentSnapshot` is new in #10185, it seemed worth settling before the field ships in a release.

# Does your change fix a particular issue?

Fixes #10351

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
