### PR TITLE
Fix governance discoverability for CLOMonitor (MAINTAINERS.md link + README section)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # Velero Maintainers
 
-[GOVERNANCE.md](https://github.com/vmware-tanzu/velero/blob/main/GOVERNANCE.md) describes governance guidelines and maintainer responsibilities.
+[GOVERNANCE.md](https://github.com/velero-io/.github/blob/main/GOVERNANCE.md) describes governance guidelines and maintainer responsibilities.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ If you encounter issues, review the [troubleshooting docs][30], [file an issue][
 
 If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing][31] documentation for guidance on how to setup Velero for development.
 
+## Governance
+
+Velero's [governance][32] describes how the project is run, including the decision-making process, the roles and responsibilities of maintainers, and how to become a maintainer. Governance applies across the Velero org and is maintained at [velero-io/.github][32].
+
 ## Changelog
 
 See [the list of releases][6] to find out about feature changes.
@@ -87,4 +91,5 @@ For website terms of use, trademark policy and other project policies please see
 [29]: https://velero.io/docs/
 [30]: https://velero.io/docs/troubleshooting
 [31]: https://velero.io/docs/start-contributing
+[32]: https://github.com/velero-io/.github/blob/main/GOVERNANCE.md
 [100]: https://velero.io/docs/main/img/velero.png


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Two related governance fixes for the CLOMonitor `documentation/governance` check:

1. The `GOVERNANCE.md` link in `MAINTAINERS.md` pointed to the old `vmware-tanzu/velero/blob/main/GOVERNANCE.md` path, which now 404s. Governance now lives at the org level under [`velero-io/.github/GOVERNANCE.md`](https://github.com/velero-io/.github/blob/main/GOVERNANCE.md). Repointed the link.

2. Added a `Governance` section to the `README`. CLOMonitor's governance check only passes when it finds a governance file or a governance header/link in the README (it does not inspect `MAINTAINERS.md`). The new section links the org-level GOVERNANCE.md and makes the info discoverable.

# Does your change fix a particular issue?

Fixes #(issue)

Related to #10383

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR. (documentation-only change; `/kind changelog-not-required`)
- [ ] Updated the corresponding documentation in `site/content/docs/main`.