### PR TITLE
stop routing credential selection on AZURE_USERNAME after username/password removal

### DIFF
--- a/changelogs/unreleased/10363-samay43
+++ b/changelogs/unreleased/10363-samay43
@@ -1,0 +1,1 @@
+stop routing credential selection on AZURE_USERNAME after username/password removal

--- a/pkg/util/azure/credential.go
+++ b/pkg/util/azure/credential.go
@@ -37,8 +37,7 @@ func NewCredential(creds map[string]string, options policy.ClientOptions) (azcor
 	// config credential
 	if len(creds[CredentialKeyClientSecret]) > 0 ||
 		len(creds[CredentialKeyClientCertificate]) > 0 ||
-		len(creds[CredentialKeyClientCertificatePath]) > 0 ||
-		len(creds[CredentialKeyUsername]) > 0 {
+		len(creds[CredentialKeyClientCertificatePath]) > 0 {
 		return newConfigCredential(creds, configCredentialOptions{
 			ClientOptions:              options,
 			AdditionallyAllowedTenants: additionalTenants,

--- a/pkg/util/azure/credential_test.go
+++ b/pkg/util/azure/credential_test.go
@@ -69,6 +69,28 @@ func TestNewCredential(t *testing.T) {
 	assert.IsType(t, &azidentity.WorkloadIdentityCredential{}, tokenCredential)
 	os.Clearenv()
 
+	// a leftover AZURE_USERNAME must not hijack credential selection. Username/password
+	// handling was removed from newConfigCredential in #9041, so routing on it sends the
+	// caller into a function that cannot serve it and short-circuits the workload
+	// identity and managed identity branches below.
+	os.Setenv(CredentialKeyTenantID, "tenantid")
+	os.Setenv(CredentialKeyClientID, "clientid")
+	os.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/token")
+	creds = map[string]string{CredentialKeyUsername: "username"}
+	tokenCredential, err = NewCredential(creds, options)
+	require.NoError(t, err)
+	assert.IsType(t, &azidentity.WorkloadIdentityCredential{}, tokenCredential)
+	os.Clearenv()
+
+	// ... and must not short-circuit managed identity either
+	creds = map[string]string{
+		CredentialKeyClientID: "clientid",
+		CredentialKeyUsername: "username",
+	}
+	tokenCredential, err = NewCredential(creds, options)
+	require.NoError(t, err)
+	assert.IsType(t, &azidentity.ManagedIdentityCredential{}, tokenCredential)
+
 	// managed identity credential
 	creds = map[string]string{CredentialKeyClientID: "clientid"}
 	tokenCredential, err = NewCredential(creds, options)


### PR DESCRIPTION
# Please add a summary of your change

#9041 removed username/password handling from `newConfigCredential` because `azidentity.UsernamePasswordCredential` is deprecated. That removal deleted the handler but left `CredentialKeyUsername` in the dispatch condition in `NewCredential`:

```go
// config credential
if len(creds[CredentialKeyClientSecret]) > 0 ||
	len(creds[CredentialKeyClientCertificate]) > 0 ||
	len(creds[CredentialKeyClientCertificatePath]) > 0 ||
	len(creds[CredentialKeyUsername]) > 0 {        // still routes on username
	return newConfigCredential(creds, ...)
}

// workload identity credential
if len(os.Getenv("AZURE_FEDERATED_TOKEN_FILE")) > 0 { ... }

// managed identity credential
```

The config-credential branch is evaluated first and returns unconditionally, so an `AZURE_USERNAME` left in the credentials secret routes into a function that can no longer serve it. `newConfigCredential` matches neither the client-secret nor the certificate branch and falls through to:

```go
return nil, errors.New("incomplete credential configuration. Only AZURE_TENANT_ID and AZURE_CLIENT_ID are set")
```

So workload identity and managed identity are never reached, and the user is told that only tenant and client ID are set — which is not true, and points them away from the cause.

The likely person to hit this is someone #9041 moved off username/password auth who still has the key in their secret; nothing prompted them to remove it.

This drops `CredentialKeyUsername` from the dispatch condition so username no longer selects a credential type that cannot be constructed. Callers with a client secret or certificate are unaffected — those conditions are unchanged. A username-only configuration now falls through to workload identity and managed identity instead of erroring, which is the behaviour #9041 implies.

In-tree callers are `pkg/util/azure/storage.go:115` and `:258`, so this covers Azure BSL and repository credential resolution. `velero-plugin-for-microsoft-azure` also calls `NewCredential`, so it picks the fix up too.

Two regression cases extend the existing `TestNewCredential` rather than adding a new test. Both assert the credential **type** returned, so they prove the correct branch ran rather than merely that the call succeeded — one for the workload-identity path and one for managed identity, since the early `return` breaks both. They fail on `main`:

```
--- FAIL: TestNewCredential
    Error Trace: pkg/util/azure/credential_test.go:81
```

## Two things I have deliberately left alone — your call

**1. `CredentialKeyUsername` and `CredentialKeyPassword` are now dead.**
After this change `CredentialKeyPassword` has no references at all, and `CredentialKeyUsername` is referenced only by the new test. Both are exported from `pkg/util/azure`, so removing them is an API change for anything importing the package. For what it is worth, a code search over `velero-plugin-for-microsoft-azure` shows it imports `pkg/util/azure` (`object_store.go`, `volume_snapshotter.go`) and uses `NewCredential`, but does not reference either constant — so that plugin at least would not break. I did not want to widen a one-line bugfix into an exported-API change on the back of a code search, so I have left them in place. Happy to remove one or both here, or in a follow-up PR, whichever you prefer.

**2. The error message at `credential.go:115` now looks unreachable.**
With username gone from the dispatch, every remaining condition (`ClientSecret`, `ClientCertificate`, `ClientCertificatePath`) maps to a branch that `newConfigCredential` handles and returns from, and `newConfigCredential` has no other callers. So the `"incomplete credential configuration..."` fallback should no longer be reachable. It may still be worth keeping as a defensive fallback, or worth rewording to name what is actually missing, or worth deleting — but that is a judgement call about the function's contract rather than part of this bug, so I have not touched it. Tell me which you would like and I will fold it in.

# Does your change fix a particular issue?

None filed — this is a follow-up to #9041, which introduced it.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
