### PR TITLE
guard the VGDP counter cache states against concurrent access from four controllers

### DIFF
--- a/changelogs/unreleased/10431-samay43
+++ b/changelogs/unreleased/10431-samay43
@@ -1,0 +1,1 @@
+Fix a data race on the VGDP counter's cached queue lengths, which are updated by every node-agent controller that shares the counter

--- a/pkg/exposer/vgdp_counter.go
+++ b/pkg/exposer/vgdp_counter.go
@@ -2,6 +2,7 @@ package exposer
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
@@ -31,6 +32,9 @@ type VgdpCounter struct {
 	pvbState dynamicQueueLength
 	pvrState dynamicQueueLength
 
+	// cacheLock guards the cache states below, which are read and updated by
+	// IsConstrained from the goroutine of every controller sharing this counter
+	cacheLock     sync.Mutex
 	duCacheState  dynamicQueueLength
 	ddCacheState  dynamicQueueLength
 	pvbCacheState dynamicQueueLength
@@ -164,6 +168,9 @@ func (w *VgdpCounter) initListeners(ctx context.Context, mgr manager.Manager) er
 }
 
 func (w *VgdpCounter) IsConstrained(ctx context.Context, log logrus.FieldLogger) bool {
+	w.cacheLock.Lock()
+	defer w.cacheLock.Unlock()
+
 	id := atomic.LoadUint64(&w.duState.changeID)
 	if id != w.duCacheState.changeID {
 		duList := &velerov2alpha1api.DataUploadList{}

--- a/pkg/exposer/vgdp_counter_test.go
+++ b/pkg/exposer/vgdp_counter_test.go
@@ -1,7 +1,11 @@
 package exposer
 
 import (
+	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -177,4 +181,77 @@ func TestIsConstrained(t *testing.T) {
 			}
 		})
 	}
+}
+
+// listProbeClient records whether more than one List call is ever in flight at
+// the same time, so a test can tell serialized callers from concurrent ones
+// without relying on the race detector.
+type listProbeClient struct {
+	client.Client
+
+	inFlight atomic.Int32
+	maxSeen  atomic.Int32
+}
+
+func (c *listProbeClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	inFlight := c.inFlight.Add(1)
+
+	for {
+		maxSeen := c.maxSeen.Load()
+		if inFlight <= maxSeen || c.maxSeen.CompareAndSwap(maxSeen, inFlight) {
+			break
+		}
+	}
+
+	// widen the window so overlapping callers are observed reliably
+	time.Sleep(time.Millisecond * 20)
+
+	err := c.Client.List(ctx, list, opts...)
+
+	c.inFlight.Add(-1)
+
+	return err
+}
+
+// The node-agent shares one VgdpCounter across the DataUpload, DataDownload,
+// PodVolumeBackup and PodVolumeRestore controllers, each of which calls
+// IsConstrained from its own goroutine. The cache states it updates must not be
+// read and written by two of them at once.
+func TestIsConstrainedConcurrent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, velerov1api.AddToScheme(scheme))
+	require.NoError(t, velerov2alpha1api.AddToScheme(scheme))
+
+	probe := &listProbeClient{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			builder.ForDataUpload("velero", "du-1").Labels(map[string]string{ExposeOnGoingLabel: "true"}).Result(),
+		).Build(),
+	}
+
+	counter := &VgdpCounter{
+		client:             probe,
+		allowedQueueLength: 100,
+	}
+
+	log := velerotest.NewLogger()
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range 10 {
+				// stand in for the informer handlers, so every call re-lists
+				atomic.AddUint64(&counter.duState.changeID, 1)
+
+				counter.IsConstrained(t.Context(), log)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int32(1), probe.maxSeen.Load(), "IsConstrained ran concurrently on a shared counter")
 }

