### PR TITLE
Show validation frequency in backup-location get output

### DIFF
--- a/changelogs/unreleased/10372-PranjalManhgaye
+++ b/changelogs/unreleased/10372-PranjalManhgaye
@@ -1,0 +1,1 @@
+Show validation frequency in `velero backup-location get` table output

--- a/pkg/cmd/cli/backuplocation/get.go
+++ b/pkg/cmd/cli/backuplocation/get.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
+	"github.com/vmware-tanzu/velero/pkg/cmd/util/serverconfig"
 )
 
 func NewGetCommand(f client.Factory, use string) *cobra.Command {
@@ -85,7 +86,12 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 				}
 			}
 
-			_, err = output.PrintWithFormat(c, locations)
+			kubeClient, err := f.KubeClient()
+			cmd.CheckError(err)
+
+			serverValidationFrequency := serverconfig.GetStoreValidationFrequency(context.Background(), kubeClient, f.Namespace())
+
+			_, err = output.PrintWithFormat(c, locations, output.WithServerValidationFrequency(serverValidationFrequency))
 			cmd.CheckError(err)
 		},
 	}

--- a/pkg/cmd/cli/backuplocation/get_test.go
+++ b/pkg/cmd/cli/backuplocation/get_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"k8s.io/client-go/kubernetes/fake"
 
 	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
 	cmdtest "github.com/vmware-tanzu/velero/pkg/cmd/test"
@@ -38,6 +39,7 @@ func TestNewGetCommand(t *testing.T) {
 	kbclient := velerotest.NewFakeControllerRuntimeClient(t)
 	f.On("Namespace").Return(mock.Anything)
 	f.On("KubebuilderClient").Return(kbclient, nil)
+	f.On("KubeClient").Return(fake.NewSimpleClientset(), nil)
 
 	// get command
 	c := NewGetCommand(f, "velero backup-location get")

--- a/pkg/cmd/util/output/backup_storage_location_printer.go
+++ b/pkg/cmd/util/output/backup_storage_location_printer.go
@@ -17,6 +17,8 @@ limitations under the License.
 package output
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -33,21 +35,22 @@ var (
 		{Name: "Bucket/Prefix"},
 		{Name: "Phase"},
 		{Name: "Last Validated"},
+		{Name: "Validation Frequency"},
 		{Name: "Access Mode"},
 		{Name: "Default"},
 	}
 )
 
-func printBackupStorageLocationList(list *velerov1api.BackupStorageLocationList) []metav1.TableRow {
+func printBackupStorageLocationList(list *velerov1api.BackupStorageLocationList, serverValidationFrequency time.Duration) []metav1.TableRow {
 	rows := make([]metav1.TableRow, 0, len(list.Items))
 
 	for i := range list.Items {
-		rows = append(rows, printBackupStorageLocation(&list.Items[i])...)
+		rows = append(rows, printBackupStorageLocation(&list.Items[i], serverValidationFrequency)...)
 	}
 	return rows
 }
 
-func printBackupStorageLocation(location *velerov1api.BackupStorageLocation) []metav1.TableRow {
+func printBackupStorageLocation(location *velerov1api.BackupStorageLocation, serverValidationFrequency time.Duration) []metav1.TableRow {
 	row := metav1.TableRow{
 		Object: runtime.RawExtension{Object: location},
 	}
@@ -84,9 +87,17 @@ func printBackupStorageLocation(location *velerov1api.BackupStorageLocation) []m
 		bucketAndPrefix,
 		status,
 		LastValidatedStr,
+		formatValidationFrequency(location.Spec.ValidationFrequency, serverValidationFrequency),
 		accessMode,
 		isDefault,
 	)
 
 	return []metav1.TableRow{row}
+}
+
+func formatValidationFrequency(freq *metav1.Duration, serverValidationFrequency time.Duration) string {
+	if freq == nil {
+		return serverValidationFrequency.String()
+	}
+	return freq.Duration.String()
 }

--- a/pkg/cmd/util/output/backup_storage_location_printer_test.go
+++ b/pkg/cmd/util/output/backup_storage_location_printer_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
+	"github.com/vmware-tanzu/velero/pkg/cmd"
+	"github.com/vmware-tanzu/velero/pkg/cmd/server/config"
+)
+
+func TestFormatValidationFrequency(t *testing.T) {
+	t.Parallel()
+
+	serverDefault := config.GetDefaultConfig().StoreValidationFrequency
+
+	assert.Equal(t, serverDefault.String(), formatValidationFrequency(nil, serverDefault))
+	assert.Equal(t, "0s", formatValidationFrequency(&metav1.Duration{Duration: 0}, serverDefault))
+	assert.Equal(t, "2m0s", formatValidationFrequency(&metav1.Duration{Duration: 2 * time.Minute}, serverDefault))
+	assert.Equal(t, "5m0s", formatValidationFrequency(nil, 5*time.Minute))
+}
+
+func TestPrintBackupStorageLocationValidationFrequencyColumn(t *testing.T) {
+	t.Parallel()
+
+	location := builder.ForBackupStorageLocation("velero", "default").
+		Provider("aws").
+		Bucket("my-bucket").
+		Default(true).
+		ValidationFrequency(5 * time.Minute).
+		Result()
+	location.Status.Phase = velerov1api.BackupStorageLocationPhaseAvailable
+
+	serverDefault := config.GetDefaultConfig().StoreValidationFrequency
+	rows := printBackupStorageLocation(location, serverDefault)
+	require.Len(t, rows, 1)
+	require.Len(t, rows[0].Cells, len(backupStorageLocationColumns))
+
+	assert.Equal(t, "5m0s", rows[0].Cells[5])
+	assert.Equal(t, cmd.TRUE, rows[0].Cells[7])
+}
+
+func TestPrintBackupStorageLocationValidationFrequencyDefault(t *testing.T) {
+	t.Parallel()
+
+	location := builder.ForBackupStorageLocation("velero", "secondary").
+		Provider("gcp").
+		Bucket("other-bucket").
+		Result()
+
+	serverDefault := 3 * time.Minute
+	rows := printBackupStorageLocation(location, serverDefault)
+	require.Len(t, rows, 1)
+
+	assert.Equal(t, "3m0s", rows[0].Cells[5])
+}

