### PR TITLE
Show default volume snapshot location in snapshot-location get output

### DIFF
--- a/changelogs/unreleased/10432-PranjalManhgaye
+++ b/changelogs/unreleased/10432-PranjalManhgaye
@@ -1,0 +1,1 @@
+Show default volume snapshot location in snapshot-location get output

--- a/pkg/cmd/cli/snapshotlocation/get.go
+++ b/pkg/cmd/cli/snapshotlocation/get.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/cmd"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
 	"github.com/vmware-tanzu/velero/pkg/cmd/util/output"
+	"github.com/vmware-tanzu/velero/pkg/cmd/util/serverconfig"
 )
 
 func NewGetCommand(f client.Factory, use string) *cobra.Command {
@@ -53,7 +54,12 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 				err = client.List(context.TODO(), locations, &kbclient.ListOptions{Namespace: f.Namespace()})
 				cmd.CheckError(err)
 			}
-			_, err = output.PrintWithFormat(c, locations)
+			kubeClient, err := f.KubeClient()
+			cmd.CheckError(err)
+
+			defaultLocations := serverconfig.GetDefaultVolumeSnapshotLocations(context.TODO(), kubeClient, f.Namespace())
+
+			_, err = output.PrintWithFormat(c, locations, output.WithDefaultVolumeSnapshotLocations(defaultLocations))
 			cmd.CheckError(err)
 		},
 	}

--- a/pkg/cmd/cli/snapshotlocation/get_test.go
+++ b/pkg/cmd/cli/snapshotlocation/get_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshotlocation
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/client-go/kubernetes/fake"
+
+	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
+	cmdtest "github.com/vmware-tanzu/velero/pkg/cmd/test"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
+)
+
+func TestNewGetCommand(t *testing.T) {
+	vslList := []string{"v1", "v2"}
+
+	f := &factorymocks.Factory{}
+	kbclient := velerotest.NewFakeControllerRuntimeClient(t)
+	f.On("Namespace").Return(mock.Anything)
+	f.On("KubebuilderClient").Return(kbclient, nil)
+	f.On("KubeClient").Return(fake.NewSimpleClientset(), nil)
+
+	c := NewGetCommand(f, "velero snapshot-location get")
+	assert.Equal(t, "Get snapshot locations", c.Short)
+
+	c.Execute()
+
+	if os.Getenv(cmdtest.CaptureFlag) == "1" {
+		c.SetArgs([]string{"v1", "v2"})
+		c.Execute()
+		return
+	}
+	cmd := exec.CommandContext(t.Context(), os.Args[0], []string{"-test.run=TestNewGetCommand"}...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=1", cmdtest.CaptureFlag))
+	_, stderr, err := veleroexec.RunCommand(cmd)
+
+	if err != nil {
+		assert.Contains(t, stderr, fmt.Sprintf("volumesnapshotlocations.velero.io \"%s\" not found", vslList[0]))
+		return
+	}
+	t.Fatalf("process ran with err %v, want snapshot location get to fail on missing resources", err)
+}

--- a/pkg/cmd/util/output/output.go
+++ b/pkg/cmd/util/output/output.go
@@ -34,6 +34,21 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/encode"
 )
 
