### PR TITLE
fix(controller): fix controller test suite failure on local environments and modernize Ginkgo v2 syntax

### DIFF
--- a/changelogs/unreleased/10434-opbot-xd
+++ b/changelogs/unreleased/10434-opbot-xd
@@ -1,0 +1,1 @@
+Fix controller test suite failure on local developer environments and modernize Ginkgo v2 suite setup

--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -28,10 +27,6 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/persistence"
 	persistencemocks "github.com/vmware-tanzu/velero/pkg/persistence/mocks"
 
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -39,9 +34,6 @@ import (
 	velerov2alpha1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -52,9 +44,7 @@ const (
 )
 
 var (
-	env         *envtest.Environment
-	testEnv     *testEnvironment
-	ctx, cancel = context.WithCancel(context.Background())
+	ctx = context.Background()
 )
 
 func TestAPIs(t *testing.T) {
@@ -62,77 +52,11 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "Controller Suite")
 }
 
-var _ = BeforeSuite(func(done Done) {
-	By("bootstrapping test environment")
-	testEnv = newTestEnvironment()
-
-	By("starting the manager")
-	go func() {
-		defer GinkgoRecover()
-		Expect(testEnv.startManager()).To(Succeed())
-	}()
-
-	close(done)
+var _ = BeforeSuite(func() {
+	By("registering API schemes")
+	Expect(velerov1api.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(velerov2alpha1api.AddToScheme(scheme.Scheme)).To(Succeed())
 })
-
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	err := testEnv.stop()
-	Expect(err).ToNot(HaveOccurred())
-})
-
-// testEnvironment encapsulates a Kubernetes local test environment.
-type testEnvironment struct {
-	manager.Manager
-	client.Client
-	Config *rest.Config
-
-	doneMgr context.Context
-}
-
-// newTestEnvironment creates a new environment spinning up a local api-server.
-//
-// This function should be called only once for each package you're running tests within,
-// usually the environment is initialized in a suite_test.go file within a `BeforeSuite` ginkgo block.
-func newTestEnvironment() *testEnvironment {
-	// scheme.Scheme is initialized with all native Kubernetes types
-	err := velerov1api.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = velerov2alpha1api.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	env = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
-	}
-
-	if _, err := env.Start(); err != nil {
-		panic(err)
-	}
-
-	mgr, err := manager.New(env.Config, manager.Options{
-		Scheme: scheme.Scheme,
-	})
-	if err != nil {
-		klog.Fatalf("Failed to start testenv manager: %v", err)
-	}
-
-	return &testEnvironment{
-		Manager: mgr,
-		Client:  mgr.GetClient(),
-		Config:  mgr.GetConfig(),
-		doneMgr: ctx,
-	}
-}
-
-func (t *testEnvironment) startManager() error {
-	return t.Manager.Start(t.doneMgr)
-}
-
-func (t *testEnvironment) stop() error {
-	cancel()
-	return env.Stop()
-}
 
 type fakeErrorBackupStoreGetter struct {
 }


### PR DESCRIPTION
# Please add a summary of your change

Running unit tests locally via `go test ./pkg/controller/...` previously failed with a panic during `BeforeSuite`:
```
[PANICKED] Test Panicked
In [BeforeSuite] at: pkg/controller/suite_test.go:110

unable to start control plane itself: failed to start the controlplane: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory
```

This occurred because `pkg/controller/suite_test.go` unconditionally attempted to start an `envtest.Environment` control plane pointing to a non-existent CRD directory, even though all tests in `pkg/controller` use in-memory fake clients (`fake.NewClientBuilder()`) and do not utilize `testEnv`. Additionally, `suite_test.go` used the deprecated Ginkgo v1 `Done` channel syntax (`BeforeSuite(func(done Done))`), triggering Ginkgo v2 deprecation warnings.

This PR:
1. Modernizes `pkg/controller/suite_test.go` to standard Ginkgo v2 suite syntax (`BeforeSuite(func())`).
2. Removes the redundant `envtest` control-plane startup and manager boilerplate that blocked local developer test execution.
3. Retains API scheme registration (`velerov1api`, `velerov2alpha1api`), shared package context, and mock persistence getters.
4. Allows developers to execute `go test ./pkg/controller/...` locally without requiring containerized kubebuilder assets.

# Does your change fix a particular issue?

Fixes #10433

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.