### PR TITLE
Set least-privilege GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/get-go-version.yaml
+++ b/.github/workflows/get-go-version.yaml
@@ -10,6 +10,9 @@ on:
         description: "The expected Go version"
         value: ${{ jobs.extract.outputs.version }}
 
+permissions:
+  contents: read
+
 jobs:
   extract:
       runs-on: ubuntu-latest

--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
 
+permissions:
+  contents: read
+
 jobs:
   nightly-scan:
     name: Trivy nightly scan
@@ -15,6 +18,7 @@ jobs:
         # list of images that need scan
         images: [velero, velero-plugin-for-aws, velero-plugin-for-gcp, velero-plugin-for-microsoft-azure]
     permissions:
+      contents: read  # for actions/checkout to fetch code
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
 
     steps:

--- a/.github/workflows/pr-ci-check.yml
+++ b/.github/workflows/pr-ci-check.yml
@@ -1,5 +1,9 @@
 name: Pull Request CI Check
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   get-go-version:
     uses: ./.github/workflows/get-go-version.yaml

--- a/.github/workflows/pr-codespell.yml
+++ b/.github/workflows/pr-codespell.yml
@@ -1,5 +1,9 @@
 name: Pull Request Codespell Check
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
 
   codespell:

--- a/.github/workflows/pr-containers.yml
+++ b/.github/workflows/pr-containers.yml
@@ -9,6 +9,9 @@ on:
       - 'Dockerfile'
       - 'Dockerfile-Windows'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/pr-filepath-check.yml
+++ b/.github/workflows/pr-filepath-check.yml
@@ -1,5 +1,9 @@
 name: Pull Request File Path Check
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
 
   filepath-check:

--- a/.github/workflows/pr-goreleaser.yml
+++ b/.github/workflows/pr-goreleaser.yml
@@ -9,6 +9,9 @@ on:
       - '.goreleaser.yml'
       - 'hack/release-tools/goreleaser.sh'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/pr-linter-check.yml
+++ b/.github/workflows/pr-linter-check.yml
@@ -6,6 +6,10 @@ on:
       - "site/**"
       - "design/**"
       - "**/*.md"
+
+permissions:
+  contents: read
+
 jobs:
   get-go-version:
     uses: ./.github/workflows/get-go-version.yaml

--- a/.github/workflows/push-builder.yml
+++ b/.github/workflows/push-builder.yml
@@ -6,6 +6,9 @@ on:
     paths:
     - 'hack/build-image/Dockerfile'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: "30 1 * * *" # Every day at 1:30 UTC
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     if: github.repository == 'velero-io/velero'


### PR DESCRIPTION
## Thank you for contributing to Velero!

Please add a summary of your change

Adds an explicit top-level `permissions:` block to the 11 GitHub Actions workflows that were relying on the repository's default `GITHUB_TOKEN` permissions. Each now defaults to least privilege (`contents: read`), with extra scopes granted only where a job actually needs them:

* `nightly-trivy-scan.yml` keeps `security-events: write` at the job level (for uploading SARIF), plus `contents: read` for checkout.
* `stale-issues.yml` gets `issues: write` and `pull-requests: write` for the `actions/stale` action.

The remaining workflows (get-go-version, pr-changelog-check, pr-ci-check, pr-codespell, pr-containers, pr-filepath-check, pr-goreleaser, pr-linter-check, push-builder) only check out and read the repo, so `contents: read` is sufficient. None of them create releases or push using `GITHUB_TOKEN` (the goreleaser check runs with `PUBLISH=false`, and image pushes use separate registry secrets).

Setting least-privilege token permissions reduces the blast radius if a workflow or one of its dependencies is compromised. This is part of the Sandbox to Incubation readiness work and satisfies the CLOMonitor `token_permissions` check (mirrors the OpenSSF Scorecard Token-Permissions check).

## Does your change fix a particular issue?

Fixes #(issue)

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/main/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.