### PR TITLE
record a warning on the DataDownload when RebindVolume fails on completion

### DIFF
--- a/changelogs/unreleased/10412-samay43
+++ b/changelogs/unreleased/10412-samay43
@@ -1,0 +1,1 @@
+Fail the DataDownload and clean up the exposed volume when RebindVolume fails on completion, instead of leaving it stranded in InProgress until it is marked Canceled by the item operation timeout

--- a/changelogs/unreleased/10412-samay43
+++ b/changelogs/unreleased/10412-samay43
@@ -1,1 +1,1 @@
-Fail the DataDownload and clean up the exposed volume when RebindVolume fails on completion, instead of leaving it stranded in InProgress until it is marked Canceled by the item operation timeout
+Clean up the exposed environment and record a warning on the DataDownload when RebindVolume fails on completion, instead of leaving it stranded in InProgress until the item operation timeout marks it Canceled

--- a/pkg/controller/data_download_controller.go
+++ b/pkg/controller/data_download_controller.go
@@ -484,6 +484,7 @@ func (r *DataDownloadReconciler) OnDataDownloadCompleted(ctx context.Context, na
 	})
 	if err != nil {
 		log.WithError(err).Error("Failed to rebind PV to target PVC on completion")
+		_, _ = r.errorOut(ctx, &dd, err, "error to rebind PV to target PVC", log)
 		return
 	}
 

--- a/pkg/controller/data_download_controller.go
+++ b/pkg/controller/data_download_controller.go
@@ -476,16 +476,17 @@ func (r *DataDownloadReconciler) OnDataDownloadCompleted(ctx context.Context, na
 	}
 
 	objRef := getDataDownloadOwnerObject(&dd)
