### PR TITLE
Add a LastSkipped printer column to Schedule

### DIFF
--- a/changelogs/unreleased/10446-Ralthos
+++ b/changelogs/unreleased/10446-Ralthos
@@ -1,0 +1,1 @@
+Add a LastSkipped printer column to Schedule so kubectl shows when a scheduled backup was skipped

--- a/config/crd/v1/bases/velero.io_schedules.yaml
+++ b/config/crd/v1/bases/velero.io_schedules.yaml
@@ -29,6 +29,10 @@ spec:
       jsonPath: .status.lastBackup
       name: LastBackup
       type: date
+    - description: The last time a Backup was skipped for this schedule
+      jsonPath: .status.lastSkipped
+      name: LastSkipped
+      type: date
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/pkg/apis/velero/v1/schedule_types.go
+++ b/pkg/apis/velero/v1/schedule_types.go
@@ -102,6 +102,7 @@ type ScheduleStatus struct {
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="Status of the schedule"
 // +kubebuilder:printcolumn:name="Schedule",type="string",JSONPath=".spec.schedule",description="A Cron expression defining when to run the Backup"
 // +kubebuilder:printcolumn:name="LastBackup",type="date",JSONPath=".status.lastBackup",description="The last time a Backup was run for this schedule"
+// +kubebuilder:printcolumn:name="LastSkipped",type="date",JSONPath=".status.lastSkipped",description="The last time a Backup was skipped for this schedule"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Paused",type="boolean",JSONPath=".spec.paused"
 // +kubebuilder:resource:shortName=sched


### PR DESCRIPTION
## Summary

`ScheduleStatus.LastSkipped` records when a scheduled Backup was skipped. The controller writes
it in `pkg/controller/schedule_controller.go` and reads it back to advance the next due time, so it takes part in scheduling
decisions. Neither `kubectl get schedules` nor
`velero schedule get` shows it.

That makes a skipped Schedule hard to spot. The phase stays `Enabled`, `paused` stays false, and
`LastBackup` holds an old timestamp with nothing beside it to say why nothing newer arrived. The
operator sees a healthy row for a Schedule that has quietly stopped producing backups.

This adds a `LastSkipped` column next to `LastBackup`, since the two are read together.

## Changes

- one `+kubebuilder:printcolumn` marker on `Schedule`
- regenerated `config/crd/v1/bases/velero.io_schedules.yaml`

## Testing

Regenerated with the pinned `controller-gen@v0.16.5` from `hack/build-image/Dockerfile`. The
generated diff is four lines in the one CRD file, with no churn elsewhere under `config/crd`.
`gofmt` is clean. I have not exercised this against a live cluster.
