### PR TITLE
point the PodVolumeBackup Node print column at .spec.node

### DIFF
--- a/changelogs/unreleased/10452-samay43
+++ b/changelogs/unreleased/10452-samay43
@@ -1,0 +1,1 @@
+Fix issue #10444, the NODE column in kubectl get podvolumebackups was always empty because the print column read .status.node, which PodVolumeBackup does not define; it now reads .spec.node where the node is actually recorded

--- a/config/crd/v1/bases/velero.io_podvolumebackups.yaml
+++ b/config/crd/v1/bases/velero.io_podvolumebackups.yaml
@@ -51,7 +51,7 @@ spec:
       name: Age
       type: date
     - description: Name of the node where the PodVolumeBackup is processed
-      jsonPath: .status.node
+      jsonPath: .spec.node
       name: Node
       type: string
     - description: The type of the uploader to handle data transfer

--- a/pkg/apis/velero/v1/pod_volume_backup_types.go
+++ b/pkg/apis/velero/v1/pod_volume_backup_types.go
@@ -151,7 +151,7 @@ type PodVolumeBackupStatus struct {
 // +kubebuilder:printcolumn:name="Incremental Bytes",type="integer",format="int64",JSONPath=".status.incrementalBytes",description="Incremental bytes",priority=10
 // +kubebuilder:printcolumn:name="Storage Location",type="string",JSONPath=".spec.backupStorageLocation",description="Name of the Backup Storage Location where this backup should be stored"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since this PodVolumeBackup was created"
-// +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.node",description="Name of the node where the PodVolumeBackup is processed"
+// +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".spec.node",description="Name of the node where the PodVolumeBackup is processed"
 // +kubebuilder:printcolumn:name="Uploader",type="string",JSONPath=".spec.uploaderType",description="The type of the uploader to handle data transfer"
 // +kubebuilder:object:root=true
 // +kubebuilder:object:generate=true


### PR DESCRIPTION
Fixes #10444

## Problem

`kubectl get podvolumebackups` shows an always-empty `NODE` column. The print column is declared as:

```go
// pkg/apis/velero/v1/pod_volume_backup_types.go:154
// +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.node",description="Name of the node where the PodVolumeBackup is processed"
```

but `PodVolumeBackupStatus` has no `Node` field — it carries `Phase`, `Path`, `SnapshotID`, `Message`, `StartTimestamp`, `CompletionTimestamp`, `Progress`, `IncrementalBytes` and `AcceptedTimestamp`. The node is on the spec instead, at `PodVolumeBackupSpec.Node` (`:29`), where it is a required field.

Because `status.node` does not exist anywhere in the PodVolumeBackup schema, the column resolves to nothing for every object, on every cluster. Nothing is broken at runtime — this is display only.

## Why `.spec.node` is the right target

This is the fix @chlins recommended on the issue, and it holds up:

For a PodVolumeBackup the processing node is pinned to `Spec.Node` by construction. The pod is scheduled before the PVB is created, fs-backup must run on the pod's own node for hostPath access to the volumes, and the controller refuses to touch a PVB belonging to another node. There are four such gates in `pkg/controller/pod_volume_backup_controller.go`, all `pvb.Spec.Node != r.nodeName`:

```
235:  if pvb.Spec.Node != r.nodeName {
280:  if pvb.Spec.Node != r.nodeName {
370:  if pvb.Spec.Node != r.nodeName {
950:  if pvb.Spec.Node != r.nodeName {      // AttemptPVBResume
```

So the node a PVB is *scheduled to* and the node it is *processed on* are necessarily the same node. The column's existing description, "Name of the node where the PodVolumeBackup is processed", stays accurate — only the path it reads changes.

That is what separates PodVolumeBackup from its three siblings, where the two can legitimately diverge and a separate status field earns its place. Each of those defines `Node` in *status* and carries the identical `.status.node` column, which resolves correctly:

- `PodVolumeRestore` — `pod_volume_restore_type.go:122`, column `:137`
- `DataUpload` — `data_upload_types.go:182`, column `:213`
- `DataDownload` — `data_download_types.go:137`, column `:162`

The alternative fix — adding `Status.Node` to PodVolumeBackup to match the siblings — is left alone deliberately. It is an API addition for a value the spec already carries and the controller already treats as authoritative.

## Origin

Introduced in `99c699fcb` ("VGDP MS PVB controller", #9015). That commit added the `Node` print column to PodVolumeBackup pointing at `.status.node`, but did not add a `Node` field to `PodVolumeBackupStatus` — the column and the field it reads were never wired together.

## The change

Two commits, kept separate so the generated output is reviewable on its own:

1. The one-line marker change in `pod_volume_backup_types.go`.
2. The regenerated `config/crd/v1/bases/velero.io_podvolumebackups.yaml`.

```
config/crd/v1/bases/velero.io_podvolumebackups.yaml | 2 +-
pkg/apis/velero/v1/pod_volume_backup_types.go       | 2 +-
```

Regenerated with `controller-gen v0.16.5`, matching the version pinned in `hack/build-image/Dockerfile` and stamped in the CRD's own `controller-gen.kubebuilder.io/version` annotation, so the generated diff is exactly the one line. The manifest reaches the binary through `//go:embed bases/*.yaml` (`config/crd/v1/crds.go`) since #10329, so no further codegen step is involved.

## Testing

No test is added, deliberately. A `+kubebuilder:printcolumn` marker produces CRD metadata that the API server evaluates when formatting `kubectl` output; there is no Velero code path that reads it, and nothing in the tree asserts on print columns. A unit test here could only re-state the marker's text back to itself.

Verified instead that the change is limited and does not disturb the embedded manifest:

```
$ go -C pkg/apis test ./...
ok      github.com/vmware-tanzu/velero/pkg/apis/velero/v1

$ go test ./pkg/install/...          # consumes the embedded CRDs
ok      github.com/vmware-tanzu/velero/pkg/install
```

Both under the `hack/test.sh` vet allow-list. `gofmt` clean.

As on the issue, this is established by inspection of the generated CRD rather than a live cluster run — `status.node` is absent from the schema, so there is no cluster state in which the current column could resolve.
