### PR TITLE
Fix e2e kind matrix misparsing pre-release node tags

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -94,12 +94,14 @@ jobs:
         id: set-matrix
         # everything excluding older tags. limits needs to be high enough to cover all latest versions
         # and test labels
-        # grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" filters for v1.25 to v9.99
+        # grep -E "^v[1-9]\.(2[5-9]|[3-9][0-9])\.[0-9]+$" filters for well-formed v1.25.x to v9.99.x
+        # GA releases only, so a pre-release tag like v1.37.0-rc.1 can't reach the
+        # awk step below and be misparsed as a patch release (e.g. "1.37.1")
         # and removes older patches of the same minor version
         # awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}'
         run: |
           echo "matrix={\
-            \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
+            \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -E "^v[1-9]\.(2[5-9]|[3-9][0-9])\.[0-9]+$" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
             \"labels\":[\
               \"Basic && (ClusterResource || NodePort || StorageClass)\", \
               \"ResourceFiltering && !FSBackup\", \

--- a/changelogs/unreleased/10359-lubronzhan
+++ b/changelogs/unreleased/10359-lubronzhan
@@ -1,0 +1,1 @@
+Fix e2e kind test matrix generation misparsing kindest/node pre-release tags (e.g. v1.37.0-rc.1) as bogus patch versions


### PR DESCRIPTION
## Summary
- The `setup-test-matrix` step in `.github/workflows/e2e-test-kind.yaml` builds the e2e version matrix from the `kindest/node` Docker Hub tags, filtering out `alpha|beta` pre-release tags but not `rc` ones.
- A tag like `v1.37.0-rc.1` slips past that filter into the `awk -F.` field-splitter, which only knows about literal `.` separators: splitting `v1.37.0-rc.1` gives `["v1","37","0-rc","1"]`, and the script's `$1"."$2"."$NF` then prints `v1.37.1` — a version that was never published, since the real (and only) 1.37 tag is the release candidate.
- This caused spurious `run-e2e-test (1.37.1, ...)` failures (`manifest for kindest/node:v1.37.1 not found`) on unrelated PRs, e.g. #10329.
- Fix: replace the two greps with one anchored pattern, `^v[1-9]\.(2[5-9]|[3-9][0-9])\.[0-9]+$`, that only matches well-formed `vX.Y.Z` tags — any hyphenated pre-release suffix (`rc`, `alpha`, `beta`, or otherwise) is excluded before it can reach the `awk` step.

Fixes #10358

## Test plan
- [x] Ran the fixed shell pipeline locally against the live Docker Hub tags API — confirms `v1.37.0-rc.1` is now excluded and the rest of the version list (1.25–1.36) is unchanged.
- [ ] CI (this is a workflow-only change; the next e2e run on this PR exercises the fixed matrix generation)

AI-Tool-Used: Claude Code
AI-Tool-Use-Level: Category 2 (Medium)
AI-Code-Category: Category 2 (Non-Production)