--- a/pkg/cmd/util/output/output.go
+++ b/pkg/cmd/util/output/output.go
@@ -30,9 +30,25 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/cmd/server/config"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
 	"github.com/vmware-tanzu/velero/pkg/util/encode"
 )
+
+type printConfig struct {
+	serverValidationFrequency time.Duration
+}
+
+// PrintOption configures table printing behavior.
+type PrintOption func(*printConfig)
+
+// WithServerValidationFrequency sets the Velero server store-validation-frequency
+// used when a BSL does not specify validationFrequency.
+func WithServerValidationFrequency(frequency time.Duration) PrintOption {
+	return func(cfg *printConfig) {
+		cfg.serverValidationFrequency = frequency
+	}
+}
 
 const (
 	downloadRequestTimeout = 30 * time.Second
@@ -110,15 +126,22 @@ func validateOutputFlag(cmd *cobra.Command) error {
 
 // PrintWithFormat prints the provided object in the format specified by
 // the command's flags.
-func PrintWithFormat(c *cobra.Command, obj runtime.Object) (bool, error) {
+func PrintWithFormat(c *cobra.Command, obj runtime.Object, opts ...PrintOption) (bool, error) {
 	format := GetOutputFlagValue(c)
 	if format == "" {
 		return false, nil
 	}
 
+	printCfg := printConfig{
+		serverValidationFrequency: config.GetDefaultConfig().StoreValidationFrequency,
+	}
+	for _, opt := range opts {
+		opt(&printCfg)
+	}
+
 	switch format {
 	case "table":
-		return printTable(c, obj)
+		return printTable(c, obj, printCfg)
 	case "json", "yaml":
 		return printEncoded(obj, format)
 	}
@@ -148,7 +171,7 @@ func printEncoded(obj runtime.Object, format string) (bool, error) {
 	return true, nil
 }
 
-func printTable(cmd *cobra.Command, obj runtime.Object) (bool, error) {
+func printTable(cmd *cobra.Command, obj runtime.Object, printCfg printConfig) (bool, error) {
 	// 1. generate table
 	var table *metav1.Table
 
@@ -196,12 +219,12 @@ func printTable(cmd *cobra.Command, obj runtime.Object) (bool, error) {
 	case *velerov1api.BackupStorageLocation:
 		table = &metav1.Table{
 			ColumnDefinitions: backupStorageLocationColumns,
-			Rows:              printBackupStorageLocation(objType),
+			Rows:              printBackupStorageLocation(objType, printCfg.serverValidationFrequency),
 		}
 	case *velerov1api.BackupStorageLocationList:
 		table = &metav1.Table{
 			ColumnDefinitions: backupStorageLocationColumns,
-			Rows:              printBackupStorageLocationList(objType),
+			Rows:              printBackupStorageLocationList(objType, printCfg.serverValidationFrequency),
 		}
 	case *velerov1api.VolumeSnapshotLocation:
 		table = &metav1.Table{

--- a/pkg/cmd/util/output/print_option_test.go
+++ b/pkg/cmd/util/output/print_option_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+)
+
+func TestPrintWithFormatBackupStorageLocationServerValidationFrequency(t *testing.T) {
+	t.Parallel()
+
+	cmd := cmdWithFormat("get", "table")
+	location := &velerov1api.BackupStorageLocation{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: velerov1api.BackupStorageLocationSpec{
+			Provider: "aws",
+			StorageType: velerov1api.StorageType{
+				ObjectStorage: &velerov1api.ObjectStorageLocation{
+					Bucket: "bucket",
+				},
+			},
+		},
+	}
+
+	printed, err := PrintWithFormat(cmd, location, WithServerValidationFrequency(5*time.Minute))
+	require.NoError(t, err)
+	assert.True(t, printed)
+}
+
+func TestPrintWithFormatBackupStorageLocationListServerValidationFrequency(t *testing.T) {
+	t.Parallel()
+
+	cmd := cmdWithFormat("get", "table")
+	list := &velerov1api.BackupStorageLocationList{
+		Items: []velerov1api.BackupStorageLocation{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec: velerov1api.BackupStorageLocationSpec{
+					Provider: "aws",
+					StorageType: velerov1api.StorageType{
+						ObjectStorage: &velerov1api.ObjectStorageLocation{
+							Bucket: "bucket",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	printed, err := PrintWithFormat(cmd, list, WithServerValidationFrequency(5*time.Minute))
+	require.NoError(t, err)
+	assert.True(t, printed)
+}

--- a/pkg/cmd/util/serverconfig/deployment.go
+++ b/pkg/cmd/util/serverconfig/deployment.go
@@ -39,6 +39,10 @@ var errVeleroDeploymentNotFound = errors.New("velero deployment not found")
 func GetStoreValidationFrequency(ctx context.Context, kubeClient kubernetes.Interface, namespace string) time.Duration {
 	defaultFrequency := config.GetDefaultConfig().StoreValidationFrequency
 
+	if kubeClient == nil {
+		return defaultFrequency
+	}
+
 	deployment, err := veleroDeployment(ctx, kubeClient, namespace)
 	if err != nil {
 		return defaultFrequency

--- a/pkg/cmd/util/serverconfig/deployment.go
+++ b/pkg/cmd/util/serverconfig/deployment.go
@@ -1,0 +1,111 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serverconfig
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/spf13/pflag"
+	appsv1api "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/vmware-tanzu/velero/pkg/cmd/server/config"
+	"github.com/vmware-tanzu/velero/pkg/install"
+)
+
+var errVeleroDeploymentNotFound = errors.New("velero deployment not found")
+
+// GetStoreValidationFrequency returns the Velero server's store-validation-frequency.
+// When the BSL spec does not set validationFrequency, the server uses this value.
+// If the deployment cannot be read or parsed, the binary default is returned.
+func GetStoreValidationFrequency(ctx context.Context, kubeClient kubernetes.Interface, namespace string) time.Duration {
+	defaultFrequency := config.GetDefaultConfig().StoreValidationFrequency
+
+	deployment, err := veleroDeployment(ctx, kubeClient, namespace)
+	if err != nil {
+		return defaultFrequency
+	}
+
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name != "velero" {
+			continue
+		}
+
+		serverConfig, err := parseServerArgs(container.Args)
+		if err != nil {
+			return defaultFrequency
+		}
+
+		return serverConfig.StoreValidationFrequency
+	}
+
+	return defaultFrequency
+}
+
+func veleroDeployment(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (*appsv1api.Deployment, error) {
+	veleroLabels := labels.FormatLabels(install.Labels())
+
+	deployList, err := kubeClient.
+		AppsV1().
+		Deployments(namespace).
+		List(ctx, metav1.ListOptions{
+			LabelSelector: veleroLabels,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range deployList.Items {
+		deploy := &deployList.Items[i]
+		for _, container := range deploy.Spec.Template.Spec.Containers {
+			if container.Name == "velero" {
+				return deploy, nil
+			}
+		}
+	}
+
+	return nil, errVeleroDeploymentNotFound
+}
+
+func parseServerArgs(args []string) (*config.Config, error) {
+	cfg := config.GetDefaultConfig()
+	fs := pflag.NewFlagSet("server", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	cfg.BindFlags(fs)
+
+	serverIndex := -1
+	for i, arg := range args {
+		if arg == "server" {
+			serverIndex = i
+			break
+		}
+	}
+
+	if serverIndex < 0 {
+		return cfg, nil
+	}
+
+	if err := fs.Parse(args[serverIndex+1:]); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}

--- a/pkg/cmd/util/serverconfig/deployment_test.go
+++ b/pkg/cmd/util/serverconfig/deployment_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serverconfig
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/velero/pkg/cmd/server/config"
+)
+
+func TestParseServerArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no server subcommand returns defaults", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := parseServerArgs([]string{"--log-level", "debug"})
+		require.NoError(t, err)
+		assert.Equal(t, config.GetDefaultConfig().StoreValidationFrequency, cfg.StoreValidationFrequency)
+	})
+
+	t.Run("custom store-validation-frequency", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := parseServerArgs([]string{"server", "--store-validation-frequency", "5m"})
+		require.NoError(t, err)
+		assert.Equal(t, 5*time.Minute, cfg.StoreValidationFrequency)
+	})
+
+	t.Run("unknown flags are ignored", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := parseServerArgs([]string{"server", "--unknown-flag", "value", "--store-validation-frequency", "30s"})
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.StoreValidationFrequency)
+	})
+}

--- a/pkg/cmd/util/serverconfig/deployment_test.go
+++ b/pkg/cmd/util/serverconfig/deployment_test.go
@@ -22,8 +22,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1api "k8s.io/api/apps/v1"
+	corev1api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/vmware-tanzu/velero/pkg/cmd/server/config"
+	"github.com/vmware-tanzu/velero/pkg/install"
 )
 
 func TestParseServerArgs(t *testing.T) {
@@ -52,4 +57,70 @@ func TestParseServerArgs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 30*time.Second, cfg.StoreValidationFrequency)
 	})
+}
+
+func TestGetStoreValidationFrequencyFallback(t *testing.T) {
+	t.Parallel()
+
+	defaultFrequency := config.GetDefaultConfig().StoreValidationFrequency
+
+	assert.Equal(t, defaultFrequency, GetStoreValidationFrequency(t.Context(), nil, "velero"))
+
+	clientset := fake.NewSimpleClientset()
+	assert.Equal(t, defaultFrequency, GetStoreValidationFrequency(t.Context(), clientset, "velero"))
+}
+
+func TestGetStoreValidationFrequencyFromDeployment(t *testing.T) {
+	t.Parallel()
+
+	deployment := veleroDeploymentWithArgs("velero", []string{"server", "--store-validation-frequency", "5m"})
+	clientset := fake.NewSimpleClientset(deployment)
+
+	assert.Equal(t, 5*time.Minute, GetStoreValidationFrequency(t.Context(), clientset, "velero"))
+}
+
+func TestGetStoreValidationFrequencyNoVeleroContainer(t *testing.T) {
+	t.Parallel()
+
+	deployment := &appsv1api.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "velero",
+			Name:      "velero",
+			Labels:    install.Labels(),
+		},
+		Spec: appsv1api.DeploymentSpec{
+			Template: corev1api.PodTemplateSpec{
+				Spec: corev1api.PodSpec{
+					Containers: []corev1api.Container{{
+						Name: "not-velero",
+						Args: []string{"server", "--store-validation-frequency", "5m"},
+					}},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment)
+	defaultFrequency := config.GetDefaultConfig().StoreValidationFrequency
+	assert.Equal(t, defaultFrequency, GetStoreValidationFrequency(t.Context(), clientset, "velero"))
+}
+
+func veleroDeploymentWithArgs(namespace string, args []string) *appsv1api.Deployment {
+	return &appsv1api.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "velero",
+			Labels:    install.Labels(),
+		},
+		Spec: appsv1api.DeploymentSpec{
+			Template: corev1api.PodTemplateSpec{
+				Spec: corev1api.PodSpec{
+					Containers: []corev1api.Container{{
+						Name: "velero",
+						Args: args,
+					}},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
Fixes #3098

## Summary
- Adds a **Validation Frequency** column to `velero backup-location get` table output
- When `spec.validationFrequency` is set on the BSL, shows that value (e.g. `5m0s`, `0s`)
- When unset, reads the running Velero server's `--store-validation-frequency` from the deployment (falls back to binary default if unavailable)

## Test plan
- [x] Unit tests for formatter and server config parsing
- [x] `go test ./pkg/cmd/util/output/... ./pkg/cmd/util/serverconfig/... ./pkg/cmd/cli/backuplocation/...`