### PR TITLE
fix: scope deleteOrphanedBackups to controller namespace and fix logger accumulation

### DIFF
--- a/changelogs/unreleased/10364-AftAb-25
+++ b/changelogs/unreleased/10364-AftAb-25
@@ -1,0 +1,1 @@
+Fixed a bug where deleteOrphanedBackups could incorrectly delete backups from other namespaces when multiple Velero instances share the same backup storage location name.

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -145,7 +145,7 @@ func (b *backupSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// sync each backup
 	for backupName := range backupsToSync {
-		log = log.WithField("backup", backupName)
+		log := log.WithField("backup", backupName)
 		log.Info("Attempting to sync backup into cluster")
 
 		exist, err := backupStore.BackupExists(location.Spec.ObjectStorage.Bucket, backupName)
@@ -338,6 +338,7 @@ func (b *backupSyncReconciler) deleteOrphanedBackups(ctx context.Context, locati
 		LabelSelector: labels.Set(map[string]string{
 			velerov1api.StorageLocationLabel: label.GetValidName(locationName),
 		}).AsSelector(),
+		Namespace: b.namespace,
 	}
 	err := b.client.List(ctx, &backupList, &listOption)
 	if err != nil {
@@ -350,7 +351,7 @@ func (b *backupSyncReconciler) deleteOrphanedBackups(ctx context.Context, locati
 	}
 
 	for i, backup := range backupList.Items {
-		log = log.WithField("backup", backup.Name)
+		log := log.WithField("backup", backup.Name)
 		if !(backup.Status.Phase == velerov1api.BackupPhaseCompleted || backup.Status.Phase == velerov1api.BackupPhasePartiallyFailed) || backupStoreBackups.Has(backup.Name) {
 			continue
 		}

--- a/pkg/controller/backup_sync_controller_test.go
+++ b/pkg/controller/backup_sync_controller_test.go
@@ -19,10 +19,13 @@ package controller
 import (
 	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1137,3 +1140,75 @@ var _ = Describe("Backup Sync Reconciler", func() {
 		Expect(references[0].UID).To(Equal(scheduleUID))
 	})
 })
+
+// TestDeleteOrphanedBackupsNamespaceScope is a regression test for
+// https://github.com/velero-io/velero/issues/10364.
+//
+// Before the fix, deleteOrphanedBackups listed Backup CRs cluster-wide because
+// Namespace was missing from the ListOptions. In clusters with multiple Velero
+// instances sharing the same BSL name, the controller in namespace A could
+// treat backups from namespace B as orphans and delete them.
+func TestDeleteOrphanedBackupsNamespaceScope(t *testing.T) {
+	ctx := context.Background()
+
+	controllerNamespace := "velero-prod"
+	otherNamespace := "velero-test"
+	bslName := "default"
+
+	fakeClient := velerotest.NewFakeControllerRuntimeClient(t)
+
+	r := backupSyncReconciler{
+		client:                  fakeClient,
+		namespace:               controllerNamespace,
+		defaultBackupSyncPeriod: time.Second * 10,
+		newPluginManager:        func(logrus.FieldLogger) clientmgmt.Manager { return &pluginmocks.Manager{} },
+		backupStoreGetter:       NewFakeObjectBackupStoreGetter(make(map[string]*persistencemocks.BackupStore)),
+		logger:                  velerotest.NewLogger(),
+	}
+
+	storageLocationLabel := label.GetValidName(bslName)
+
+	// A completed backup in the controller's namespace that IS in the object store — must be preserved.
+	backupInStore := builder.ForBackup(controllerNamespace, "backup-in-store").
+		ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, storageLocationLabel)).
+		Phase(velerov1api.BackupPhaseCompleted).
+		Result()
+
+	// A completed backup in the controller's namespace that is NOT in the object store — must be deleted.
+	orphanedBackup := builder.ForBackup(controllerNamespace, "orphaned-backup").
+		ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, storageLocationLabel)).
+		Phase(velerov1api.BackupPhaseCompleted).
+		Result()
+
+	// A completed backup in a DIFFERENT namespace with the same BSL label.
+	// Before the fix this would be incorrectly treated as an orphan and deleted.
+	otherNsBackup := builder.ForBackup(otherNamespace, "other-ns-backup").
+		ObjectMeta(builder.WithLabels(velerov1api.StorageLocationLabel, storageLocationLabel)).
+		Phase(velerov1api.BackupPhaseCompleted).
+		Result()
+
+	for _, b := range []*velerov1api.Backup{backupInStore, orphanedBackup, otherNsBackup} {
+		require.NoError(t, fakeClient.Create(ctx, b))
+	}
+
+	// The object store only contains "backup-in-store".
+	cloudBackups := sets.New[string]("backup-in-store")
+	r.deleteOrphanedBackups(ctx, bslName, cloudBackups, velerotest.NewLogger())
+
+	// "backup-in-store" must still exist in the controller namespace.
+	surviving := &velerov1api.Backup{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Namespace: controllerNamespace, Name: "backup-in-store"}, surviving))
+
+	// "orphaned-backup" must have been deleted from the controller namespace.
+	deleted := &velerov1api.Backup{}
+	err := fakeClient.Get(ctx, types.NamespacedName{Namespace: controllerNamespace, Name: "orphaned-backup"}, deleted)
+	assert.True(t, apierrors.IsNotFound(err), "orphaned backup in the controller namespace should have been deleted")
+
+	// "other-ns-backup" must NOT have been deleted — this is the core of the fix.
+	otherSurviving := &velerov1api.Backup{}
+	assert.NoError(
+		t,
+		fakeClient.Get(ctx, types.NamespacedName{Namespace: otherNamespace, Name: "other-ns-backup"}, otherSurviving),
+		"backup from another namespace must not be deleted by deleteOrphanedBackups",
+	)
+}

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -641,28 +641,38 @@ func (r *DataUploadReconciler) OnDataUploadProgress(ctx context.Context, namespa
 	}
 }
 