-	err := r.restoreExposer.RebindVolume(ctx, objRef, exposer.GenericRestoreRebindVolumeParam{
+	rebindErr := r.restoreExposer.RebindVolume(ctx, objRef, exposer.GenericRestoreRebindVolumeParam{
 		TargetPVCName:    dd.Spec.TargetVolume.PVC,
 		TargetNamespace:  dd.Spec.TargetVolume.Namespace,
 		OperationTimeout: dd.Spec.OperationTimeout.Duration,
 		TargetFSType:     dd.Spec.TargetVolume.FSType,
 	})
-	if err != nil {
-		log.WithError(err).Error("Failed to rebind PV to target PVC on completion")
-		_, _ = r.errorOut(ctx, &dd, err, "error to rebind PV to target PVC", log)
-		return
+	if rebindErr != nil {
+		// The data has been restored at this point, so the DataDownload is still completed.
+		// Carry the rebind failure in the status message so that users are notified that the
+		// target volume may not be usable.
+		log.WithError(rebindErr).Error("Failed to rebind PV to target PVC on completion")
 	}
 
 	log.Info("Cleaning up exposed environment")
@@ -498,6 +499,10 @@ func (r *DataDownloadReconciler) OnDataDownloadCompleted(ctx context.Context, na
 
 		dd.Status.Phase = velerov2alpha1api.DataDownloadPhaseCompleted
 		dd.Status.CompletionTimestamp = &metav1.Time{Time: r.Clock.Now()}
+		if rebindErr != nil {
+			dd.Status.Message = fmt.Sprintf("Warning: data was restored but failed to rebind the restored PV to target PVC %s/%s, so the target volume may not contain the restored data: %v",
+				dd.Spec.TargetVolume.Namespace, dd.Spec.TargetVolume.PVC, rebindErr)
+		}
 
 		delete(dd.Labels, exposer.ExposeOnGoingLabel)
 

--- a/pkg/controller/data_download_controller_test.go
+++ b/pkg/controller/data_download_controller_test.go
@@ -706,21 +706,20 @@ func TestOnDataDownloadCompleted(t *testing.T) {
 		emptyFSBR       bool
 		isGetErr        bool
 		rebindVolumeErr bool
-		expectedPhase   velerov2alpha1api.DataDownloadPhase
+		expectedMessage string
 	}{
 		{
 			name:            "Data download complete",
 			emptyFSBR:       false,
 			isGetErr:        false,
 			rebindVolumeErr: false,
-			expectedPhase:   velerov2alpha1api.DataDownloadPhaseCompleted,
 		},
 		{
 			name:            "Rebind volume fails",
 			emptyFSBR:       false,
 			isGetErr:        false,
 			rebindVolumeErr: true,
-			expectedPhase:   velerov2alpha1api.DataDownloadPhaseFailed,
+			expectedMessage: "Warning: data was restored but failed to rebind the restored PV to target PVC test-ns/test-pvc, so the target volume may not contain the restored data: Error to rebind volume",
 		},
 	}
 
@@ -754,8 +753,9 @@ func TestOnDataDownloadCompleted(t *testing.T) {
 				assert.True(t, updatedDD.Status.CompletionTimestamp.IsZero())
 			} else {
 				require.NoError(t, r.client.Get(ctx, types.NamespacedName{Name: ddName, Namespace: namespace}, updatedDD))
-				assert.Equal(t, test.expectedPhase, updatedDD.Status.Phase)
+				assert.Equal(t, velerov2alpha1api.DataDownloadPhaseCompleted, updatedDD.Status.Phase)
 				assert.False(t, updatedDD.Status.CompletionTimestamp.IsZero())
+				assert.Equal(t, test.expectedMessage, updatedDD.Status.Message)
 			}
 		})
 	}

--- a/pkg/controller/data_download_controller_test.go
+++ b/pkg/controller/data_download_controller_test.go
@@ -706,12 +706,21 @@ func TestOnDataDownloadCompleted(t *testing.T) {
 		emptyFSBR       bool
 		isGetErr        bool
 		rebindVolumeErr bool
+		expectedPhase   velerov2alpha1api.DataDownloadPhase
 	}{
 		{
 			name:            "Data download complete",
 			emptyFSBR:       false,
 			isGetErr:        false,
 			rebindVolumeErr: false,
+			expectedPhase:   velerov2alpha1api.DataDownloadPhaseCompleted,
+		},
+		{
+			name:            "Rebind volume fails",
+			emptyFSBR:       false,
+			isGetErr:        false,
+			rebindVolumeErr: true,
+			expectedPhase:   velerov2alpha1api.DataDownloadPhaseFailed,
 		},
 	}
 
@@ -732,7 +741,7 @@ func TestOnDataDownloadCompleted(t *testing.T) {
 			}()
 
 			require.NoError(t, err)
-			dd := dataDownloadBuilder().Result()
+			dd := dataDownloadBuilder().Phase(velerov2alpha1api.DataDownloadPhaseInProgress).Result()
 			namespace := dd.Namespace
 			ddName := dd.Name
 			// Add the DataDownload object to the fake client
@@ -745,7 +754,7 @@ func TestOnDataDownloadCompleted(t *testing.T) {
 				assert.True(t, updatedDD.Status.CompletionTimestamp.IsZero())
 			} else {
 				require.NoError(t, r.client.Get(ctx, types.NamespacedName{Name: ddName, Namespace: namespace}, updatedDD))
-				assert.Equal(t, velerov2alpha1api.DataDownloadPhaseCompleted, updatedDD.Status.Phase)
+				assert.Equal(t, test.expectedPhase, updatedDD.Status.Phase)
 				assert.False(t, updatedDD.Status.CompletionTimestamp.IsZero())
 			}
 		})


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

`OnDataDownloadCompleted` runs when the async data path has finished copying data for a CSI data mover restore. Its first statement schedules teardown of that data path:

```go
defer r.dataPathMgr.RemoveAsyncBR(ddName)
```

and its `RebindVolume` error branch then returns without doing anything else:

```go
	if err != nil {
		log.WithError(err).Error("Failed to rebind PV to target PVC on completion")
		return
	}

	log.Info("Cleaning up exposed environment")
	r.restoreExposer.CleanUp(ctx, objRef)
```

That `return` skips the `CleanUp` on the very next line and the status update below it, so the DataDownload keeps its `InProgress` phase — while the deferred `RemoveAsyncBR` has already disposed of the data path, so no callback can fire for this DataDownload again.

Nothing brings it back. The periodical enqueue predicate in `SetupWithManager` admits only `Accepted`, `Cancel`-set, and being-deleted objects, so an `InProgress` DataDownload with `Cancel` unset is never re-enqueued; and the `InProgress` branch of `Reconcile` is wrapped entirely in `if dd.Spec.Cancel` and otherwise falls straight through. It sits there until the restore item operation hits `defaultItemOperationTimeout` (4 hours) and `cancelDataDownload` patches `Spec.Cancel = true`, at which point it routes to `OnDataDownloadCancelled` and lands in **`Canceled`** — the phase that means somebody called the restore off. The exposed restore pod and PVC stay in the cluster for those four hours.

The fix keeps `OnDataDownloadCompleted` going when the rebind fails, so the exposed environment is cleaned up and the DataDownload reaches a terminal phase. Per @Lyndon-Li's review, that phase is `Completed` rather than `Failed` — the data path itself succeeded, and a restore that may have taken hours should not be reported as a failure. The rebind failure is instead carried on the object as a warning:

```go
	if rebindErr != nil {
		dd.Status.Message = fmt.Sprintf("Warning: data was restored but failed to rebind the restored PV to target PVC %s/%s, so the target volume may not contain the restored data: %v",
			dd.Spec.TargetVolume.Namespace, dd.Spec.TargetVolume.PVC, rebindErr)
	}
```

`Status.Message` is the only warning carrier the DataDownload CR has today. There is precedent for setting it on a successful object: `OnDataUploadCompleted` sets it to `"volume was empty so no data was upload"` on a `Completed` DataUpload.

**Open questions raised in review** (see the comment thread): `CleanUp` deletes the restored PV whether we fail or complete, so this does not by itself preserve the restored data; and `pvcRestoreItemAction.Progress` reads `Status.Message` only for the `Failed` phase, so the warning does not currently reach `velero restore describe`.

**On the test.** `TestOnDataDownloadCompleted` already had the hook for this and it had never been switched on — `rebindVolumeErr bool` with a mock branch returning `errors.New("Error to rebind volume")`, and a single table case setting it `false`. All three arrived together in `2f667f519` (Jul 2023) and `git log -S` shows nothing has touched them since, so this is a dormant hook rather than the residue of a deleted case. This PR turns it on and adds `Phase(InProgress)` to the builder so the fixture matches what the controller actually sees.

Reverting the fix and keeping the test fails three ways:

```
=== RUN   TestOnDataDownloadCompleted/Rebind_volume_fails
    data_download_controller_test.go:757:
        	Error:      	Should be false            # CompletionTimestamp never set
    data_download_controller_test.go:758:
        	Error:      	Not equal:
        	            	expected: "Warning: data was restored but failed to rebind..."
        	            	actual  : ""
    GenericRestoreExposer.go:26: FAIL:	CleanUp(string,string)
    GenericRestoreExposer.go:26: FAIL: 1 out of 2 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
--- FAIL: TestOnDataDownloadCompleted/Rebind_volume_fails (0.05s)
```

The last two lines are the exposer mock's own `AssertExpectations` reporting that `CleanUp` was never called — the leaked restore pod and PVC, surfaced by the existing test setup without a new assertion.

`TestAPIs` fails locally for me on clean `main` as well; it needs the envtest kube-apiserver/etcd binaries, so it is unrelated to this change.

# Does your change fix a particular issue?

Fixes #10411

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`. — n/a, no user-facing documented behaviour changes.
