### PR TITLE
Fix e2e build-artifact handoff race (velero.tar missing after force-push)

### DIFF
--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -36,32 +36,33 @@ jobs:
         with:
           go-version: ${{ needs.get-go-version.outputs.version }}
 
-      # Look for a CLI that's made for this PR
-      - name: Fetch built CLI
-        id: cli-cache
-        uses: actions/cache@v6
-        with:
-          path: ./_output/bin/linux/amd64/velero
-          # The cache key a combination of the current PR number and the commit SHA
-          key: velero-cli-${{ github.event.pull_request.number }}-${{ github.sha }}
-      - name: Fetch built image
-        id: image-cache
-        uses: actions/cache@v6
-        with:
-          path: ./velero.tar
-          # The cache key a combination of the current PR number and the commit SHA
-          key: velero-image-${{ github.event.pull_request.number }}-${{ github.sha }}
-      # If no binaries were built for this PR, build it now.
       - name: Build Velero CLI
-        if: steps.cli-cache.outputs.cache-hit != 'true'
         run: |
           make local
-      # If no image were built for this PR, build it now.
       - name: Build Velero Image
-        if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
           IMAGE=velero VERSION=pr-test BUILD_OUTPUT_TYPE=docker make container
           docker save velero:pr-test-linux-amd64 -o ./velero.tar
+      # actions/cache is eventually-consistent and unsuited to same-run,
+      # guaranteed-fresh handoffs: its save happens in a post-job hook after
+      # this job reports success, but the cache service can lag before a
+      # dependent job's restore sees it -- deterministic on every fresh
+      # sha (e.g. after a force-push), see #9927. actions/upload-artifact /
+      # download-artifact are the right tool for passing a same-run build
+      # output to dependent jobs: the download step blocks until the
+      # artifact is actually available, no race.
+      - name: Upload Velero CLI
+        uses: actions/upload-artifact@v7
+        with:
+          name: velero-cli
+          path: ./_output/bin/linux/amd64/velero
+          retention-days: 1
+      - name: Upload Velero Image
+        uses: actions/upload-artifact@v7
+        with:
+          name: velero-image
+          path: ./velero.tar
+          retention-days: 1
       # Build the MinIO image once for all e2e tests, from the reviewed bitnami/containers commit.
       - name: Cache MinIO Image
         uses: actions/cache@v6
@@ -148,17 +149,17 @@ jobs:
           version: "v0.32.0"
           node_image: "kindest/node:v${{ matrix.k8s }}"
       - name: Fetch built CLI
-        id: cli-cache
-        uses: actions/cache@v6
+        uses: actions/download-artifact@v7
         with:
-          path: ./_output/bin/linux/amd64/velero
-          key: velero-cli-${{ github.event.pull_request.number }}-${{ github.sha }}
+          name: velero-cli
+          path: ./_output/bin/linux/amd64
       - name: Fetch built Image
-        id: image-cache
-        uses: actions/cache@v6
+        uses: actions/download-artifact@v7
         with:
-          path: ./velero.tar
-          key: velero-image-${{ github.event.pull_request.number }}-${{ github.sha }}
+          name: velero-image
+          path: .
+      - name: Make CLI executable
+        run: chmod +x ./_output/bin/linux/amd64/velero
       - name: Load Velero Image
         run:
           kind load image-archive velero.tar


### PR DESCRIPTION
Fixes #9927

# Please add a summary of your change

`e2e-test-kind.yaml` used `actions/cache` to hand the built Velero CLI and container image (`velero.tar`) from the `build` job to each `run-e2e-test` matrix job. `actions/cache` saves in a post-job hook that runs after the job reports success, but the cache backend is eventually-consistent -- a dependent job's restore can lose the race against that save. Because the CLI/image cache keys are `velero-{cli,image}-<PR>-<sha>` (always a brand-new key on every push, no prior entry to fall back to), this race is deterministic rather than intermittent: it reproduces on every force-push, and re-running the failed jobs always "fixes" it once the cache has had time to settle.

## Changes

- `build` job: drop the `actions/cache` restore/conditional-build dance for the CLI binary and `velero.tar`; always build them, then hand them to dependent jobs via `actions/upload-artifact@v7`.
- `run-e2e-test` job: fetch both via `actions/download-artifact@v7` instead of `actions/cache@v6`. Artifact downloads block until the artifact is actually present -- no race, unlike cache restores.
- Re-`chmod +x` the downloaded CLI binary (artifact upload/download doesn't reliably preserve the executable bit).
- Left the MinIO image cache alone -- it's keyed by a stable `BITNAMI_CONTAINERS_COMMIT` value shared across runs/PRs, not a same-run fresh miss, so it isn't exposed to this race.

Trade-off: this always rebuilds the CLI/image on every workflow run rather than potentially reusing a cache entry from an earlier attempt at the same commit. A **re-run of already-failed jobs** in the same run still reuses the original attempt's artifacts (GitHub Actions artifacts are scoped to the run, not lost on job re-run), so the common "flaky e2e job, hit re-run" path is unaffected.

# Does your change fix a particular issue?

Fixes #9927

# Please indicate you've done the following:

- [x] Accepted the DCO.
- [ ] Created a changelog file / comment `/kind changelog-not-required` on this PR (CI-only change, no user-facing behavior -- requesting the label).
- [ ] Updated the corresponding documentation in `site/content/docs/main` (not applicable, CI-internal).

> [!Note]
> Responses generated with Claude