### PR TITLE
[release-1.18] Skip upstream-only workflows on forks (cherry-pick #10001)

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   # Automatically assigns reviewers and owner
   add-reviews:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - name: Set the author of a PR as the assignee

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   # Automatically labels PRs based on file globs in the change.
   triage:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   auto-request-review:
+    if: github.repository == 'velero-io/velero'
     name: Auto Request Review
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-changelog-check.yml
+++ b/.github/workflows/pr-changelog-check.yml
@@ -7,6 +7,7 @@ on:
 jobs:
 
   build:
+    if: github.repository == 'velero-io/velero'
     name: Run Changelog Check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-codespell.yml
+++ b/.github/workflows/pr-codespell.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 jobs:
 
   codespell:
+    if: github.repository == 'velero-io/velero'
     name: Run Codespell
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-filepath-check.yml
+++ b/.github/workflows/pr-filepath-check.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 jobs:
 
   filepath-check:
+    if: github.repository == 'velero-io/velero'
     name: Check for invalid characters in file paths
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prow-action.yml
+++ b/.github/workflows/prow-action.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   execute:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - uses: jpmcb/prow-github-actions@v1.1.3

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -5,7 +5,7 @@ name: Automatic Rebase
 jobs:
   rebase:
     name: Rebase
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    if: github.repository == 'velero-io/velero' && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the latest code

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10.1.1

--- a/changelogs/unreleased/10426-kaovilai
+++ b/changelogs/unreleased/10426-kaovilai
@@ -1,0 +1,1 @@
+Guard upstream-only GitHub Actions workflows to skip on forks (e.g. openshift/velero)


### PR DESCRIPTION
> [!IMPORTANT]
> Not intended for `v1.18.3`. Merge into `release-1.18` for a later patch release, not the next one to be cut.

Cherry-pick of #10001 to `release-1.18`.

Original PR: https://github.com/velero-io/velero/pull/10001

Fixes CI on downstream forks (e.g. `openshift/velero`) where upstream-only workflows (changelog check, codespell, filepath check, linter, e2e-test-kind, rebase automation, etc.) currently run and fail due to missing secrets/config, instead of being skipped.

> [!Note]
> Responses generated with Claude