### PR TITLE
prevent panic when the restore hook init container command annotation is empty

### DIFF
--- a/changelogs/unreleased/10371-samay43
+++ b/changelogs/unreleased/10371-samay43
@@ -1,0 +1,1 @@
+prevent panic when the restore hook init container command annotation is empty

--- a/internal/hook/item_hook_handler.go
+++ b/internal/hook/item_hook_handler.go
@@ -365,6 +365,12 @@ func getPodExecHookFromAnnotations(annotations map[string]string, phase HookPhas
 
 func parseStringToCommand(commandValue string) []string {
 	var command []string
+	// An empty command means the container image's own entrypoint should be used.
+	// Callers that require a command already return early; getInitContainerFromAnnotation
+	// deliberately allows this case, so return nil rather than indexing an empty string.
+	if commandValue == "" {
+		return nil
+	}
 	// check for json array
 	if commandValue[0] == '[' {
 		if err := json.Unmarshal([]byte(commandValue), &command); err != nil {

--- a/internal/hook/item_hook_handler_test.go
+++ b/internal/hook/item_hook_handler_test.go
@@ -1287,6 +1287,25 @@ func TestGetInitContainerFromAnnotations(t *testing.T) {
 				podRestoreHookInitContainerCommandAnnotationKey: "[foobarbaz",
 			},
 		},
+		{
+			name:      "should use the image's default entrypoint when the command annotation is empty",
+			expectNil: false,
+			expected:  builder.ForContainer("restore-init1", "busy-box").Result(),
+			inputAnnotations: map[string]string{
+				podRestoreHookInitContainerImageAnnotationKey:   "busy-box",
+				podRestoreHookInitContainerNameAnnotationKey:    "restore-init",
+				podRestoreHookInitContainerCommandAnnotationKey: "",
+			},
+		},
+		{
+			name:      "should use the image's default entrypoint when the command annotation is missing",
+			expectNil: false,
+			expected:  builder.ForContainer("restore-init1", "busy-box").Result(),
+			inputAnnotations: map[string]string{
+				podRestoreHookInitContainerImageAnnotationKey: "busy-box",
+				podRestoreHookInitContainerNameAnnotationKey:  "restore-init",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
`parseStringToCommand` indexes the first byte of its argument without checking
that the string is non-empty:

```go
func parseStringToCommand(commandValue string) []string {
	var command []string
	// check for json array
	if commandValue[0] == '[' {   // panics when commandValue is ""
```

`getInitContainerFromAnnotation` reaches it with an empty string. Annotate a pod
with `init.hook.restore.velero.io/container-image` and leave
`init.hook.restore.velero.io/command` empty or absent, and restoring that pod
panics:

```
panic: runtime error: index out of range [0] with length 0
	internal/hook.parseStringToCommand(...)          item_hook_handler.go:369
	internal/hook.getInitContainerFromAnnotation(...) item_hook_handler.go:439
```

## Why this is a bug rather than an unsupported input

The empty command is already treated as a *supported* case in the same function,
four lines before the crash:

```go
if command == "" {
	log.Infof("RestoreHook init container for pod %s is using container's default entrypoint", podName)
}
```

The code deliberately notes that the image's own entrypoint will be used, and
then hands that same empty string to a function that cannot accept it.

The other two callers of `parseStringToCommand` confirm this is the odd one out —
both return early rather than pass an empty command through:

- `getPodExecHookFromAnnotations` (`item_hook_handler.go:337`)
- `getPodExecRestoreHookFromAnnotations` (`item_hook_handler.go:481`)

So the empty case is only reachable from the one path that intends to allow it.

## Fix

Return `nil` from `parseStringToCommand` for an empty command. A container with no
`Command` set is how Kubernetes expresses "use the image's ENTRYPOINT", which is
exactly what the log message above already claims happens.

The guard is in `parseStringToCommand` rather than at the call site because that
is where the fragility is; the other two callers are unaffected either way.

## Testing

Two cases added to the existing `TestGetInitContainerFromAnnotations` table —
command annotation present but empty, and command annotation absent.

Both were verified to actually catch the panic rather than merely pass alongside
the fix. With the guard removed:

```
--- FAIL: TestGetInitContainerFromAnnotations/should_use_the_image's_default_entrypoint_when_the_command_annotation_is_empty
panic: runtime error: index out of range [0] with length 0
```

With it restored, the package is green. `parseStringToCommand` goes to 100%
statement coverage and `getInitContainerFromAnnotation` to 94.4%.

```
go test -vet="atomic,bool,buildtags,directive,errorsas,ifaceassert,nilfunc,stringintconv,tests" \
  ./internal/hook/... ./pkg/restore/...
```
