### PR TITLE
Add OpenSSF Security Insights manifest and dependency management docs

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,101 @@
+header:
+  schema-version: 2.2.0
+  last-updated: '2026-09-02'
+  last-reviewed: '2026-09-02'
+  url: https://github.com/velero-io/velero/blob/main/SECURITY-INSIGHTS.yml
+  comment: |
+    OpenSSF Security Insights manifest for the Velero project.
+
+project:
+  name: Velero
+  homepage: https://velero.io
+  roadmap: https://github.com/velero-io/velero/blob/main/ROADMAP.md
+  administrators:
+    - name: Scott Seago
+      affiliation: Red Hat
+      primary: false
+    - name: Daniel Jiang
+      affiliation: Broadcom
+      primary: true
+    - name: Wenkai Yin
+      affiliation: Broadcom
+      primary: false
+    - name: Xun Jiang
+      affiliation: Broadcom
+      primary: false
+    - name: Shubham Pampattiwar
+      affiliation: Red Hat
+      primary: false
+    - name: Yonghui Li
+      affiliation: Broadcom
+      primary: false
+    - name: Anshul Ahuja
+      affiliation: Microsoft Azure
+      primary: false
+    - name: Tiger Kaovilai
+      affiliation: Red Hat
+      primary: false
+  documentation:
+    detailed-guide: https://velero.io/docs/
+  repositories:
+    - name: velero
+      url: https://github.com/velero-io/velero
+      comment: |
+        velero is the core repository for the Velero project.
+  vulnerability-reporting:
+    reports-accepted: true
+    bug-bounty-available: false
+    contact:
+      name: Velero Security Team
+      email: cncf-velero-security@lists.cncf.io
+      primary: true
+    comment: |
+      Report vulnerabilities privately to the Velero Security Team by email or
+      via GitHub private vulnerability reporting on the repository Security tab.
+      See the security policy for full details.
+
+repository:
+  url: https://github.com/velero-io/velero
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  core-team:
+    - name: Scott Seago
+      affiliation: Red Hat
+      primary: false
+    - name: Daniel Jiang
+      affiliation: Broadcom
+      primary: true
+    - name: Wenkai Yin
+      affiliation: Broadcom
+      primary: false
+    - name: Xun Jiang
+      affiliation: Broadcom
+      primary: false
+    - name: Shubham Pampattiwar
+      affiliation: Red Hat
+      primary: false
+    - name: Yonghui Li
+      affiliation: Broadcom
+      primary: false
+    - name: Anshul Ahuja
+      affiliation: Microsoft Azure
+      primary: false
+    - name: Tiger Kaovilai
+      affiliation: Red Hat
+      primary: false
+  license:
+    url: https://github.com/velero-io/velero/blob/main/LICENSE
+    expression: Apache-2.0
+  documentation:
+    contributing-guide: https://velero.io/docs/main/start-contributing/
+    governance: https://github.com/velero-io/.github/blob/main/GOVERNANCE.md
+    security-policy: https://github.com/velero-io/.github/blob/main/SECURITY.md
+    dependency-management-policy: https://github.com/velero-io/velero/blob/main/site/content/docs/main/development.md#dependency-management
+  security:
+    assessments:
+      self:
+        comment: |
+          A formal third-party security assessment has not yet been completed.
+          The project follows the CNCF security disclosure and response process
+          documented in the security policy.

--- a/site/content/docs/main/development.md
+++ b/site/content/docs/main/development.md
@@ -47,3 +47,14 @@ velero install --crds-only --dry-run -o yaml | kubectl apply -f -
 
 **NOTE:** You could change the default CRD API version (v1beta1 _or_ v1) if Velero CLI can't discover the Kubernetes preferred CRD API version. The Kubernetes version < 1.16 preferred CRD API version is v1beta1; the Kubernetes version >= 1.16 preferred CRD API version is v1.
 
+
+## Dependency management
+
+Velero is written in Go and uses [Go modules](https://go.dev/ref/mod) to manage its dependencies. Direct and indirect dependencies are declared in `go.mod` and pinned in `go.sum`.
+
+The project keeps dependencies up to date and responds to upstream security fixes as follows:
+
+* [Dependabot](https://docs.github.com/en/code-security/dependabot) is configured in [`.github/dependabot.yml`](https://github.com/velero-io/velero/blob/main/.github/dependabot.yml) to open pull requests for Go module and GitHub Actions updates on a weekly schedule. Updates are grouped to reduce noise.
+* Dependency update pull requests follow the same review process as any other change: they must pass CI and be approved by a maintainer before merging.
+* Security-relevant updates are prioritized. Vulnerabilities in dependencies that affect Velero are handled through the [security release process](https://github.com/velero-io/.github/blob/main/SECURITY.md).
+* New direct dependencies should be kept to a minimum and use a license compatible with Velero's [Apache 2.0 license](https://github.com/velero-io/velero/blob/main/LICENSE).


### PR DESCRIPTION
## Thank you for contributing to Velero!

Please add a summary of your change

Adds a schema-valid [OpenSSF Security Insights](https://github.com/ossf/security-insights-spec) v2 (2.2.0) manifest at `SECURITY-INSIGHTS.yml`. It documents, in a machine-processable form, the project's maintainers, vulnerability reporting process, license, and links to the governance, security, and dependency management policies.

It also adds a **Dependency management** section to `site/content/docs/main/development.md` covering Go modules, Dependabot automation, the review process, and how security-relevant dependency updates are handled. The manifest references this section as the dependency management policy.

This improves the project's CLOMonitor score by satisfying the `security_insights` and `dependencies_policy` checks (part of the Sandbox to Incubation readiness work).

The manifest was validated against the official Security Insights v2.2.0 schema (all required fields present, formats valid).

## Does your change fix a particular issue?

Fixes #(issue)

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/main/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.