### PR TITLE
Ignore e2e debug bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tilt-resources/cloud
 
 # test generated files
 test/e2e/report.xml
+test/e2e/debug-bundle*.tar.gz
 coverage.out
 __debug_bin*
 debug.test*

--- a/changelogs/unreleased/10477-krishhna24
+++ b/changelogs/unreleased/10477-krishhna24
@@ -1,0 +1,1 @@
+Ignore e2e debug bundles in .gitignore


### PR DESCRIPTION
A failing e2e run writes `test/e2e/debug-bundle-<timestamp>.tar.gz` into the worktree and it is not ignored, so it shows up as an untracked file after any local run that fails. The kind workflow already treats it as a generated artifact and uploads it from that path on failure (`.github/workflows/e2e-test-kind.yaml:255`).

Add it next to `test/e2e/report.xml`, which is the same kind of file from the same suite.

## Does your change fix a particular issue?

No linked issue; noticed while running the kind e2e suite locally.

## Please indicate you have done the following.

- [x] Signed off on the commit (DCO).
- [x] Added a changelog file.
- [x] Verified with `git check-ignore -v test/e2e/debug-bundle-20260902.tar.gz`, which matches at `.gitignore:55`.

Note this path does not trigger the e2e workflow (`pull_request` paths filter, #10458), which is expected for a gitignore-only change.