+type printConfig struct {
+	defaultVolumeSnapshotLocations map[string]string
+}
+
+// PrintOption configures table printing behavior.
+type PrintOption func(*printConfig)
+
+// WithDefaultVolumeSnapshotLocations sets the Velero server default volume snapshot
+// locations used when printing VolumeSnapshotLocation tables.
+func WithDefaultVolumeSnapshotLocations(locations map[string]string) PrintOption {
+	return func(cfg *printConfig) {
+		cfg.defaultVolumeSnapshotLocations = locations
+	}
+}
+
 const (
 	downloadRequestTimeout = 30 * time.Second
 	emptyDisplay           = "<none>"
@@ -110,15 +125,20 @@ func validateOutputFlag(cmd *cobra.Command) error {
 
 // PrintWithFormat prints the provided object in the format specified by
 // the command's flags.
-func PrintWithFormat(c *cobra.Command, obj runtime.Object) (bool, error) {
+func PrintWithFormat(c *cobra.Command, obj runtime.Object, opts ...PrintOption) (bool, error) {
 	format := GetOutputFlagValue(c)
 	if format == "" {
 		return false, nil
 	}
 
+	printCfg := printConfig{}
+	for _, opt := range opts {
+		opt(&printCfg)
+	}
+
 	switch format {
 	case "table":
-		return printTable(c, obj)
+		return printTable(c, obj, printCfg)
 	case "json", "yaml":
 		return printEncoded(obj, format)
 	}
@@ -148,7 +168,7 @@ func printEncoded(obj runtime.Object, format string) (bool, error) {
 	return true, nil
 }
 
-func printTable(cmd *cobra.Command, obj runtime.Object) (bool, error) {
+func printTable(cmd *cobra.Command, obj runtime.Object, printCfg printConfig) (bool, error) {
 	// 1. generate table
 	var table *metav1.Table
 
@@ -206,12 +226,12 @@ func printTable(cmd *cobra.Command, obj runtime.Object) (bool, error) {
 	case *velerov1api.VolumeSnapshotLocation:
 		table = &metav1.Table{
 			ColumnDefinitions: volumeSnapshotLocationColumns,
-			Rows:              printVolumeSnapshotLocation(objType),
+			Rows:              printVolumeSnapshotLocation(objType, printCfg.defaultVolumeSnapshotLocations),
 		}
 	case *velerov1api.VolumeSnapshotLocationList:
 		table = &metav1.Table{
 			ColumnDefinitions: volumeSnapshotLocationColumns,
-			Rows:              printVolumeSnapshotLocationList(objType),
+			Rows:              printVolumeSnapshotLocationList(objType, printCfg.defaultVolumeSnapshotLocations),
 		}
 	case *velerov1api.ServerStatusRequest:
 		table = &metav1.Table{

--- a/pkg/cmd/util/output/print_option_test.go
+++ b/pkg/cmd/util/output/print_option_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+)
+
+func TestPrintWithFormatVolumeSnapshotLocationDefaultLocations(t *testing.T) {
+	t.Parallel()
+
+	cmd := cmdWithFormat("get", "table")
+	location := &velerov1api.VolumeSnapshotLocation{
+		ObjectMeta: metav1.ObjectMeta{Name: "aws-default"},
+		Spec: velerov1api.VolumeSnapshotLocationSpec{
+			Provider: "aws",
+		},
+	}
+
+	printed, err := PrintWithFormat(cmd, location, WithDefaultVolumeSnapshotLocations(map[string]string{
+		"aws": "aws-default",
+	}))
+	require.NoError(t, err)
+	assert.True(t, printed)
+}
+
+func TestPrintWithFormatVolumeSnapshotLocationListDefaultLocations(t *testing.T) {
+	t.Parallel()
+
+	cmd := cmdWithFormat("get", "table")
+	list := &velerov1api.VolumeSnapshotLocationList{
+		Items: []velerov1api.VolumeSnapshotLocation{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "aws-default"},
+				Spec: velerov1api.VolumeSnapshotLocationSpec{
+					Provider: "aws",
+				},
+			},
+		},
+	}
+
+	printed, err := PrintWithFormat(cmd, list, WithDefaultVolumeSnapshotLocations(map[string]string{
+		"aws": "aws-default",
+	}))
+	require.NoError(t, err)
+	assert.True(t, printed)
+}

--- a/pkg/cmd/util/output/volume_snapshot_location_printer.go
+++ b/pkg/cmd/util/output/volume_snapshot_location_printer.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/cmd"
 )
 
 var (
@@ -29,26 +30,33 @@ var (
 		// https://github.com/kubernetes/kubernetes/blob/v1.15.3/pkg/printers/tableprinter.go#L204
 		{Name: "Name", Type: "string", Format: "name"},
 		{Name: "Provider"},
+		{Name: "Default"},
 	}
 )
 
-func printVolumeSnapshotLocationList(list *v1.VolumeSnapshotLocationList) []metav1.TableRow {
+func printVolumeSnapshotLocationList(list *v1.VolumeSnapshotLocationList, defaultLocations map[string]string) []metav1.TableRow {
 	rows := make([]metav1.TableRow, 0, len(list.Items))
 
 	for i := range list.Items {
-		rows = append(rows, printVolumeSnapshotLocation(&list.Items[i])...)
+		rows = append(rows, printVolumeSnapshotLocation(&list.Items[i], defaultLocations)...)
 	}
 	return rows
 }
 
-func printVolumeSnapshotLocation(location *v1.VolumeSnapshotLocation) []metav1.TableRow {
+func printVolumeSnapshotLocation(location *v1.VolumeSnapshotLocation, defaultLocations map[string]string) []metav1.TableRow {
 	row := metav1.TableRow{
 		Object: runtime.RawExtension{Object: location},
+	}
+
+	isDefault := ""
+	if defaultLocation, ok := defaultLocations[location.Spec.Provider]; ok && defaultLocation == location.Name {
+		isDefault = cmd.TRUE
 	}
 
 	row.Cells = append(row.Cells,
 		location.Name,
 		location.Spec.Provider,
+		isDefault,
 	)
 
 	return []metav1.TableRow{row}

--- a/pkg/cmd/util/output/volume_snapshot_location_printer_test.go
+++ b/pkg/cmd/util/output/volume_snapshot_location_printer_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
+	"github.com/vmware-tanzu/velero/pkg/cmd"
+)
+
+func TestPrintVolumeSnapshotLocationDefaultColumn(t *testing.T) {
+	t.Parallel()
+
+	location := builder.ForVolumeSnapshotLocation("velero", "aws-default").
+		Provider("aws").
+		Result()
+
+	defaultLocations := map[string]string{
+		"aws": "aws-default",
+		"gcp": "gcp-default",
+	}
+
+	rows := printVolumeSnapshotLocation(location, defaultLocations)
+	require.Len(t, rows, 1)
+	require.Len(t, rows[0].Cells, len(volumeSnapshotLocationColumns))
+
+	assert.Equal(t, "aws-default", rows[0].Cells[0])
+	assert.Equal(t, "aws", rows[0].Cells[1])
+	assert.Equal(t, cmd.TRUE, rows[0].Cells[2])
+}
+
+func TestPrintVolumeSnapshotLocationDefaultColumnNotDefault(t *testing.T) {
+	t.Parallel()
+
+	location := builder.ForVolumeSnapshotLocation("velero", "aws-secondary").
+		Provider("aws").
+		Result()
+
+	defaultLocations := map[string]string{
+		"aws": "aws-default",
+	}
+
+	rows := printVolumeSnapshotLocation(location, defaultLocations)
+	require.Len(t, rows, 1)
+
+	assert.Empty(t, rows[0].Cells[2])
+}
+
+func TestPrintVolumeSnapshotLocationDefaultColumnUnknownProvider(t *testing.T) {
+	t.Parallel()
+
+	location := builder.ForVolumeSnapshotLocation("velero", "portworx-default").
+		Provider("portworx").
+		Result()
+
+	rows := printVolumeSnapshotLocation(location, map[string]string{"aws": "aws-default"})
+	require.Len(t, rows, 1)
+
+	assert.Empty(t, rows[0].Cells[2])
+}
+
+func TestPrintVolumeSnapshotLocationListWithNilDefaults(t *testing.T) {
+	t.Parallel()
+
+	list := &velerov1api.VolumeSnapshotLocationList{
+		Items: []velerov1api.VolumeSnapshotLocation{
+			*builder.ForVolumeSnapshotLocation("velero", "default").Provider("aws").Result(),
+		},
+	}
+
+	rows := printVolumeSnapshotLocationList(list, nil)
+	require.Len(t, rows, 1)
+	assert.Empty(t, rows[0].Cells[2])
+}

--- a/pkg/cmd/util/serverconfig/deployment.go
+++ b/pkg/cmd/util/serverconfig/deployment.go
@@ -1,0 +1,126 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serverconfig
+
+import (
+	"context"
+	"errors"
+
+	"github.com/spf13/pflag"
+	appsv1api "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/vmware-tanzu/velero/pkg/cmd/server/config"
+	"github.com/vmware-tanzu/velero/pkg/install"
+)
+
+var errVeleroDeploymentNotFound = errors.New("velero deployment not found")
+
+// GetDefaultVolumeSnapshotLocations returns the Velero server's
+// --default-volume-snapshot-locations map (provider -> location name).
+// If the deployment cannot be read or parsed, an empty map is returned.
+func GetDefaultVolumeSnapshotLocations(ctx context.Context, kubeClient kubernetes.Interface, namespace string) map[string]string {
+	if kubeClient == nil {
+		return map[string]string{}
+	}
+
+	serverConfig, ok := getServerConfig(ctx, kubeClient, namespace)
+	if !ok {
+		return map[string]string{}
+	}
+
+	locations := serverConfig.DefaultVolumeSnapshotLocations.Data()
+	if locations == nil {
+		return map[string]string{}
+	}
+
+	return locations
+}
+
+func getServerConfig(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (*config.Config, bool) {
+	deployment, err := veleroDeployment(ctx, kubeClient, namespace)
+	if err != nil {
+		return nil, false
+	}
+
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name != "velero" {
+			continue
+		}
+
+		serverConfig, err := parseServerArgs(container.Args)
+		if err != nil {
+			return nil, false
+		}
+
+		return serverConfig, true
+	}
+
+	return nil, false
+}
+
+func veleroDeployment(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (*appsv1api.Deployment, error) {
+	veleroLabels := labels.FormatLabels(install.Labels())
+
+	deployList, err := kubeClient.
+		AppsV1().
+		Deployments(namespace).
+		List(ctx, metav1.ListOptions{
+			LabelSelector: veleroLabels,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range deployList.Items {
+		deploy := &deployList.Items[i]
+		for _, container := range deploy.Spec.Template.Spec.Containers {
+			if container.Name == "velero" {
+				return deploy, nil
+			}
+		}
+	}
+
+	return nil, errVeleroDeploymentNotFound
+}
+
+func parseServerArgs(args []string) (*config.Config, error) {
+	cfg := config.GetDefaultConfig()
+	fs := pflag.NewFlagSet("server", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	cfg.BindFlags(fs)
+
+	serverIndex := -1
+	for i, arg := range args {
+		if arg == "server" {
+			serverIndex = i
+			break
+		}
+	}
+
+	if serverIndex < 0 {
+		return cfg, nil
+	}
+
+	if err := fs.Parse(args[serverIndex+1:]); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}

--- a/pkg/cmd/util/serverconfig/deployment_test.go
+++ b/pkg/cmd/util/serverconfig/deployment_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serverconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1api "k8s.io/api/apps/v1"
+	corev1api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/vmware-tanzu/velero/pkg/install"
+)
+
+func TestParseServerArgsDefaultVolumeSnapshotLocations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no server subcommand returns empty defaults", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := parseServerArgs([]string{"--log-level", "debug"})
+		require.NoError(t, err)
+		assert.Empty(t, cfg.DefaultVolumeSnapshotLocations.Data())
+	})
+
+	t.Run("custom default-volume-snapshot-locations", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := parseServerArgs([]string{"server", "--default-volume-snapshot-locations", "aws:my-aws-location,gcp:my-gcp-location"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"aws": "my-aws-location",
+			"gcp": "my-gcp-location",
+		}, cfg.DefaultVolumeSnapshotLocations.Data())
+	})
+
+	t.Run("unknown flags are ignored", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := parseServerArgs([]string{"server", "--unknown-flag", "value", "--default-volume-snapshot-locations", "azure:default"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"azure": "default"}, cfg.DefaultVolumeSnapshotLocations.Data())
+	})
+}
+
+func TestGetDefaultVolumeSnapshotLocationsFallback(t *testing.T) {
+	t.Parallel()
+
+	locations := GetDefaultVolumeSnapshotLocations(t.Context(), nil, "velero")
+	assert.Empty(t, locations)
+}
+
+func TestGetDefaultVolumeSnapshotLocationsFromDeployment(t *testing.T) {
+	t.Parallel()
+
+	deployment := &appsv1api.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "velero",
+			Name:      "velero",
+			Labels:    install.Labels(),
+		},
+		Spec: appsv1api.DeploymentSpec{
+			Template: corev1api.PodTemplateSpec{
+				Spec: corev1api.PodSpec{
+					Containers: []corev1api.Container{{
+						Name: "velero",
+						Args: []string{"server", "--default-volume-snapshot-locations", "aws:my-aws,gcp:my-gcp"},
+					}},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment)
+	locations := GetDefaultVolumeSnapshotLocations(t.Context(), clientset, "velero")
+	assert.Equal(t, map[string]string{
+		"aws": "my-aws",
+		"gcp": "my-gcp",
+	}, locations)
+}
+
+func TestGetDefaultVolumeSnapshotLocationsNoDeployment(t *testing.T) {
+	t.Parallel()
+
+	clientset := fake.NewSimpleClientset()
+	assert.Empty(t, GetDefaultVolumeSnapshotLocations(t.Context(), clientset, "velero"))
+}
+
+func TestGetDefaultVolumeSnapshotLocationsNoVeleroContainer(t *testing.T) {
+	t.Parallel()
+
+	deployment := &appsv1api.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "velero",
+			Name:      "velero",
+			Labels:    install.Labels(),
+		},
+		Spec: appsv1api.DeploymentSpec{
+			Template: corev1api.PodTemplateSpec{
+				Spec: corev1api.PodSpec{
+					Containers: []corev1api.Container{{
+						Name: "not-velero",
+						Args: []string{"server", "--default-volume-snapshot-locations", "aws:my-aws"},
+					}},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment)
+	assert.Empty(t, GetDefaultVolumeSnapshotLocations(t.Context(), clientset, "velero"))
+}


### PR DESCRIPTION
Fixes #3099

## Summary
- Adds a **Default** column to `velero snapshot-location get` table output
- Marks a location as default when its name matches the Velero server's `--default-volume-snapshot-locations` entry for that provider
- Reads server defaults from the Velero deployment (falls back to empty when unavailable)

## Test plan
- [x] Unit tests for VSL default column rendering
- [x] Unit tests for parsing `--default-volume-snapshot-locations` from server args
- [x] `go test ./pkg/cmd/util/output/... ./pkg/cmd/util/serverconfig/...`