### PR TITLE
Set OwnerReference on repository maintenance Jobs

### DIFF
--- a/changelogs/unreleased/10459-tonyjthomas
+++ b/changelogs/unreleased/10459-tonyjthomas
@@ -1,0 +1,1 @@
+Set OwnerReference on repository maintenance Jobs pointing to their BackupRepository so the Jobs are garbage-collected when the BackupRepository is deleted

--- a/pkg/repository/maintenance/maintenance.go
+++ b/pkg/repository/maintenance/maintenance.go
@@ -43,6 +43,7 @@ import (
 	velerolabel "github.com/vmware-tanzu/velero/pkg/label"
 	velerotypes "github.com/vmware-tanzu/velero/pkg/types"
 	"github.com/vmware-tanzu/velero/pkg/util"
+	"github.com/vmware-tanzu/velero/pkg/util/boolptr"
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
 	"github.com/vmware-tanzu/velero/pkg/util/logging"
 	veleroutil "github.com/vmware-tanzu/velero/pkg/util/velero"
@@ -665,6 +666,15 @@ func buildJob(
 			Namespace: repo.Namespace,
 			Labels: map[string]string{
 				RepositoryNameLabel: velerolabel.ReturnNameOrHash(repo.Name),
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: velerov1api.SchemeGroupVersion.String(),
+					Kind:       "BackupRepository",
+					Name:       repo.Name,
+					UID:        repo.UID,
+					Controller: boolptr.True(),
+				},
 			},
 		},
 		Spec: batchv1api.JobSpec{

--- a/pkg/repository/maintenance/maintenance_test.go
+++ b/pkg/repository/maintenance/maintenance_test.go
@@ -1499,6 +1499,7 @@ func TestBuildJob(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "velero",
 				Name:      "test-123",
+				UID:       "test-uid-123",
 			},
 			Spec: velerov1api.BackupRepositorySpec{
 				VolumeNamespace: "test-123",
@@ -1556,6 +1557,16 @@ func TestBuildJob(t *testing.T) {
 				assert.Contains(t, job.Name, tc.expectedJobName)
 				assert.Equal(t, param.BackupRepo.Namespace, job.Namespace)
 				assert.Equal(t, param.BackupRepo.Name, job.Labels[RepositoryNameLabel])
+
+				assert.Equal(t, []metav1.OwnerReference{
+					{
+						APIVersion: velerov1api.SchemeGroupVersion.String(),
+						Kind:       "BackupRepository",
+						Name:       param.BackupRepo.Name,
+						UID:        param.BackupRepo.UID,
+						Controller: boolptr.True(),
+					},
+				}, job.OwnerReferences)
 
 				assert.Equal(t, param.BackupRepo.Name, job.Spec.Template.ObjectMeta.Labels[RepositoryNameLabel])
 


### PR DESCRIPTION
Repository maintenance Jobs created by the node-agent (via `pkg/repository/maintenance`) had no `OwnerReference` pointing back to the `BackupRepository` they maintain. This means the Jobs were not garbage-collected by Kubernetes when the owning `BackupRepository` was deleted, and tooling that inspects ownership couldn't tell which `BackupRepository` a maintenance Job belonged to.

This change sets an `OwnerReference` on the maintenance `Job` (in `buildJob`) pointing to its `BackupRepository`, following the same pattern already used elsewhere in the codebase (e.g. `pkg/podvolume/backupper.go`, `pkg/podvolume/restorer.go`) for owning child objects.

Verified locally:
- Unit tests updated and passing (`pkg/repository/maintenance`).
- End-to-end: ran the `RepoMaintenance`-labeled e2e specs against a real cluster with CSI snapshot-move-data + node-agent/kopia, and confirmed in-cluster that the resulting maintenance Jobs carry the correct `OwnerReference` (`Kind: BackupRepository`, matching Name/UID, `controller: true`) across multiple maintenance cycles.

# Please indicate you've done the following:

- [x] Accepted the DCO.
- [x] Created a changelog file (`changelogs/unreleased/10459-tonyjthomas`).
- [ ] Updated the corresponding documentation in `site/content/docs/main` (not applicable - internal behavior change, no user-facing doc change needed).