### PR TITLE
Add printer columns for BackupStorageLocation provider and access mode

### DIFF
--- a/changelogs/unreleased/10441-Ralthos
+++ b/changelogs/unreleased/10441-Ralthos
@@ -1,0 +1,1 @@
+Add printer columns for BackupStorageLocation so kubectl shows provider and access mode

--- a/config/crd/v1/bases/velero.io_backupstoragelocations.yaml
+++ b/config/crd/v1/bases/velero.io_backupstoragelocations.yaml
@@ -17,6 +17,10 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - description: Provider is the provider of the backup storage
+      jsonPath: .spec.provider
+      name: Provider
+      type: string
     - description: Backup Storage Location status such as Available/Unavailable
       jsonPath: .status.phase
       name: Phase
@@ -26,6 +30,10 @@ spec:
       jsonPath: .status.lastValidationTime
       name: Last Validated
       type: date
+    - description: AccessMode defines the permissions for the backup storage location
+      jsonPath: .spec.accessMode
+      name: Access Mode
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/pkg/apis/velero/v1/backupstoragelocation_types.go
+++ b/pkg/apis/velero/v1/backupstoragelocation_types.go
@@ -104,8 +104,10 @@ type BackupStorageLocationStatus struct {
 // +kubebuilder:resource:shortName=bsl
 // +kubebuilder:object:generate=true
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="Provider",type="string",JSONPath=".spec.provider",description="Provider is the provider of the backup storage"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Backup Storage Location status such as Available/Unavailable"
 // +kubebuilder:printcolumn:name="Last Validated",type="date",JSONPath=".status.lastValidationTime",description="LastValidationTime is the last time the backup store location was validated"
+// +kubebuilder:printcolumn:name="Access Mode",type="string",JSONPath=".spec.accessMode",description="AccessMode defines the permissions for the backup storage location"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Default",type="boolean",JSONPath=".spec.default",description="Default backup storage location"
 


### PR DESCRIPTION
## Summary

`velero backup-location get` shows Provider and Access Mode. `kubectl get backupstoragelocations`
shows neither: the CRD's printer columns are Phase, Last Validated, Age and Default.

Access Mode is the gap worth closing. A location with `spec.accessMode: ReadOnly` still reports
`status.phase: Available`, so `kubectl get bsl` shows a healthy row for a location that cannot
take new backups.

This adds printer columns for `.spec.provider` and `.spec.accessMode`, placed to match the order
in `pkg/cmd/util/output/backup_storage_location_printer.go`, which reads those same two spec
fields. VolumeSnapshotLocation exposes Provider the same way.

## Changes

- two `+kubebuilder:printcolumn` markers on `BackupStorageLocation`
- regenerated `config/crd/v1/bases/velero.io_backupstoragelocations.yaml`

## One caveat

`spec.accessMode` has no default marker, so the column is blank for locations that never set it.
The CLI avoids this by substituting `ReadWrite` inside its own printer, which a CRD column cannot
do. `velero backup-location create` defaults the flag to `ReadWrite`, so locations created
through the CLI carry the value.

## Testing

Regenerated with the pinned `controller-gen@v0.16.5` from `hack/build-image/Dockerfile`. The
generated diff is limited to the one CRD file, with no churn elsewhere under `config/crd`.
`gofmt` is clean. I have not exercised this against a live cluster.
