### PR TITLE
test: implement missing e2e test case for additional BSL deletion

### DIFF
--- a/changelogs/unreleased/10368-opbot-xd
+++ b/changelogs/unreleased/10368-opbot-xd
@@ -1,0 +1,1 @@
+test: implement missing e2e test case for additional BSL deletion

--- a/test/e2e/bsl-mgmt/deletion.go
+++ b/test/e2e/bsl-mgmt/deletion.go
@@ -335,12 +335,22 @@ func BslDeletionTest(useVolumeSnapshots bool) {
 					backupName1, BackupObjectsPrefix)).To(Succeed())
 			})
 
-			// TODO: Choose additional BSL to be deleted as an new test case
-			// By(fmt.Sprintf("Backup %s should still exist in cloud object store", backupName_2), func() {
-			// 	Expect(ObjectsShouldBeInBucket(veleroCfg.ObjectStoreProvider, veleroCfg.AdditionalBSLCredentials,
-			// 		veleroCfg.AdditionalBSLBucket, veleroCfg.AdditionalBSLPrefix, veleroCfg.AdditionalBSLConfig,
-			// 		backupName_2, BackupObjectsPrefix)).To(Succeed())
-			// })
+			By(fmt.Sprintf("Delete the additional backup location - %s", backupLocation2), func() {
+				Expect(DeleteBslResource(context.Background(), veleroCfg.VeleroCLI, backupLocation2)).To(Succeed())
+				Expect(WaitForBackupsToBeDeleted(context.Background(), backupsInBSL2, 10*time.Minute, &veleroCfg)).To(Succeed())
+			})
+
+			By("Get all backups from 2 BSLs after deleting both of them", func() {
+				backupsAfterDel, err := GetAllBackups(context.Background(), veleroCfg.VeleroCLI)
+				Expect(err).To(Succeed())
+				Expect(backupsAfterDel).Should(BeEmpty())
+			})
+
+			By(fmt.Sprintf("Backup %s should still exist in cloud object store after additional bsl deletion", backupName2), func() {
+				Expect(ObjectsShouldBeInBucket(veleroCfg.ObjectStoreProvider, veleroCfg.AdditionalBSLCredentials,
+					veleroCfg.AdditionalBSLBucket, veleroCfg.AdditionalBSLPrefix, veleroCfg.AdditionalBSLConfig,
+					backupName2, BackupObjectsPrefix)).To(Succeed())
+			})
 
 			if useVolumeSnapshots {
 				if veleroCfg.HasVspherePlugin {
@@ -398,9 +408,9 @@ func BslDeletionTest(useVolumeSnapshots bool) {
 					Expect(BackupRepositoriesCountShouldBe(context.Background(),
 						veleroCfg.VeleroNamespace, bslDeletionTestNs+"-"+backupLocation1, 0)).To(Succeed())
 				})
-				By(fmt.Sprintf("BackupRepositories for BSL %s should still exist in Velero namespace", backupLocation2), func() {
+				By(fmt.Sprintf("BackupRepositories for BSL %s should be deleted in Velero namespace", backupLocation2), func() {
 					Expect(BackupRepositoriesCountShouldBe(context.Background(),
-						veleroCfg.VeleroNamespace, bslDeletionTestNs+"-"+backupLocation2, 1)).To(Succeed())
+						veleroCfg.VeleroNamespace, bslDeletionTestNs+"-"+backupLocation2, 0)).To(Succeed())
 				})
 			}
 			fmt.Printf("|| EXPECTED || - Backup deletion test completed successfully\n")


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

This PR implements the missing e2e test case for verifying that Backup Storage Location (BSL) deletion works correctly for secondary/additional BSLs, closing the outstanding `TODO` in `test/e2e/bsl-mgmt/deletion.go`.

**Specifically, this PR introduces the following changes:**
1. **Implemented secondary BSL teardown:** Added the step to use `DeleteBslResource` and `WaitForBackupsToBeDeleted` to safely delete the secondary `backupLocation2`.
2. **Updated API assertions:** Validates that after both the primary and additional BSLs have been deleted, the Velero API accurately reflects that `0` backups remain in the cluster (`Expect(backupsAfterDel).Should(BeEmpty())`).
3. **Restored cloud data validation:** Fixed a variable name typo (`backupName_2` -> `backupName2`) and uncommented the `ObjectsShouldBeInBucket` assertion to confirm that backups in the secondary object store remain untouched after the cluster BSL object is deleted.
4. **Refined resource cleanup check:** Modified the dangling `BackupRepositories` test assertion at the end of the run to check for `0` instead of `1`, as the secondary BSL is now properly destroyed during the test loop.

# Does your change fix a particular issue?

Fixes #10367

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
