### PR TITLE
Add Community section with meeting info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Please use the version selector at the top of the site to ensure you are using t
 
 If you encounter issues, review the [troubleshooting docs][30], [file an issue][4], or talk to us on the [#velero channel][25] on the Kubernetes Slack server.
 
+## Community
+
+Velero is an open community and we welcome your participation. The best way to get involved is to join our bi-weekly community meetings:
+
+* Join the [Velero community meetings](https://velero.io/community/), held bi-weekly, alternating between Beijing-friendly and US/Europe-friendly time zones.
+* Subscribe to the [project meeting calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/velero?view=week).
+* Watch previous meetings on our [YouTube channel](https://www.youtube.com/playlist?list=PL7bmigfV0EqQRysvqvqOtRNk4L5S7uqwM).
+* Chat with us on the [Kubernetes Slack][25] `#velero` channel and join the [mailing list][24].
+
+See the [community page](https://velero.io/community/) for the full schedule and details.
+
 ## Contributing
 
 If you are ready to jump in and test, add code, or help with documentation, follow the instructions on our [Start contributing][31] documentation for guidance on how to setup Velero for development.


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

The README had no reference to Velero's community meetings, which CLOMonitor flags via the `community_meeting` check. The meeting details already live on the [community page](https://velero.io/community/) but were not discoverable from the README.

This adds a `Community` section to the README linking:
- the bi-weekly community meetings (community page)
- the project meeting calendar
- the YouTube archive of past meetings
- the Kubernetes Slack `#velero` channel and mailing list

# Does your change fix a particular issue?

Fixes #(issue)

Related to #10383

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR. (documentation-only change; `/kind changelog-not-required`)
- [ ] Updated the corresponding documentation in `site/content/docs/main`.