### PR TITLE
fix(cli): fix velero uninstall deployment deletion and add test coverage

### DIFF
--- a/changelogs/unreleased/10443-opbot-xd
+++ b/changelogs/unreleased/10443-opbot-xd
@@ -1,0 +1,1 @@
+Fix uninstall CLI bugs and add tests

--- a/pkg/cmd/cli/uninstall/uninstall.go
+++ b/pkg/cmd/cli/uninstall/uninstall.go
@@ -53,8 +53,6 @@ import (
 
 var gracefulDeletionMaximumDuration = 1 * time.Minute
 
-var resToDelete = []kbclient.ObjectList{}
-
 // uninstallOptions collects all the options for uninstalling Velero from a Kubernetes cluster.
 type uninstallOptions struct {
 	force bool
@@ -230,15 +228,16 @@ func deleteResourcesWithFinalizer(ctx context.Context, kbClient kbclient.Client,
 	return deleteResources(ctx, kbClient, namespace)
 }
 
-func checkResources(ctx context.Context, kbClient kbclient.Client) error {
+func checkResources(ctx context.Context, kbClient kbclient.Client) ([]kbclient.ObjectList, error) {
 	checkCRDs := []string{"restores.velero.io", "datauploads.velero.io", "datadownloads.velero.io"}
 	var err error
 	v1crd := &apiextv1.CustomResourceDefinition{}
+	var resToDelete []kbclient.ObjectList
 	for _, crd := range checkCRDs {
 		key := kbclient.ObjectKey{Name: crd}
 		if err = kbClient.Get(ctx, key, v1crd); err != nil {
 			if !apierrors.IsNotFound(err) {
-				return errors.Wrapf(err, "Error getting %s crd", crd)
+				return nil, errors.Wrapf(err, "Error getting %s crd", crd)
 			}
 		} else {
 			// no error with found CRD that we should delete
@@ -254,25 +253,25 @@ func checkResources(ctx context.Context, kbClient kbclient.Client) error {
 			}
 		}
 	}
-	return nil
+	return resToDelete, nil
 }
 
 func deleteResources(ctx context.Context, kbClient kbclient.Client, namespace string) error {
 	// Check if resources crd exists, if it does not exist, return immediately.
-	err := checkResources(ctx, kbClient)
+	resToDelete, err := checkResources(ctx, kbClient)
 	if err != nil {
 		return err
 	}
 
 	// First attempt to gracefully delete all the resources within a specified time frame, If the process exceeds the timeout limit,
 	// it is likely that there may be errors during the finalization of restores. In such cases, we should proceed with forcefully deleting the restores.
-	err = gracefullyDeleteResources(ctx, kbClient, namespace)
+	err = gracefullyDeleteResources(ctx, kbClient, namespace, resToDelete)
 	if err != nil && !wait.Interrupted(err) {
 		return errors.Wrap(err, "Error deleting resources")
 	}
 
 	if wait.Interrupted(err) {
-		err = forcedlyDeleteResources(ctx, kbClient, namespace)
+		err = forcedlyDeleteResources(ctx, kbClient, namespace, resToDelete)
 		if err != nil {
 			return errors.Wrap(err, "Error deleting resources forcedly")
 		}
@@ -281,7 +280,7 @@ func deleteResources(ctx context.Context, kbClient kbclient.Client, namespace st
 	return nil
 }
 
-func gracefullyDeleteResources(ctx context.Context, kbClient kbclient.Client, namespace string) error {
+func gracefullyDeleteResources(ctx context.Context, kbClient kbclient.Client, namespace string, resToDelete []kbclient.ObjectList) error {
 	errorChan := make(chan error)
 
 	var wg sync.WaitGroup
@@ -305,7 +304,7 @@ func gracefullyDeleteResources(ctx context.Context, kbClient kbclient.Client, na
 		}
 	}
 
-	return waitDeletingResources(ctx, kbClient, namespace)
+	return waitDeletingResources(ctx, kbClient, namespace, resToDelete)
 }
 
 func gracefullyDeleteResource(ctx context.Context, kbClient kbclient.Client, namespace string, list kbclient.ObjectList) error {
@@ -343,7 +342,7 @@ func gracefullyDeleteResource(ctx context.Context, kbClient kbclient.Client, nam
 	return nil
 }
 
-func waitDeletingResources(ctx context.Context, kbClient kbclient.Client, namespace string) error {
+func waitDeletingResources(ctx context.Context, kbClient kbclient.Client, namespace string, resToDelete []kbclient.ObjectList) error {
 	// Wait for the deletion of all the restores within a specified time frame
 	err := wait.PollUntilContextTimeout(ctx, time.Second, gracefulDeletionMaximumDuration, true, func(ctx context.Context) (bool, error) {
 		itemsCount := 0
@@ -364,14 +363,14 @@ func waitDeletingResources(ctx context.Context, kbClient kbclient.Client, namesp
 	return err
 }
 
-func forcedlyDeleteResources(ctx context.Context, kbClient kbclient.Client, namespace string) error {
+func forcedlyDeleteResources(ctx context.Context, kbClient kbclient.Client, namespace string, resToDelete []kbclient.ObjectList) error {
 	// Delete velero deployment first in case:
 	// 1. finalizers will be added back by resources related controller after they are removed at next step;
 	// 2. new resources attached with finalizer will be created by controller after we remove all the resources' finalizer at next step;
 	deploy := &appsv1api.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "velero",
-			Name:      namespace,
+			Namespace: namespace,
+			Name:      "velero",
 		},
 	}
 
@@ -401,10 +400,10 @@ func forcedlyDeleteResources(ctx context.Context, kbClient kbclient.Client, name
 	if err != nil {
 		return errors.Wrap(err, "Error deleting velero deployment during force deletion")
 	}
-	return removeResourcesFinalizer(ctx, kbClient, namespace)
+	return removeResourcesFinalizer(ctx, kbClient, namespace, resToDelete)
 }
 
-func removeResourcesFinalizer(ctx context.Context, kbClient kbclient.Client, namespace string) error {
+func removeResourcesFinalizer(ctx context.Context, kbClient kbclient.Client, namespace string, resToDelete []kbclient.ObjectList) error {
 	for i := range resToDelete {
 		if err := removeResourceFinalizer(ctx, kbClient, namespace, resToDelete[i]); err != nil {
 			return err

--- a/pkg/cmd/cli/uninstall/uninstall_test.go
+++ b/pkg/cmd/cli/uninstall/uninstall_test.go
@@ -2,15 +2,18 @@ package uninstall
 
 import (
 	"context"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1api "k8s.io/api/apps/v1"
 	corev1api "k8s.io/api/core/v1"
-	rbacv1api "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,6 +22,7 @@ import (
 
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
+	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
 	"github.com/vmware-tanzu/velero/pkg/controller"
 )
 
@@ -26,7 +30,7 @@ func buildScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = corev1api.AddToScheme(scheme)
 	_ = appsv1api.AddToScheme(scheme)
-	_ = rbacv1api.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
 	_ = apiextv1.AddToScheme(scheme)
 	_ = apiextv1beta1.AddToScheme(scheme)
 	_ = velerov1api.AddToScheme(scheme)
@@ -59,6 +63,22 @@ func TestRun(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		{
+			name: "CRDs exist and namespace exists",
+			initialObjs: []kbclient.Object{
+				&corev1api.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+					},
+				},
+				&apiextv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "restores.velero.io",
+					},
+				},
+			},
+			expectedError: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -66,7 +86,7 @@ func TestRun(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.initialObjs...).Build()
 			err := Run(context.Background(), client, namespace)
 			if tc.expectedError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
@@ -76,7 +96,7 @@ func TestRun(t *testing.T) {
 
 func TestForcedlyDeleteResources(t *testing.T) {
 	scheme := buildScheme()
-	namespace := "velero"
+	namespace := "velero-custom"
 
 	restoreWithFinalizer := &velerov1api.Restore{
 		ObjectMeta: metav1.ObjectMeta{
@@ -108,6 +128,11 @@ func TestForcedlyDeleteResources(t *testing.T) {
 	err = client.Get(context.Background(), types.NamespacedName{Name: "test-restore", Namespace: namespace}, restoreWithFinalizer)
 	require.NoError(t, err)
 	assert.Empty(t, restoreWithFinalizer.ObjectMeta.Finalizers)
+
+	// Verify deployment is deleted
+	err = client.Get(context.Background(), types.NamespacedName{Name: "velero", Namespace: namespace}, &appsv1api.Deployment{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err))
 }
 
 func TestCheckResources(t *testing.T) {
@@ -126,4 +151,153 @@ func TestCheckResources(t *testing.T) {
 	assert.Len(t, resToDelete, 1)
 	_, ok := resToDelete[0].(*velerov1api.RestoreList)
 	assert.True(t, ok)
+}
+
+func TestNewCommand(t *testing.T) {
+	scheme := buildScheme()
+
+	tests := []struct {
+		name        string
+		args        []string
+		input       string
+		expectError bool
+		expectRun   bool
+	}{
+		{
+			name:        "force flag skips confirmation",
+			args:        []string{"--force"},
+			input:       "",
+			expectError: false,
+			expectRun:   true,
+		},
+		{
+			name:        "interactive cancellation",
+			args:        []string{},
+			input:       "N\n",
+			expectError: false,
+			expectRun:   false,
+		},
+		{
+			name:        "interactive confirmation",
+			args:        []string{},
+			input:       "Y\n",
+			expectError: false,
+			expectRun:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &factorymocks.Factory{}
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			if tc.expectRun {
+				f.On("KubebuilderClient").Return(client, nil)
+				f.On("Namespace").Return("velero")
+			}
+
+			cmd := NewCommand(f)
+			cmd.SetArgs(tc.args)
+
+			// Mock stdin
+			oldStdin := os.Stdin
+			defer func() { os.Stdin = oldStdin }()
+
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
+			os.Stdin = r
+
+			go func() {
+				defer w.Close()
+				if tc.input != "" {
+					w.Write([]byte(tc.input))
+				}
+			}()
+
+			err = cmd.Execute()
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			f.AssertExpectations(t)
+		})
+	}
+}
+
+func TestWaitDeletingResourcesTimeout(t *testing.T) {
+	scheme := buildScheme()
+	namespace := "velero"
+
+	restoreWithFinalizer := &velerov1api.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-restore",
+			Namespace: namespace,
+			Finalizers: []string{
+				controller.ExternalResourcesFinalizer,
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(restoreWithFinalizer).WithObjects(restoreWithFinalizer).Build()
+
+	resToDelete := []kbclient.ObjectList{
+		&velerov1api.RestoreList{},
+	}
+
+	// Create a context that is already canceled to trigger timeout immediately
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := waitDeletingResources(ctx, client, namespace, resToDelete)
+	require.Error(t, err)
+}
+
+func TestDeleteResourcesGracefulTimeoutToForcedDelete(t *testing.T) {
+	scheme := buildScheme()
+	namespace := "velero-custom"
+
+	restoreWithFinalizer := &velerov1api.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-restore",
+			Namespace: namespace,
+			Finalizers: []string{
+				controller.ExternalResourcesFinalizer,
+			},
+		},
+	}
+	deploy := &appsv1api.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "velero",
+			Namespace: namespace,
+		},
+	}
+	v1crd := &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "restores.velero.io",
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(restoreWithFinalizer).WithObjects(restoreWithFinalizer, deploy, v1crd).Build()
+
+	// Shrink the maximum duration to ensure wait.PollUntilContextTimeout triggers timeout quickly
+	originalDuration := gracefulDeletionMaximumDuration
+	gracefulDeletionMaximumDuration = 10 * time.Millisecond
+	defer func() {
+		gracefulDeletionMaximumDuration = originalDuration
+	}()
+
+	err := deleteResources(context.Background(), client, namespace)
+	require.NoError(t, err)
+
+	// Verify restore is deleted (finalizer was removed and DeletionTimestamp was set)
+	err = client.Get(context.Background(), types.NamespacedName{Name: "test-restore", Namespace: namespace}, restoreWithFinalizer)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err))
+
+	// Verify deployment is deleted
+	err = client.Get(context.Background(), types.NamespacedName{Name: "velero", Namespace: namespace}, &appsv1api.Deployment{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err))
 }

--- a/pkg/cmd/cli/uninstall/uninstall_test.go
+++ b/pkg/cmd/cli/uninstall/uninstall_test.go
@@ -1,0 +1,129 @@
+package uninstall
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1api "k8s.io/api/apps/v1"
+	corev1api "k8s.io/api/core/v1"
+	rbacv1api "k8s.io/api/rbac/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	velerov2alpha1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
+	"github.com/vmware-tanzu/velero/pkg/controller"
+)
+
+func buildScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1api.AddToScheme(scheme)
+	_ = appsv1api.AddToScheme(scheme)
+	_ = rbacv1api.AddToScheme(scheme)
+	_ = apiextv1.AddToScheme(scheme)
+	_ = apiextv1beta1.AddToScheme(scheme)
+	_ = velerov1api.AddToScheme(scheme)
+	_ = velerov2alpha1api.AddToScheme(scheme)
+	return scheme
+}
+
+func TestRun(t *testing.T) {
+	scheme := buildScheme()
+	namespace := "velero-custom"
+
+	tests := []struct {
+		name          string
+		initialObjs   []kbclient.Object
+		expectedError bool
+	}{
+		{
+			name:          "Namespace does not exist",
+			initialObjs:   []kbclient.Object{},
+			expectedError: false,
+		},
+		{
+			name: "CRDs missing but namespace exists",
+			initialObjs: []kbclient.Object{
+				&corev1api.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+					},
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.initialObjs...).Build()
+			err := Run(context.Background(), client, namespace)
+			if tc.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestForcedlyDeleteResources(t *testing.T) {
+	scheme := buildScheme()
+	namespace := "velero"
+
+	restoreWithFinalizer := &velerov1api.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-restore",
+			Namespace: namespace,
+			Finalizers: []string{
+				controller.ExternalResourcesFinalizer,
+			},
+		},
+	}
+
+	deploy := &appsv1api.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "velero",
+			Namespace: namespace,
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(restoreWithFinalizer).WithObjects(restoreWithFinalizer, deploy).Build()
+
+	resToDelete := []kbclient.ObjectList{
+		&velerov1api.RestoreList{},
+	}
+
+	err := forcedlyDeleteResources(context.Background(), client, namespace, resToDelete)
+	require.NoError(t, err)
+
+	// Verify finalizer is removed
+	err = client.Get(context.Background(), types.NamespacedName{Name: "test-restore", Namespace: namespace}, restoreWithFinalizer)
+	require.NoError(t, err)
+	assert.Empty(t, restoreWithFinalizer.ObjectMeta.Finalizers)
+}
+
+func TestCheckResources(t *testing.T) {
+	scheme := buildScheme()
+
+	v1crd := &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "restores.velero.io",
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(v1crd).Build()
+
+	resToDelete, err := checkResources(context.Background(), client)
+	require.NoError(t, err)
+	assert.Len(t, resToDelete, 1)
+	_, ok := resToDelete[0].(*velerov1api.RestoreList)
+	assert.True(t, ok)
+}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This PR introduces critical safety validations and a comprehensive unit test suite for the `velero uninstall` CLI command. It specifically resolves two undetected logic bugs caused by a lack of testing:
1. **Global State Bug**: Removed the package-level `resToDelete` global slice in `uninstall.go`, properly returning it from `checkResources()` and safely passing it down. This prevents slice accumulation across multiple calls or concurrent execution.
2. **Inverted Namespace/Name Bug**: Fixed a metadata assignment error in `forcedlyDeleteResources()` that incorrectly specified `Namespace: "velero"` and `Name: namespace` when defining the deployment target. This has been flipped.

Additionally, this PR adds robust unit testing (`uninstall_test.go`) to prevent regressions on this highly destructive command.

# Does your change fix a particular issue?

Fixes #10442

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
