### PR TITLE
Make repository password configurable per BSL

### DIFF
--- a/changelogs/unreleased/10451-Kajot-dev
+++ b/changelogs/unreleased/10451-Kajot-dev
@@ -1,0 +1,1 @@
+Make repository password configurable per BackupStorageLocation

--- a/config/crd/v1/bases/velero.io_backupstoragelocations.yaml
+++ b/config/crd/v1/bases/velero.io_backupstoragelocations.yaml
@@ -155,6 +155,33 @@ spec:
               provider:
                 description: Provider is the provider of the backup storage.
                 type: string
+              repositoryPasswordSecretRef:
+                description: |-
+                  RepositoryPasswordSecretRef is a reference to the secret, in the same
+                  namespace as the BackupStorageLocation, that holds the repository
+                  password. If unset, the global repository password from the velero
+                  install namespace is used.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
               validationFrequency:
                 description: ValidationFrequency defines how frequently to validate
                   the corresponding object storage. A value of 0 disables validation.

--- a/pkg/apis/velero/v1/backupstoragelocation_types.go
+++ b/pkg/apis/velero/v1/backupstoragelocation_types.go
@@ -37,6 +37,13 @@ type BackupStorageLocationSpec struct {
 	// +optional
 	Credential *corev1api.SecretKeySelector `json:"credential,omitempty"`
 
+	// RepositoryPasswordSecretRef is a reference to the secret, in the same
+	// namespace as the BackupStorageLocation, that holds the repository
+	// password. If unset, the global repository password from the velero
+	// install namespace is used.
+	// +optional
+	RepositoryPasswordSecretRef *corev1api.SecretKeySelector `json:"repositoryPasswordSecretRef,omitempty"`
+
 	StorageType `json:",inline"`
 
 	// Default indicates this location is the default backup storage location.

--- a/pkg/apis/velero/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/velero/v1/zz_generated.deepcopy.go
@@ -550,6 +550,11 @@ func (in *BackupStorageLocationSpec) DeepCopyInto(out *BackupStorageLocationSpec
 		*out = new(corev1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.RepositoryPasswordSecretRef != nil {
+		in, out := &in.RepositoryPasswordSecretRef, &out.RepositoryPasswordSecretRef
+		*out = new(corev1.SecretKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
 	in.StorageType.DeepCopyInto(&out.StorageType)
 	if in.BackupSyncPeriod != nil {
 		in, out := &in.BackupSyncPeriod, &out.BackupSyncPeriod

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -401,12 +401,12 @@ func (urp *unifiedRepoProvider) ClientSideCacheLimit(repoOption map[string]strin
 }
 
 func (urp *unifiedRepoProvider) GetPassword(param any) (string, error) {
-	_, ok := param.(RepoParam)
+	repoParam, ok := param.(RepoParam)
 	if !ok {
 		return "", errors.Errorf("invalid parameter, expect %T, actual %T", RepoParam{}, param)
 	}
 
-	repoPassword, err := getRepoPassword(urp.credentialGetter.FromSecret)
+	repoPassword, err := getRepoPassword(urp.credentialGetter.FromSecret, repoParam)
 	if err != nil {
 		return "", errors.Wrap(err, "error to get repo password")
 	}
@@ -458,12 +458,19 @@ func (urcp *unifiedRepoConfigProvider) ClientSideCacheLimit(repoOption map[strin
 	return urcp.repoService.ClientSideCacheLimit(repoOption)
 }
 
-func getRepoPassword(secretStore credentials.SecretStore) (string, error) {
+func getRepoPassword(secretStore credentials.SecretStore, param RepoParam) (string, error) {
 	if secretStore == nil {
 		return "", errors.New("invalid credentials interface")
 	}
 
-	rawPass, err := secretStore.Get(repokey.RepoKeySelector())
+	// Use the per-BSL repository password secret when set, otherwise fall back
+	// to the global repository password in the velero install namespace.
+	selector := repokey.RepoKeySelector()
+	if param.BackupLocation != nil && param.BackupLocation.Spec.RepositoryPasswordSecretRef != nil {
+		selector = param.BackupLocation.Spec.RepositoryPasswordSecretRef
+	}
+
+	rawPass, err := secretStore.Get(selector)
 	if err != nil {
 		return "", errors.Wrap(err, "error to get password")
 	}

--- a/pkg/repository/provider/unified_repo_test.go
+++ b/pkg/repository/provider/unified_repo_test.go
@@ -33,6 +33,7 @@ import (
 	velerocredentials "github.com/vmware-tanzu/velero/internal/credentials"
 	credmock "github.com/vmware-tanzu/velero/internal/credentials/mocks"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/repository/udmrepo"
 	reposervicenmocks "github.com/vmware-tanzu/velero/pkg/repository/udmrepo/mocks"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
@@ -485,6 +486,8 @@ func TestGetRepoPassword(t *testing.T) {
 		credStoreReturn string
 		credStoreError  error
 		cached          string
+		repoParam       any
+		expectSelector  *corev1api.SecretKeySelector
 		expected        string
 		expectedErr     string
 	}{
@@ -504,13 +507,33 @@ func TestGetRepoPassword(t *testing.T) {
 			credStoreReturn: " fake-passwor d  ",
 			expected:        "fake-passwor d",
 		},
+		{
+			name:            "use per-BSL repository password secret",
+			getter:          new(credmock.SecretStore),
+			credStoreReturn: "per-bsl-pass",
+			repoParam: RepoParam{
+				BackupLocation: &velerov1api.BackupStorageLocation{
+					Spec: velerov1api.BackupStorageLocationSpec{
+						RepositoryPasswordSecretRef: builder.ForSecretKeySelector("my-bsl-secret", "repository-password").Result(),
+					},
+				},
+			},
+			expectSelector: builder.ForSecretKeySelector("my-bsl-secret", "repository-password").Result(),
+			expected:       "per-bsl-pass",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var secretStore velerocredentials.SecretStore
 			if tc.getter != nil {
-				tc.getter.On("Get", mock.Anything, mock.Anything).Return(tc.credStoreReturn, tc.credStoreError)
+				if tc.expectSelector != nil {
+					tc.getter.On("Get", mock.MatchedBy(func(sel *corev1api.SecretKeySelector) bool {
+						return sel.Name == tc.expectSelector.Name && sel.Key == tc.expectSelector.Key
+					})).Return(tc.credStoreReturn, tc.credStoreError)
+				} else {
+					tc.getter.On("Get", mock.Anything).Return(tc.credStoreReturn, tc.credStoreError)
+				}
 				secretStore = tc.getter
 			}
 
@@ -520,7 +543,12 @@ func TestGetRepoPassword(t *testing.T) {
 				},
 			}
 
-			password, err := getRepoPassword(urp.credentialGetter.FromSecret)
+			param := RepoParam{}
+			if tc.repoParam != nil {
+				param = tc.repoParam.(RepoParam)
+			}
+
+			password, err := getRepoPassword(urp.credentialGetter.FromSecret, param)
 
 			require.Equal(t, tc.expected, password)
 

--- a/site/content/docs/main/csi-snapshot-data-movement.md
+++ b/site/content/docs/main/csi-snapshot-data-movement.md
@@ -59,6 +59,16 @@ You can update the secret with your own password encoded as base64 prior to the 
 data:
   repository-password: <custom-password>
 ```
+
+You can also define `BackupStorageLocation` specific repository password by setting `repositoryPasswordSecretRef` in its `spec` section pointing to a secret in the same namespace, like this:
+
+```yaml
+spec:
+  repositoryPasswordSecretRef:
+    name: my-bsl-secret
+    key: my-repository-password
+```
+
 Backup repository is created during the first execution of backup targeting to it after installing Velero with node agent. If you update the secret password after the first backup which created the backup repository, then Velero will not be able to connect with the older backups.  
 
 ## Install Velero with CSI support on source cluster
@@ -428,5 +438,3 @@ Sometimes, `RestorePVC` needs to be configured to increase the performance of re
 [20]: node-agent-prepare-queue-length.md
 [21]: data-movement-cache-volume.md
 [22]: https://tip.golang.org/doc/go1.25#container-aware-gomaxprocs:~:text=Runtime%C2%B6-,Container%2Daware%20GOMAXPROCS,-%C2%B6
-
-

--- a/site/content/docs/main/file-system-backup.md
+++ b/site/content/docs/main/file-system-backup.md
@@ -79,6 +79,16 @@ You can update the secret with your own password encoded as base64 prior to the 
 data:
   repository-password: <custom-password>
 ```
+
+You can also define `BackupStorageLocation` specific repository password by setting `repositoryPasswordSecretRef` in its `spec` section pointing to a secret in the same namespace, like this:
+
+```yaml
+spec:
+  repositoryPasswordSecretRef:
+    name: my-bsl-secret
+    key: my-repository-password
+```
+
 Backup repository is created during the first execution of backup targeting to it after installing Velero with node agent. If you update the secret password after the first
 backup which created the backup repository, then Velero will not be able to connect with the older backups.
 


### PR DESCRIPTION
Makes the repository password configurable per BackupStorageLocation via secret ref. This allows cases like migration between clusters (if you dom't want to share repository password between clusters for all backups)

I am aware that #10152 exists, but this is much simpler in scope and made to allow "secure-ish" multicluster scenarios. We have a case where we have cluster A and cluster B. Each cluster has its dedicated backup storage (and dedicated BSL) and each velero instance is using a different repository password. We would like to not share the password and/or access to all backups between the cluser - but create "shared" storage for backups with separate repository password which would be used on demand. This only adds minimal chanages so velero instance can use multiple repository passwords.  

Fixes #5443

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
