### PR TITLE
fix log format string mismatches that produce wrong or mangled output

### DIFF
--- a/changelogs/unreleased/10370-samay43
+++ b/changelogs/unreleased/10370-samay43
@@ -1,0 +1,1 @@
+fix log format string mismatches that produce wrong or mangled output

--- a/internal/hook/item_hook_handler.go
+++ b/internal/hook/item_hook_handler.go
@@ -419,7 +419,7 @@ func getInitContainerFromAnnotation(podName string, annotations map[string]strin
 		return nil
 	}
 	if command == "" {
-		log.Infof("RestoreHook init container for pod %s is using container's default entrypoint", podName, containerImage)
+		log.Infof("RestoreHook init container for pod %s is using the default entrypoint of image %s", podName, containerImage)
 	}
 	if containerName == "" {
 		uid, err := uuid.NewRandom()

--- a/internal/volume/volumes_information.go
+++ b/internal/volume/volumes_information.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/features"
 	"github.com/vmware-tanzu/velero/pkg/itemoperation"
 	"github.com/vmware-tanzu/velero/pkg/kuberesource"
+	"github.com/vmware-tanzu/velero/pkg/util/stringptr"
 )
 
 type Method string
@@ -494,7 +495,8 @@ func (v *BackupVolumesInformation) generateVolumeInfoForCSIVolumeSnapshot() {
 
 			tmpVolumeInfos = append(tmpVolumeInfos, volumeInfo)
 		} else {
-			v.logger.Warnf("cannot find info for PVC %s/%s", volumeSnapshot.Namespace, volumeSnapshot.Spec.Source.PersistentVolumeClaimName)
+			v.logger.Warnf("cannot find info for PVC %s/%s", volumeSnapshot.Namespace,
+				stringptr.GetString(volumeSnapshot.Spec.Source.PersistentVolumeClaimName))
 			continue
 		}
 	}