+func duGenericEventPredicate(object client.Object) bool {
+	du, ok := object.(*velerov2alpha1api.DataUpload)
+	if !ok {
+		return false
+	}
+
+	if du.Status.Phase == velerov2alpha1api.DataUploadPhaseAccepted {
+		return true
+	}
+
+	if du.Status.Phase == velerov2alpha1api.DataUploadPhasePrepared {
+		return true
+	}
+
+	if du.Spec.Cancel && !isDataUploadInFinalState(du) {
+		return true
+	}
+
+	if isDataUploadInFinalState(du) && !du.DeletionTimestamp.IsZero() {
+		return true
+	}
+
+	return false
+}
+
 // SetupWithManager registers the DataUpload controller.
 // The fresh new DataUpload CR first created will trigger to create one pod (long time, maybe failure or unknown status) by one of the dataupload controllers
 // then the request will get out of the Reconcile queue immediately by not blocking others' CR handling, in order to finish the rest data upload process we need to
 // re-enqueue the previous related request once the related pod is in running status to keep going on the rest logic. and below logic will avoid handling the unwanted
 // pod status and also avoid block others CR handling
 func (r *DataUploadReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	gp := kube.NewGenericEventPredicate(func(object client.Object) bool {
-		du := object.(*velerov2alpha1api.DataUpload)
-		if du.Status.Phase == velerov2alpha1api.DataUploadPhaseAccepted {
-			return true
-		}
-
-		if du.Spec.Cancel && !isDataUploadInFinalState(du) {
-			return true
-		}
-
-		if isDataUploadInFinalState(du) && !du.DeletionTimestamp.IsZero() {
-			return true
-		}
-
-		return false
-	})
+	gp := kube.NewGenericEventPredicate(duGenericEventPredicate)
 	s := kube.NewPeriodicalEnqueueSource(r.logger.WithField("controller", constant.ControllerDataUpload), r.client, &velerov2alpha1api.DataUploadList{}, preparingMonitorFrequency, kube.PeriodicalEnqueueSourceOption{
 		Predicates: []predicate.Predicate{gp},
 	})

--- a/pkg/controller/data_upload_controller_test.go
+++ b/pkg/controller/data_upload_controller_test.go
@@ -1615,3 +1615,84 @@ func TestDataUploadCancelConcurrency(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, firstTime, v.(time.Time), "The initially recorded timestamp should be preserved")
 }
+
+func TestDUGenericEventPredicate(t *testing.T) {
+	tests := []struct {
+		name     string
+		object   kbclient.Object
+		expected bool
+	}{
+		{
+			name:     "invalid object type",
+			object:   &corev1api.Pod{},
+			expected: false,
+		},
+		{
+			name: "accepted phase",
+			object: &velerov2alpha1api.DataUpload{
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhaseAccepted,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "prepared phase",
+			object: &velerov2alpha1api.DataUpload{
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhasePrepared,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "in progress phase not canceled",
+			object: &velerov2alpha1api.DataUpload{
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhaseInProgress,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "canceled and not in final state",
+			object: &velerov2alpha1api.DataUpload{
+				Spec: velerov2alpha1api.DataUploadSpec{
+					Cancel: true,
+				},
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhaseInProgress,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "completed with deletion timestamp",
+			object: &velerov2alpha1api.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhaseCompleted,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "completed without deletion timestamp",
+			object: &velerov2alpha1api.DataUpload{
+				Status: velerov2alpha1api.DataUploadStatus{
+					Phase: velerov2alpha1api.DataUploadPhaseCompleted,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := duGenericEventPredicate(tt.object)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION


## Summary
This PR fixes a potentially dangerous bug in `deleteOrphanedBackups` where it was missing the `Namespace` filter in its `ListOptions`. 

Before this change, `deleteOrphanedBackups` would list `Backup` CRs across the entire cluster. If multiple Velero instances run in different namespaces but use a BackupStorageLocation with the same name (like `default`), the sync controller in one namespace could mistakenly see backups from the other namespace as "orphaned" and delete them. This PR adds `Namespace: b.namespace` to the `ListOptions` so it's scoped correctly, matching the behavior of the main `Reconcile` loop.

Additionally, this fixes a minor logger bug in the same file. In both the `backupsToSync` loop and the `backupList` loop, the code was doing `log = log.WithField("backup", ...)` instead of `log := ...`. Because `WithField` extends the logger, this caused the logger to accumulate fields across loop iterations. I changed these to shadow the variable (`log := log.WithField(...)`) so each iteration gets a clean, scoped logger.

## Fixed

Fixes #10364

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
