### PR TITLE
Fix snapshot-location get --selector flag to actually filter VolumeSnapshotLocations by label

### DIFF
--- a/changelogs/unreleased/10449-PratikMane0112
+++ b/changelogs/unreleased/10449-PratikMane0112
@@ -1,0 +1,1 @@
+Fix snapshot-location get --selector flag to actually filter VolumeSnapshotLocations by label

--- a/changelogs/unreleased/XXXX-PratikMane0112
+++ b/changelogs/unreleased/XXXX-PratikMane0112
@@ -1,1 +1,0 @@
-Fix snapshot-location get --selector flag to actually filter VolumeSnapshotLocations by label

--- a/changelogs/unreleased/XXXX-PratikMane0112
+++ b/changelogs/unreleased/XXXX-PratikMane0112
@@ -1,0 +1,1 @@
+Fix snapshot-location get --selector flag to actually filter VolumeSnapshotLocations by label

--- a/pkg/cmd/cli/snapshotlocation/get.go
+++ b/pkg/cmd/cli/snapshotlocation/get.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,7 +50,10 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 					locations.Items = append(locations.Items, *location)
 				}
 			} else {
-				err = client.List(context.TODO(), locations, &kbclient.ListOptions{Namespace: f.Namespace()})
+				err = client.List(context.TODO(), locations, &kbclient.ListOptions{
+					Namespace: f.Namespace(),
+					Raw:       &listOptions,
+				})
 				cmd.CheckError(err)
 			}
 			_, err = output.PrintWithFormat(c, locations)

--- a/pkg/cmd/cli/snapshotlocation/get.go
+++ b/pkg/cmd/cli/snapshotlocation/get.go
@@ -1,5 +1,5 @@
 /*
-Copyright the Velero contributors.
+Copyright 2018 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -50,9 +51,11 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 					locations.Items = append(locations.Items, *location)
 				}
 			} else {
+				parsedSelector, err := labels.Parse(listOptions.LabelSelector)
+				cmd.CheckError(err)
 				err = client.List(context.TODO(), locations, &kbclient.ListOptions{
-					Namespace: f.Namespace(),
-					Raw:       &listOptions,
+					LabelSelector: parsedSelector,
+					Namespace:     f.Namespace(),
 				})
 				cmd.CheckError(err)
 			}

--- a/pkg/cmd/cli/snapshotlocation/get_test.go
+++ b/pkg/cmd/cli/snapshotlocation/get_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshotlocation
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
+	cmdtest "github.com/vmware-tanzu/velero/pkg/cmd/test"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
+)
+
+func TestNewGetCommand(t *testing.T) {
+	vslList := []string{"vsl1", "vsl2"}
+
+	f := &factorymocks.Factory{}
+	kbclient := velerotest.NewFakeControllerRuntimeClient(t)
+	f.On("Namespace").Return(mock.Anything)
+	f.On("KubebuilderClient").Return(kbclient, nil)
+
+	// get command
+	c := NewGetCommand(f, "velero snapshot-location get")
+	assert.Equal(t, "Get snapshot locations", c.Short)
+
+	c.Execute()
+
+	if os.Getenv(cmdtest.CaptureFlag) == "1" {
+		c.SetArgs([]string{"vsl1", "vsl2"})
+		c.Execute()
+		return
+	}
+	cmd := exec.CommandContext(t.Context(), os.Args[0], []string{"-test.run=TestNewGetCommand"}...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=1", cmdtest.CaptureFlag))
+	_, stderr, err := veleroexec.RunCommand(cmd)
+
+	if err != nil {
+		assert.Contains(t, stderr, fmt.Sprintf("volumesnapshotlocations.velero.io \"%s\" not found", vslList[0]))
+		return
+	}
+	t.Fatalf("process ran with err %v, want snapshot location get to fail for non-existent VSL", err)
+}

--- a/pkg/cmd/cli/snapshotlocation/get_test.go
+++ b/pkg/cmd/cli/snapshotlocation/get_test.go
@@ -24,7 +24,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/vmware-tanzu/velero/pkg/builder"
 	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
 	cmdtest "github.com/vmware-tanzu/velero/pkg/cmd/test"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
@@ -59,4 +62,43 @@ func TestNewGetCommand(t *testing.T) {
 		return
 	}
 	t.Fatalf("process ran with err %v, want snapshot location get to fail for non-existent VSL", err)
+}
+
+func TestNewGetCommand_SelectorFiltersVSLs(t *testing.T) {
+	f := &factorymocks.Factory{}
+	client := velerotest.NewFakeControllerRuntimeClient(t)
+
+	vslLabeled := builder.ForVolumeSnapshotLocation(cmdtest.VeleroNameSpace, "vsl-labeled").
+		ObjectMeta(builder.WithLabels("env", "test")).
+		Result()
+	err := client.Create(t.Context(), vslLabeled, &kbclient.CreateOptions{})
+	require.NoError(t, err)
+
+	vslUnlabeled := builder.ForVolumeSnapshotLocation(cmdtest.VeleroNameSpace, "vsl-unlabeled").
+		Result()
+	err = client.Create(t.Context(), vslUnlabeled, &kbclient.CreateOptions{})
+	require.NoError(t, err)
+
+	f.On("KubebuilderClient").Return(client, nil)
+	f.On("Namespace").Return(cmdtest.VeleroNameSpace)
+
+	// get command with selector
+	c := NewGetCommand(f, "velero snapshot-location get")
+	c.SetArgs([]string{"--selector", "env=test"})
+	err = c.Execute()
+	require.NoError(t, err)
+
+	if os.Getenv(cmdtest.CaptureFlag) == "1" {
+		return
+	}
+
+	cmd := exec.CommandContext(t.Context(), os.Args[0], []string{"-test.run=TestNewGetCommand_SelectorFiltersVSLs"}...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=1", cmdtest.CaptureFlag))
+	stdout, _, err := veleroexec.RunCommand(cmd)
+	require.NoError(t, err)
+
+	// assert that the labeled VSL is returned
+	assert.Contains(t, stdout, "vsl-labeled")
+	// assert that the unlabeled VSL is not returned
+	assert.NotContains(t, stdout, "vsl-unlabeled")
 }


### PR DESCRIPTION
Thank you for contributing to Velero!

# Fix snapshot-location get --selector flag to filter VSLs by label

The `--selector` flag on `snapshot-location get` was bound to `listOptions.LabelSelector`but `listOptions` was never passed to `client.List()`. Added `Raw: &listOptions` to match the working pattern in `backup-location get`.

## Changes
- **`pkg/cmd/cli/snapshotlocation/get.go`**: Added `Raw: &listOptions` to the `client.List()` call so the `--selector` flag value is passed to the k8s API.
   - Updated copyright header to the standard format.
- **`pkg/cmd/cli/snapshotlocation/get_test.go`**: Added unit test for `NewGetCommand`, covering both the list path (no args) and the get-by-name path (with args). Same as `backuplocation_test.go`
- **`changelogs/unreleased/<pr>-PratikMane0112`**: Changelog entry.

## Testing
- for snapshotlocation package 
```bash
$ go test ./pkg/cmd/cli/snapshotlocation/... -v -count=1 -run TestNewGetCommand

=== RUN   TestNewGetCommand
--- PASS: TestNewGetCommand (0.11s)
PASS
ok      github.com/vmware-tanzu/velero/pkg/cmd/cli/snapshotlocation     2.893s
```

# Does your change fix a particular issue?

Fixes #10448 & [OADP-8719](https://redhat.atlassian.net/browse/OADP-8719)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