--- a/pkg/exposer/vgdp_counter_test.go
+++ b/pkg/exposer/vgdp_counter_test.go
@@ -19,23 +19,23 @@ import (
 func TestIsConstrained(t *testing.T) {
 	tests := []struct {
 		name          string
-		counter       VgdpCounter
+		counter       *VgdpCounter
 		kubeClientObj []client.Object
 		getErr        bool
 		expected      bool
 	}{
 		{
 			name:     "no change, constrained",
-			counter:  VgdpCounter{},
+			counter:  &VgdpCounter{},
 			expected: true,
 		},
 		{
 			name:    "no change, not constrained",
-			counter: VgdpCounter{allowedQueueLength: 1},
+			counter: &VgdpCounter{allowedQueueLength: 1},
 		},
 		{
 			name: "change in du, get failed",
-			counter: VgdpCounter{
+			counter: &VgdpCounter{
 				allowedQueueLength: 1,
 				duState:            dynamicQueueLength{0, 1},
 			},
@@ -43,7 +43,7 @@ func TestIsConstrained(t *testing.T) {
 		},
 		{
 			name: "change in du, constrained",
-			counter: VgdpCounter{
+			counter: &VgdpCounter{
 				allowedQueueLength: 1,
 				duState:            dynamicQueueLength{0, 1},
 			},
@@ -54,7 +54,7 @@ func TestIsConstrained(t *testing.T) {
 		},
 		{
 			name: "change in dd, get failed",
-			counter: VgdpCounter{
+			counter: &VgdpCounter{
 				allowedQueueLength: 1,
 				ddState:            dynamicQueueLength{0, 1},
 			},
@@ -62,7 +62,7 @@ func TestIsConstrained(t *testing.T) {
 		},
 		{
 			name: "change in dd, constrained",
-			counter: VgdpCounter{
+			counter: &VgdpCounter{
 				allowedQueueLength: 1,
 				ddState:            dynamicQueueLength{0, 1},
 			},
@@ -73,7 +73,7 @@ func TestIsConstrained(t *testing.T) {
 		},
 		{
 			name: "change in pvb, get failed",
-			counter: VgdpCounter{
+			counter: &VgdpCounter{
 				allowedQueueLength: 1,
 				pvbState:           dynamicQueueLength{0, 1},
 			},
@@ -81,7 +81,7 @@ func TestIsConstrained(t *testing.T) {
 		},
 		{
 			name: "change in pvb, constrained",
-			counter: VgdpCounter{
+			counter: &VgdpCounter{
 				allowedQueueLength: 1,
 				pvbState:           dynamicQueueLength{0, 1},
 			},
@@ -92,7 +92,7 @@ func TestIsConstrained(t *testing.T) {
 		},
 		{
 			name: "change in pvr, get failed",
-			counter: VgdpCounter{
+			counter: &VgdpCounter{
 				allowedQueueLength: 1,
 				pvrState:           dynamicQueueLength{0, 1},
 			},
@@ -100,7 +100,7 @@ func TestIsConstrained(t *testing.T) {
 		},
 		{
 			name: "change in pvr, constrained",
-			counter: VgdpCounter{
+			counter: &VgdpCounter{
 				allowedQueueLength: 1,
 				pvrState:           dynamicQueueLength{0, 1},
 			},
@@ -111,7 +111,7 @@ func TestIsConstrained(t *testing.T) {
 		},
 		{
 			name: "change in du, pvb, not constrained",
-			counter: VgdpCounter{
+			counter: &VgdpCounter{
 				allowedQueueLength: 3,
 				duState:            dynamicQueueLength{0, 1},
 				pvbState:           dynamicQueueLength{0, 1},
@@ -123,7 +123,7 @@ func TestIsConstrained(t *testing.T) {
 		},
 		{
 			name: "change in dd, pvr, constrained",
-			counter: VgdpCounter{
+			counter: &VgdpCounter{
 				allowedQueueLength: 1,
 				ddState:            dynamicQueueLength{0, 1},
 				pvrState:           dynamicQueueLength{0, 1},


### PR DESCRIPTION
Fixes #10429

`VgdpCounter` is shared by four controllers — `pkg/cmd/cli/nodeagent/server.go:351` builds one instance and passes the same pointer to the PodVolumeBackup (`:399`), PodVolumeRestore (`:420`), DataUpload (`:444`) and DataDownload (`:473`) reconcilers, each of which runs its own worker goroutine and calls `IsConstrained` on it.

`IsConstrained` reads the four `*State.changeID` fields with `atomic.LoadUint64`, but read-modify-writes the four `*CacheState` mirrors, and sums them at the end, with nothing protecting them. Half of the struct is synchronized and half is not.

Beyond being a reported data race, the refresh is gated on the cached `changeID` differing from the live one, so a bad interleaving latches a stale queue length: the node-agent then either refuses to start new exposes until an unrelated CR changes phase, or admits past the configured `prepareQueueLength`. The full sequence is in the issue.

## The change

A `sync.Mutex` on the counter, held across the body of `IsConstrained`. The four `List` calls inside it are served from the informer cache rather than the API server, so holding the lock across them is cheap — and it is the only shape that closes the stale-write ordering. Guarding just the field assignments would still let two goroutines list concurrently and clobber each other's results.

Adding a mutex to the struct meant the existing `TestIsConstrained` table could no longer hold `VgdpCounter` by value, since `for _, test := range tests` copied the lock:

```
$ go vet -copylocks ./pkg/exposer/
vgdp_counter_test.go:139:9: range var test copies lock: ... contains sync.Mutex
```

The table now holds `*VgdpCounter`. Nothing else in the existing cases changed. Note that `copylocks` is not in `hack/test.sh`'s vet allow-list and `.golangci.yaml` runs govet with only `atomicalign`, so this was not failing CI — it is fixed because copying the lock would be wrong, not because the pipeline asked.

## On the regression test

`hack/test.sh:46` runs `go test` without `-race`, so a test that only trips the race detector would never be exercised by CI. `TestIsConstrainedConcurrent` therefore wraps the client with a probe that records whether two `List` calls are ever in flight simultaneously and asserts the maximum observed is one. That makes the property deterministic under the command CI actually runs:

```
$ go test ./pkg/exposer/ -run TestIsConstrainedConcurrent   # with the mutex removed
--- FAIL: TestIsConstrainedConcurrent (0.25s)
        	expected: 1
        	actual  : 4
        	Messages:   	IsConstrained ran concurrently on a shared counter
```

With the fix in place it passes, and under `-race` the same test additionally surfaces the underlying races at `vgdp_counter.go:177`, `:178` and `:223`. `IsConstrained` is at 100% statement coverage.

## Open questions for the reviewer

1. I have kept `-race` out of `hack/test.sh` deliberately — it is a repo-wide change and belongs in its own PR if wanted. The test above is written so it does not depend on that decision, but if you would rather CI ran `-race`, say so and I will open it separately.
2. The `*State` half keeps its atomics; only the cache mirrors move under the lock. If you would prefer the whole counter converge on one mechanism, that is a slightly larger diff and I am happy to do it.

## Scope

Only reachable when the node-agent configmap sets `loadConcurrency.prepareQueueLength > 0`, since `StartVgdpCounter` is otherwise never called. A default installation does not construct the counter.
