### PR TITLE
Add OpenSSF Scorecard workflow and README badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '20 7 * * 1'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    # Skip on forks; results are only meaningful for the canonical repo.
+    if: github.repository == 'velero-io/velero'
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to OpenSSF REST API for the Scorecard badge and to
+          # allow the project to be included in the OpenSSF metrics dashboard.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@v4.37.9
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![100]
 
 [![Build Status][1]][2] [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3811/badge)](https://bestpractices.coreinfrastructure.org/projects/3811)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/velero-io/velero/badge)](https://scorecard.dev/viewer/?uri=github.com/velero-io/velero)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/velero-io/velero)](https://github.com/velero-io/velero/releases)
 [![GitHub stars](https://img.shields.io/github/stars/velero-io/velero)](https://github.com/velero-io/velero/stargazers)
 [![Docker Pulls](https://img.shields.io/docker/pulls/velero/velero.svg)](https://hub.docker.com/r/velero/velero)


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Velero currently has no published OpenSSF Scorecard results, so the Scorecard badge does not resolve (renders `invalid repo path`) and CLOMonitor flags the `openssf_scorecard_badge` check as missing. Note this is distinct from the OpenSSF Best Practices badge (project 3811), which the project already has.

This PR:
- Adds `.github/workflows/scorecard.yml` using the SHA-pinned `ossf/scorecard-action` (v2.4.4), with default `read-all` permissions, job-scoped `security-events: write` + `id-token: write`, running weekly and on push to `main`, with `publish_results: true`.
- Adds the OpenSSF Scorecard badge to the README next to the existing Best Practices badge.

Once the workflow runs after merge, results publish to the OpenSSF API and the badge resolves. Velero's current Scorecard score is 6.2/10; the weakest checks (Token-Permissions, Pinned-Dependencies) are being addressed in companion CLOMonitor PRs.

# Does your change fix a particular issue?

Fixes #(issue)

Related to #10383

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR. (CI-only change; `/kind changelog-not-required`)
- [ ] Updated the corresponding documentation in `site/content/docs/main`.