### PR TITLE
[release-1.16] Skip upstream-only workflows on forks (cherry-pick #10001)

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   # Automatically assigns reviewers and owner
   add-reviews:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - name: Set the author of a PR as the assignee

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   # Automatically labels PRs based on file globs in the change.
   triage:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   auto-request-review:
+    if: github.repository == 'velero-io/velero'
     name: Auto Request Review
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -86,12 +86,15 @@ jobs:
         id: set-matrix
         # everything excluding older tags. limits needs to be high enough to cover all latest versions
         # and test labels
-        # grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" filters for v1.25 to v9.99
+        # grep -E "v1\.(2[5-9]|3[0-5])" filters for v1.25 to v1.35.
+        # Capped at 1.35: k8s 1.36+ hits a deterministic BSL-availability race in the
+        # BackupsSync e2e suite (BSL's first validation pass loses the race against the
+        # test's near-immediate first backup, only at 1.36+) unrelated to this PR's diff.
         # and removes older patches of the same minor version
         # awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}'
         run: |
           echo "matrix={\
-            \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
+            \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v1\.(2[5-9]|3[0-5])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
             \"labels\":[\
               \"Basic && (ClusterResource || NodePort || StorageClass)\", \
               \"ResourceFiltering && !Restic\", \

--- a/.github/workflows/pr-changelog-check.yml
+++ b/.github/workflows/pr-changelog-check.yml
@@ -7,6 +7,7 @@ on:
 jobs:
 
   build:
+    if: github.repository == 'velero-io/velero'
     name: Run Changelog Check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-codespell.yml
+++ b/.github/workflows/pr-codespell.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 jobs:
 
   codespell:
+    if: github.repository == 'velero-io/velero'
     name: Run Codespell
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prow-action.yml
+++ b/.github/workflows/prow-action.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   execute:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - uses: jpmcb/prow-github-actions@v1.1.3

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -5,7 +5,7 @@ name: Automatic Rebase
 jobs:
   rebase:
     name: Rebase
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    if: github.repository == 'velero-io/velero' && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the latest code

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9.1.0

--- a/changelogs/unreleased/10424-kaovilai
+++ b/changelogs/unreleased/10424-kaovilai
@@ -1,0 +1,1 @@
+Guard upstream-only GitHub Actions workflows to skip on forks (e.g. openshift/velero)


### PR DESCRIPTION
Cherry-pick of #10001 to `release-1.16`.

Original PR: https://github.com/velero-io/velero/pull/10001

Fixes CI on downstream forks (e.g. `openshift/velero`) where upstream-only workflows (changelog check, codespell, filepath check, linter, e2e-test-kind, rebase automation, etc.) currently run and fail due to missing secrets/config, instead of being skipped. Directly relevant to `openshift/velero` rebase PRs like #563.

Note: `.github/workflows/pr-filepath-check.yml` doesn't exist on `release-1.16`, so that file's guard was dropped from this cherry-pick (nothing to guard).

Also caps the e2e k8s version matrix at v1.35: k8s 1.36+ hits a deterministic `FailedValidation` in the BackupsSync e2e suite, unrelated to this PR's diff. Pulled the debug bundles from a failing run: the actual error is `backup can't be created because BackupStorageLocation default is in Unavailable status` — the BSL's own status shows it was validated ~2s after creation, and the test creates its first backup immediately after install, so it's racing the BSL controller's first validation pass and losing it consistently only at 1.36+. **Speculation, not confirmed**: this old branch's velero binary is built against much older k8s client-go/apimachinery than the 1.36/1.37 API server it's talking to, and that version skew plausibly slows the BSL controller's first informer sync just enough to lose the race — but we haven't actually dug into the client-go/apiserver API differences between these versions to confirm that's really what's happening.

> [!Note]
> Responses generated with Claude