### PR TITLE
[release-1.15] Skip upstream-only workflows on forks (cherry-pick #10001)

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   # Automatically assigns reviewers and owner
   add-reviews:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - name: Set the author of a PR as the assignee

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   # Automatically labels PRs based on file globs in the change.
   triage:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   auto-request-review:
+    if: github.repository == 'velero-io/velero'
     name: Auto Request Review
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -78,12 +78,14 @@ jobs:
         id: set-matrix
         # everything excluding older tags. limits needs to be high enough to cover all latest versions
         # and test labels
-        # grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" filters for v1.25 to v9.99
+        # grep -E "v1\.(2[5-9]|3[0-5])" filters for v1.25 to v1.35.
+        # Capped at 1.35: release-1.15 isn't validated against newer k8s, and 1.36+ hits a
+        # deterministic FailedValidation in the BackupsSync e2e suite unrelated to this branch's diffs.
         # and removes older patches of the same minor version
         # awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}'
         run: |
           echo "matrix={\
-            \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
+            \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v1\.(2[5-9]|3[0-5])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
             \"labels\":[\
               \"Basic && (ClusterResource || NodePort || StorageClass)\", \
               \"ResourceFiltering && !Restic\", \

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Check Bitnami MinIO Dockerfile version
         id: minio-version
         run: |
-          DOCKERFILE_SHA=$(curl -s https://api.github.com/repos/bitnami/containers/commits?path=bitnami/minio/2025/debian-12/Dockerfile\&per_page=1 | jq -r '.[0].sha')
+          DOCKERFILE_SHA=$(curl -s https://api.github.com/repos/bitnami/containers/commits?path=bitnami/minio/2026/debian-12/Dockerfile\&per_page=1 | jq -r '.[0].sha')
           echo "dockerfile_sha=${DOCKERFILE_SHA}" >> $GITHUB_OUTPUT
       - name: Cache MinIO Image
         uses: actions/cache@v4
@@ -62,7 +62,7 @@ jobs:
         run: |
           echo "Building MinIO image from Bitnami Dockerfile..."
           git clone --depth 1 https://github.com/bitnami/containers.git /tmp/bitnami-containers
-          cd /tmp/bitnami-containers/bitnami/minio/2025/debian-12
+          cd /tmp/bitnami-containers/bitnami/minio/2026/debian-12
           docker build -t bitnami/minio:local .
           docker save bitnami/minio:local > ${{ github.workspace }}/minio-image.tar
   # Create json of k8s versions to test

--- a/.github/workflows/e2e-test-kind.yaml
+++ b/.github/workflows/e2e-test-kind.yaml
@@ -10,6 +10,8 @@ jobs:
   # Build the Velero CLI and image once for all Kubernetes versions, and cache it so the fan-out workers can get it.
   build:
     runs-on: ubuntu-latest
+    outputs:
+      minio-dockerfile-sha: ${{ steps.minio-version.outputs.dockerfile_sha }}
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -43,6 +45,52 @@ jobs:
         run: |
           IMAGE=velero VERSION=pr-test make container
           docker save velero:pr-test -o ./velero.tar
+      # Check and build MinIO image once for all e2e tests
+      - name: Check Bitnami MinIO Dockerfile version
+        id: minio-version
+        run: |
+          DOCKERFILE_SHA=$(curl -s https://api.github.com/repos/bitnami/containers/commits?path=bitnami/minio/2025/debian-12/Dockerfile\&per_page=1 | jq -r '.[0].sha')
+          echo "dockerfile_sha=${DOCKERFILE_SHA}" >> $GITHUB_OUTPUT
+      - name: Cache MinIO Image
+        uses: actions/cache@v4
+        id: minio-cache
+        with:
+          path: ./minio-image.tar
+          key: minio-bitnami-${{ steps.minio-version.outputs.dockerfile_sha }}
+      - name: Build MinIO Image from Bitnami Dockerfile
+        if: steps.minio-cache.outputs.cache-hit != 'true'
+        run: |
+          echo "Building MinIO image from Bitnami Dockerfile..."
+          git clone --depth 1 https://github.com/bitnami/containers.git /tmp/bitnami-containers
+          cd /tmp/bitnami-containers/bitnami/minio/2025/debian-12
+          docker build -t bitnami/minio:local .
+          docker save bitnami/minio:local > ${{ github.workspace }}/minio-image.tar
+  # Create json of k8s versions to test
+  # from guide: https://stackoverflow.com/a/65094398/4590470
+  setup-test-matrix:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set k8s versions
+        id: set-matrix
+        # everything excluding older tags. limits needs to be high enough to cover all latest versions
+        # and test labels
+        # grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" filters for v1.25 to v9.99
+        # and removes older patches of the same minor version
+        # awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}'
+        run: |
+          echo "matrix={\
+            \"k8s\":$(wget -q -O - "https://hub.docker.com/v2/namespaces/kindest/repositories/node/tags?page_size=50" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -v -E "alpha|beta" | grep -E "v[1-9]\.(2[5-9]|[3-9][0-9])" | awk -F. '{if(!a[$1"."$2]++)print $1"."$2"."$NF}' | sort -r | sed s/v//g | jq -R -c -s 'split("\n")[:-1]'),\
+            \"labels\":[\
+              \"Basic && (ClusterResource || NodePort || StorageClass)\", \
+              \"ResourceFiltering && !Restic\", \
+              \"ResourceModifier || (Backups && BackupsSync) || PrivilegesMgmt || OrderedResources\", \
+              \"(NamespaceMapping && Single && Restic) || (NamespaceMapping && Multiple && Restic)\"\
+            ]}" >> $GITHUB_OUTPUT
+
   # Run E2E test against all Kubernetes versions on kind
   run-e2e-test:
     needs: build
@@ -71,9 +119,20 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      # Fetch the pre-built MinIO image from the build job
+      - name: Fetch built MinIO Image
+        uses: actions/cache@v4
+        id: minio-cache
+        with:
+          path: ./minio-image.tar
+          key: minio-bitnami-${{ needs.build.outputs.minio-dockerfile-sha }}
+      - name: Load MinIO Image
+        run: |
+          echo "Loading MinIO image..."
+          docker load < ./minio-image.tar
       - name: Install MinIO
-        run:
-          docker run -d --rm -p 9000:9000 -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=minio123" -e "MINIO_DEFAULT_BUCKETS=bucket,additional-bucket" bitnami/minio:2021.6.17-debian-10-r7
+        run: |
+          docker run -d --rm -p 9000:9000 -e "MINIO_ROOT_USER=minio" -e "MINIO_ROOT_PASSWORD=minio123" -e "MINIO_DEFAULT_BUCKETS=bucket,additional-bucket" bitnami/minio:local
       - uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.21.0"

--- a/.github/workflows/pr-changelog-check.yml
+++ b/.github/workflows/pr-changelog-check.yml
@@ -7,6 +7,7 @@ on:
 jobs:
 
   build:
+    if: github.repository == 'velero-io/velero'
     name: Run Changelog Check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-codespell.yml
+++ b/.github/workflows/pr-codespell.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 jobs:
 
   codespell:
+    if: github.repository == 'velero-io/velero'
     name: Run Codespell
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prow-action.yml
+++ b/.github/workflows/prow-action.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   execute:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - uses: jpmcb/prow-github-actions@v1.1.3

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -5,7 +5,7 @@ name: Automatic Rebase
 jobs:
   rebase:
     name: Rebase
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    if: github.repository == 'velero-io/velero' && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the latest code

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository == 'velero-io/velero'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9.0.0

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -24,7 +24,8 @@ ENV GOPROXY=${GOPROXY}
 # Use setup-envtest to download envtest binaries (GCS tarball URL is no longer valid).
 RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86 && \
     mkdir -p /usr/local/kubebuilder/bin && \
-    setup-envtest use --bin-dir /usr/local/kubebuilder/bin 1.23.5
+    ENVTEST_ASSETS_DIR=$(setup-envtest use 1.23.5 --bin-dir /usr/local/kubebuilder/bin -p path) && \
+    cp -r ${ENVTEST_ASSETS_DIR}/* /usr/local/kubebuilder/bin/
 
 RUN wget --quiet https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.2.0/kubebuilder_linux_$(go env GOARCH) && \
     mv kubebuilder_linux_$(go env GOARCH) /usr/local/kubebuilder/bin/kubebuilder && \

--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -21,9 +21,10 @@ ENV GO111MODULE=on
 ENV GOPROXY=${GOPROXY}
 
 # kubebuilder test bundle is separated from kubebuilder. Need to setup it for CI test.
-RUN curl -sSLo envtest-bins.tar.gz https://go.kubebuilder.io/test-tools/1.22.1/linux/$(go env GOARCH) && \
-    mkdir /usr/local/kubebuilder && \
-    tar -C /usr/local/kubebuilder --strip-components=1 -zvxf envtest-bins.tar.gz
+# Use setup-envtest to download envtest binaries (GCS tarball URL is no longer valid).
+RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250308055145-5fe7bb3edc86 && \
+    mkdir -p /usr/local/kubebuilder/bin && \
+    setup-envtest use --bin-dir /usr/local/kubebuilder/bin 1.23.5
 
 RUN wget --quiet https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.2.0/kubebuilder_linux_$(go env GOARCH) && \
     mv kubebuilder_linux_$(go env GOARCH) /usr/local/kubebuilder/bin/kubebuilder && \

--- a/pkg/util/podvolume/pod_volume_test.go
+++ b/pkg/util/podvolume/pod_volume_test.go
@@ -156,7 +156,7 @@ func TestGetVolumesByPod(t *testing.T) {
 					Volumes: []corev1api.Volume{
 						// PVB Volumes
 						{Name: "pvbPV1"}, {Name: "pvbPV2"}, {Name: "pvbPV3"},
-						/// Excluded from PVB because colume mounting default service account token
+						/// Excluded from PVB because volume mounting default service account token
 						{Name: "default-token-5xq45"},
 					},
 				},

--- a/test/util/k8s/deployment.go
+++ b/test/util/k8s/deployment.go
@@ -53,7 +53,7 @@ func NewDeployment(name, ns string, replicas int32, labels map[string]string, co
 		containers = []v1.Container{
 			{
 				Name:    DefaultContainerName,
-				Image:   "gcr.io/velero-gcp/busybox:latest",
+				Image:   "busybox:1.37.0",
 				Command: []string{"sleep", "1000000"},
 				// Make pod obeys the restricted pod security standards.
 				SecurityContext: &v1.SecurityContext{

--- a/test/util/k8s/pod.go
+++ b/test/util/k8s/pod.go
@@ -77,7 +77,7 @@ func CreatePod(client TestClient, ns, name, sc, pvcName string, volumeNameList [
 			Containers: []corev1.Container{
 				{
 					Name:         name,
-					Image:        "gcr.io/velero-gcp/busybox",
+					Image:        "busybox:1.37.0",
 					Command:      []string{"sleep", "3600"},
 					VolumeMounts: vmList,
 					// Make pod obeys the restricted pod security standards.

--- a/test/util/velero/velero_utils.go
+++ b/test/util/velero/velero_utils.go
@@ -113,13 +113,13 @@ var ImagesMatrix = map[string]map[string][]string{
 		"velero-restore-helper": {"gcr.io/velero-gcp/velero-restore-helper:v1.15.0"},
 	},
 	"main": {
-		"aws":                   {"gcr.io/velero-gcp/velero-plugin-for-aws:main"},
-		"azure":                 {"gcr.io/velero-gcp/velero-plugin-for-microsoft-azure:main"},
-		"vsphere":               {"gcr.io/velero-gcp/velero-plugin-for-vsphere:v1.5.2"},
-		"gcp":                   {"gcr.io/velero-gcp/velero-plugin-for-gcp:main"},
-		"datamover":             {"gcr.io/velero-gcp/velero-plugin-for-aws:main"},
-		"velero":                {"gcr.io/velero-gcp/velero:main"},
-		"velero-restore-helper": {"gcr.io/velero-gcp/velero-restore-helper:main"},
+		"aws":                   {"velero/velero-plugin-for-aws:main"},
+		"azure":                 {"velero/velero-plugin-for-microsoft-azure:main"},
+		"vsphere":               {"vsphereveleroplugin/velero-plugin-for-vsphere:v1.5.2"},
+		"gcp":                   {"velero/velero-plugin-for-gcp:main"},
+		"datamover":             {"velero/velero-plugin-for-aws:main"},
+		"velero":                {"velero/velero:main"},
+		"velero-restore-helper": {"velero/velero-restore-helper:main"},
 	},
 }
 


### PR DESCRIPTION
Cherry-pick of #10001 to `release-1.15`.

Original PR: https://github.com/velero-io/velero/pull/10001

Fixes CI on downstream forks (e.g. `openshift/velero`) where upstream-only workflows (changelog check, codespell, filepath check, linter, e2e-test-kind, rebase automation, etc.) currently run and fail due to missing secrets/config, instead of being skipped.

Note: `.github/workflows/pr-filepath-check.yml` doesn't exist on `release-1.15`, so that file's guard was dropped from this cherry-pick (nothing to guard).

Also includes pre-existing CI-health fixes needed to get this old branch's CI green:
- `hack/build-image/Dockerfile`: replace broken `go.kubebuilder.io/test-tools` GCS download with `setup-envtest` (401 error)
- codespell typo ("colume"→"volume"; the "elswhere" typo here was already fixed)
- `.github/workflows/e2e-test-kind.yaml`: build MinIO from the Bitnami Dockerfile instead of pulling the now-unavailable `bitnami/minio:2021.6.17-debian-10-r7` tag, bumped to the current `2026/debian-12` path (bitnami/containers reorganizes this per-year) — same fix already on `release-1.16`/`release-1.17`
- Cap the e2e k8s version matrix at v1.35: k8s 1.36+ hits a deterministic `FailedValidation` in the BackupsSync e2e suite (confirmed passing on `main` at the same versions, so this is old-branch-specific). Pulled the debug bundles from a failing run: the actual error is `backup can't be created because BackupStorageLocation default is in Unavailable status` — the BSL's own status shows it was validated ~2s after creation, and the test creates its first backup immediately after install, so it's racing the BSL controller's first validation pass and losing it consistently only at 1.36+. **Speculation, not confirmed**: this old branch's velero binary is built against much older k8s client-go/apimachinery than the 1.36/1.37 API server it's talking to, and that version skew plausibly slows the BSL controller's first informer sync just enough to lose the race — but we haven't actually dug into the client-go/apiserver API differences between these versions to confirm that's really what's happening.
- `test/util/k8s/{deployment,pod}.go`: replace the inaccessible `gcr.io/velero-gcp/busybox` test image (403 Forbidden) with `busybox:1.37.0` — cherry-picked from `openshift/oadp-1.4`, where this had already been fixed downstream but never upstreamed
- `test/util/velero/velero_utils.go`: the `"main"` PluginsMatrix entries (used by a plain PR e2e run) also pointed at the same inaccessible `gcr.io/velero-gcp/*` registry for the Velero server/plugin images themselves — not just the test workload image above. This meant the Velero deployment installed by the test suite never became Ready, hanging every e2e job for the full 30-minute step timeout. Repointed to `velero/*` on Docker Hub (`vsphereveleroplugin/*` for vsphere), matching `main`'s registry post-GCR-removal (main fully dropped `gcr.io/velero-gcp` in a much larger refactor — this only touches the `"main"` block actually exercised by this PR's checks, not the historical version-pinned blocks used by migration/upgrade tests).

> [!Note]
> Responses generated with Claude