--- a/pkg/backup/actions/csi/pvc_action.go
+++ b/pkg/backup/actions/csi/pvc_action.go
@@ -1234,7 +1234,7 @@ func setPVCRequestSizeToVSRestoreSize(
 	logger logrus.FieldLogger,
 ) {
 	if vsc.Status.RestoreSize != nil {
-		logger.Debugf("Patching PVC request size to fit the volumesnapshot restore size %d", vsc.Status.RestoreSize)
+		logger.Debugf("Patching PVC request size to fit the volumesnapshot restore size %d", *vsc.Status.RestoreSize)
 		restoreSize := *resource.NewQuantity(*vsc.Status.RestoreSize, resource.BinarySI)
 
 		// It is possible that the volume provider allocated a larger

--- a/pkg/backup/actions/csi/volumesnapshot_action.go
+++ b/pkg/backup/actions/csi/volumesnapshot_action.go
@@ -269,8 +269,8 @@ func (p *volumeSnapshotBackupItemAction) Progress(
 	}
 	var err error
 	if progress.Started, err = time.Parse(time.RFC3339, operationIDParts[2]); err != nil {
-		p.log.Errorf("error parsing operation ID's StartedTime",
-			"part into time %s: %s", operationID, err.Error())
+		p.log.Errorf("error parsing operation ID's StartedTime part into time %s: %s",
+			operationID, err.Error())
 		return progress, errors.WithStack(err)
 	}
 

--- a/pkg/backup/actions/csi/volumesnapshotcontent_action.go
+++ b/pkg/backup/actions/csi/volumesnapshotcontent_action.go
@@ -107,8 +107,7 @@ func (p *volumeSnapshotContentBackupItemAction) Execute(
 	}
 
 	p.log.Infof(
-		"Returning from VolumeSnapshotContentBackupItemAction",
-		"with %d additionalItems to backup",
+		"Returning from VolumeSnapshotContentBackupItemAction with %d additionalItems to backup",
 		len(additionalItems),
 	)
 	return &unstructured.Unstructured{Object: snapContMap}, additionalItems, "", nil, nil

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -2843,7 +2843,7 @@ func (ctx *restoreContext) getSelectedRestoreableItems(resource string, original
 				}
 
 				if skipItem {
-					ctx.log.Infof("restore orSelector labels did not match, skipping restore of item: %s", skipItem, item)
+					ctx.log.Infof("restore orSelector labels did not match, skipping restore of item: %s", item)
 					continue
 				}
 			}


### PR DESCRIPTION
Fixes #10369

Six log statements pass arguments that do not match their format string. They
compile and run, but emit wrong or mangled text at exactly the moment someone is
reading logs to debug a failure.

This is a logging-correctness change only. No control flow, no behaviour, no API.

### A bool printed where the item name belongs

`pkg/restore/restore.go:2846`

```go
ctx.log.Infof("restore orSelector labels did not match, skipping restore of item: %s", skipItem, item)
```

`skipItem` is a `bool` and `item` is the name, so the operator sees
`skipping restore of item: %!s(bool=true)%!(EXTRA string=<item>)`. The one detail
the line exists to report is the one it drops.

Six lines earlier, at `:2840`, the same log is already written correctly:

```go
ctx.log.Infof("setting skip flag to true for item: %s", item)
```

Same function, same variable in scope — this is a slip, not a convention.

### A pointer address printed for the PVC name

`internal/volume/volumes_information.go:497`

`Spec.Source.PersistentVolumeClaimName` is a `*string`, so `%s` rendered
`0xc000...`. The warning whose whole purpose is to name the missing PVC never
named it. Fixed with `stringptr.GetString`, the helper this repo already uses for
exactly this in `pkg/util/csi/volume_snapshot.go`.

### Two format strings accidentally split into separate arguments

`pkg/backup/actions/csi/volumesnapshot_action.go:272` and
`pkg/backup/actions/csi/volumesnapshotcontent_action.go:109`

```go
p.log.Errorf("error parsing operation ID's StartedTime",
	"part into time %s: %s", operationID, err.Error())
```

Only the first literal is the format string, so the operation ID and the parse
error are appended as `%!(EXTRA ...)` instead of being interpolated.

### One extra argument with no verb

`internal/hook/item_hook_handler.go:422` passed `containerImage` to a format
string with a single verb. Rather than drop the argument I gave it a verb, since
the image is useful there and was clearly meant to be logged.

### One that no linter can catch

`pkg/backup/actions/csi/pvc_action.go:1237`

```go
logger.Debugf("Patching PVC request size to fit the volumesnapshot restore size %d", vsc.Status.RestoreSize)
```

`RestoreSize` is `*int64`. `fmt` explicitly permits `%d` on a pointer and formats
the *address* as an integer, so this is legal and silently wrong. The very next
line dereferences the same field correctly.

Confirmed rather than assumed:

```
with pointer: 14174496702768
dereferenced: 1073741824
```

## Reproducer

```
go vet -printf.funcs=Debugf,Infof,Warnf,Errorf,Tracef,Panicf,Fatalf,Logf ./pkg/... ./internal/...
```

On `main` this reports five of the six:

```
internal/hook/item_hook_handler.go:422:3: Infof call needs 1 arg but has 2 args
internal/volume/volumes_information.go:497:48: Warnf format %s has arg volumeSnapshot.Spec.Source.PersistentVolumeClaimName of wrong type *string
pkg/backup/actions/csi/volumesnapshot_action.go:273:4: Errorf call has arguments but no formatting directives
pkg/backup/actions/csi/volumesnapshotcontent_action.go:111:3: Infof call has arguments but no formatting directives
pkg/restore/restore.go:2846:88: Infof format %s has arg skipItem of wrong type bool
```

With this PR applied it reports none. The sixth (`pvc_action.go`) is legal `fmt`,
so it has to be read rather than detected.

The pre-existing `non-constant format string` findings in `pkg/util/kube` and
`pkg/datamover` are untouched and out of scope here.

## Scope

Deliberately not included: wiring this check into CI. It needs either `printf`
added to the `hack/test.sh` vet allow-list or `govet` enabled in
`.golangci.yaml`, and in both cases the logrus method names have to be registered
via `-printf.funcs` or it finds nothing. That is a shared-config decision and the
pre-existing findings above would have to be resolved first, so I left it as an
open question on #10369 rather than bundling it here.

## Testing

```
go build ./...
go test -vet="atomic,bool,buildtags,directive,errorsas,ifaceassert,nilfunc,stringintconv,tests" \
  ./pkg/restore/... ./internal/volume/... ./internal/hook/... ./pkg/backup/actions/csi/...
```

All green. No test changes: these are log-message defects with no observable
behaviour to assert, and adding assertions on log text would couple tests to
wording.
