### PR TITLE
Evaluate changelog exemption labels from live PR state

### DIFF
--- a/.github/workflows/pr-changelog-check.yml
+++ b/.github/workflows/pr-changelog-check.yml
@@ -4,6 +4,11 @@ name: Pull Request Changelog Check
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
 
   build:
@@ -16,5 +21,6 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Changelog check
-      if: ${{ !(contains(github.event.pull_request.labels.*.name, 'kind/changelog-not-required') || contains(github.event.pull_request.labels.*.name, 'Design') || contains(github.event.pull_request.labels.*.name, 'Website') || contains(github.event.pull_request.labels.*.name, 'Documentation'))}}
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: ./hack/changelog-check.sh

--- a/hack/changelog-check.sh
+++ b/hack/changelog-check.sh
@@ -28,6 +28,22 @@ CHANGELOG_PATH='changelogs/unreleased'
 # GITHUB_REF is something like "refs/pull/:prNumber/merge"
 pr_number=$(echo $GITHUB_REF | cut -d / -f 3)
 
+# Some kinds of pull requests do not require a changelog entry. Rather than
+# relying on the (frozen) event payload, query the PR's current labels so the
+# check reflects the latest state. This makes re-runs and labels added after
+# the initial run behave correctly.
+EXEMPT_LABELS=("kind/changelog-not-required" "Design" "Website" "Documentation")
+
+if command -v gh > /dev/null 2>&1; then
+    current_labels=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq '.labels[].name' 2>/dev/null || true)
+    for label in "${EXEMPT_LABELS[@]}"; do
+        if grep -Fxq "$label" <<< "$current_labels"; then
+            echo "PR ${pr_number} has the '${label}' label; changelog not required."
+            exit 0
+        fi
+    done
+fi
+
 change_log_file="${CHANGELOG_PATH}/${pr_number}-*"
 
 if ls ${change_log_file} 1> /dev/null 2>&1; then


### PR DESCRIPTION
## Thank you for contributing to Velero!

Please add a summary of your change

The changelog check decided whether a PR was exempt using the labels in the triggering event payload (`github.event.pull_request.labels`, evaluated in the step's `if:` condition). That payload is frozen at event time, which causes two problems:

* If a PR gets the `kind/changelog-not-required` label **after** its first run (for example via a `/kind changelog-not-required` comment), re-running the failed job replays the old label-less payload and keeps failing. The exemption only takes effect if a brand new event happens to fire afterward.
* Contributors reasonably assume re-running the check will pick up the newly added label, but it never can.

This moves the exemption logic into `hack/changelog-check.sh`, which now queries the PR's **current** labels via the GitHub API. Re-runs and labels added after the initial run are evaluated correctly. The workflow grants `pull-requests: read` and passes `github.token` so the script can read the labels. The exempt label set (`kind/changelog-not-required`, `Design`, `Website`, `Documentation`) is unchanged.

## Does your change fix a particular issue?

Fixes #(issue)

## Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/main/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.