### PR TITLE
Add .clomonitor.yml with Artifact Hub badge exemption

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,0 +1,7 @@
+# CLOMonitor metadata file
+# https://github.com/cncf/clomonitor/blob/main/docs/metadata/.clomonitor.yml
+
+# Checks exemptions
+exemptions:
+  - check: artifacthub_badge
+    reason: "Velero is not distributed as an Artifact Hub package. The Velero core project is consumed via container images and release binaries, and the community-maintained Helm chart is published from a separate repository (vmware-tanzu/helm-charts). There is no Artifact Hub listing for this repository."


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Adds a `.clomonitor.yml` metadata file at the repo root declaring an exemption for the `artifacthub_badge` check.

The Velero core project is not distributed as an Artifact Hub package: it is consumed via container images and release binaries, and the community Helm chart is published from a separate repository (vmware-tanzu/helm-charts). The Artifact Hub badge check is therefore not applicable to this repository, and CLOMonitor supports declaring such exemptions with a justification (displayed in the UI).

# Does your change fix a particular issue?

Fixes #(issue)

Related to #10383

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR. (metadata-only change; `/kind changelog-not-required`)
- [ ] Updated the corresponding documentation in `site/content/docs/main`.