### PR TITLE
[cherry-pick #10359][1.18] Fix e2e kind matrix misparsing pre-release node tags (#10359)

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -87,12 +87,14 @@ jobs:
         id: set-matrix
         # everything excluding older tags. limits needs to be high enough to cover all latest versions
         # and test labels
-        # grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" filters for v1.25 to v9.99
+        # grep -E "^v[1-9]\.(2[5-9]|[3-9][0-9])\.[0-9]+$" filters for well-formed v1.25.x to v9.99.x
+        # GA releases only, so a pre-release tag like v1.37.0-rc.1 can't reach the
+        # awk step below and be misparsed as a patch release (e.g. "1.37.1")
         # and removes older patches of the same minor version
         # awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}'
         run: |
           echo "matrix={\
-            \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
+            \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -E "^v[1-9]\.(2[5-9]|[3-9][0-9])\.[0-9]+$" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
             \"labels\":[\
               \"Basic && (ClusterResource || NodePort || StorageClass)\", \
               \"ResourceFiltering && !Restic\", \


### PR DESCRIPTION
This is the cherry-pick of #10359 to release-1.18 branch.

* Fix e2e kind matrix misparsing pre-release node tags

The setup-test-matrix step excluded "alpha|beta" pre-release tags but not "rc" ones. A tag like v1.37.0-rc.1 slipped through to the awk field-splitter, which treats "." as the only separator: splitting "v1.37.0-rc.1" yields ["v1","37","0-rc","1"], and printing $1"."$2"."$NF produced the bogus version "v1.37.1" - an image that was never published, since the real tag is v1.37.0-rc.1.

Replace the two greps with a single anchored pattern that only matches well-formed vX.Y.Z tags, so any hyphenated pre-release suffix (rc, alpha, beta, or otherwise) is excluded before reaching the awk step.

Fixes #10358

AI-Tool-Used: Claude Code
AI-Tool-Use-Level: Category 2 (Medium)
AI-Code-Category: Category 2 (Non-Production)

---------

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
