### PR TITLE
Scope schedule and repo CLI list calls to the Velero namespace

### DIFF
--- a/changelogs/unreleased/10482-MaxFreedomPollard
+++ b/changelogs/unreleased/10482-MaxFreedomPollard
@@ -1,0 +1,1 @@
+Scope velero schedule get/describe/pause/unpause and velero repo get to the Velero namespace instead of listing across all namespaces

--- a/pkg/cmd/cli/repo/get.go
+++ b/pkg/cmd/cli/repo/get.go
@@ -58,7 +58,7 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 					selector, err = labels.Parse(listOptions.LabelSelector)
 					cmd.CheckError(err)
 				}
-				err = crClient.List(context.TODO(), repos, &ctrlclient.ListOptions{LabelSelector: selector})
+				err = crClient.List(context.TODO(), repos, &ctrlclient.ListOptions{LabelSelector: selector, Namespace: f.Namespace()})
 				cmd.CheckError(err)
 			}
 

--- a/pkg/cmd/cli/repo/get_test.go
+++ b/pkg/cmd/cli/repo/get_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repo
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
+	cmdtest "github.com/vmware-tanzu/velero/pkg/cmd/test"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+func backupRepository(namespace, name string) *velerov1api.BackupRepository {
+	return &velerov1api.BackupRepository{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: velerov1api.SchemeGroupVersion.String(),
+			Kind:       "BackupRepository",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: velerov1api.BackupRepositorySpec{
+			RepositoryType: velerov1api.BackupRepositoryTypeKopia,
+		},
+	}
+}
+
+// captureStdout runs execute and returns everything it wrote to os.Stdout. The
+// output helpers write to os.Stdout directly rather than to the command's
+// output writer, so the file has to be swapped to read them back.
+func captureStdout(t *testing.T, execute func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	original := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = original }()
+
+	execute()
+
+	require.NoError(t, w.Close())
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+
+	return buf.String()
+}
+
+func TestNewGetCommandListsOnlyTheVeleroNamespace(t *testing.T) {
+	ours := backupRepository(cmdtest.VeleroNameSpace, "ours")
+	theirs := backupRepository("another-velero", "theirs")
+
+	crClient := velerotest.NewFakeControllerRuntimeClient(t, ours, theirs)
+
+	f := &factorymocks.Factory{}
+	f.On("Namespace").Return(cmdtest.VeleroNameSpace)
+	f.On("KubebuilderClient").Return(crClient, nil)
+
+	c := NewGetCommand(f, "get")
+	c.SetArgs([]string{})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, c.Execute())
+	})
+
+	assert.Contains(t, out, "ours")
+	assert.NotContains(t, out, "theirs")
+}

--- a/pkg/cmd/cli/schedule/describe.go
+++ b/pkg/cmd/cli/schedule/describe.go
@@ -56,7 +56,7 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 					selector, err = labels.Parse(listOptions.LabelSelector)
 					cmd.CheckError(err)
 				}
-				err = crClient.List(context.TODO(), schedules, &ctrlclient.ListOptions{LabelSelector: selector})
+				err = crClient.List(context.TODO(), schedules, &ctrlclient.ListOptions{LabelSelector: selector, Namespace: f.Namespace()})
 				cmd.CheckError(err)
 			}
 

--- a/pkg/cmd/cli/schedule/describe_test.go
+++ b/pkg/cmd/cli/schedule/describe_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/velero/pkg/builder"
+	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
+	cmdtest "github.com/vmware-tanzu/velero/pkg/cmd/test"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+func TestNewDescribeCommandDescribesOnlyTheVeleroNamespace(t *testing.T) {
+	ours := builder.ForSchedule(cmdtest.VeleroNameSpace, "ours").CronSchedule("@daily").Result()
+	theirs := builder.ForSchedule("another-velero", "theirs").CronSchedule("@daily").Result()
+
+	crClient := velerotest.NewFakeControllerRuntimeClient(t, ours, theirs)
+
+	f := &factorymocks.Factory{}
+	f.On("Namespace").Return(cmdtest.VeleroNameSpace)
+	f.On("KubebuilderClient").Return(crClient, nil)
+
+	c := NewDescribeCommand(f, "describe")
+	c.SetArgs([]string{})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, c.Execute())
+	})
+
+	assert.Contains(t, out, "ours")
+	assert.NotContains(t, out, "theirs")
+}

--- a/pkg/cmd/cli/schedule/get.go
+++ b/pkg/cmd/cli/schedule/get.go
@@ -58,7 +58,7 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 					selector, err = labels.Parse(listOptions.LabelSelector)
 					cmd.CheckError(err)
 				}
-				err := crClient.List(context.TODO(), schedules, &ctrlclient.ListOptions{LabelSelector: selector})
+				err := crClient.List(context.TODO(), schedules, &ctrlclient.ListOptions{LabelSelector: selector, Namespace: f.Namespace()})
 				cmd.CheckError(err)
 			}
 

--- a/pkg/cmd/cli/schedule/get_test.go
+++ b/pkg/cmd/cli/schedule/get_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedule
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware-tanzu/velero/pkg/builder"
+	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
+	cmdtest "github.com/vmware-tanzu/velero/pkg/cmd/test"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+// captureStdout runs execute and returns everything it wrote to os.Stdout. The
+// describe and output helpers write to os.Stdout directly rather than to the
+// command's output writer, so the file has to be swapped to read them back.
+func captureStdout(t *testing.T, execute func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	original := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = original }()
+
+	execute()
+
+	require.NoError(t, w.Close())
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+
+	return buf.String()
+}
+
+func TestNewGetCommandListsOnlyTheVeleroNamespace(t *testing.T) {
+	ours := builder.ForSchedule(cmdtest.VeleroNameSpace, "ours").CronSchedule("@daily").Result()
+	theirs := builder.ForSchedule("another-velero", "theirs").CronSchedule("@daily").Result()
+
+	crClient := velerotest.NewFakeControllerRuntimeClient(t, ours, theirs)
+
+	f := &factorymocks.Factory{}
+	f.On("Namespace").Return(cmdtest.VeleroNameSpace)
+	f.On("KubebuilderClient").Return(crClient, nil)
+
+	c := NewGetCommand(f, "get")
+	c.SetArgs([]string{})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, c.Execute())
+	})
+
+	assert.Contains(t, out, "ours")
+	assert.NotContains(t, out, "theirs")
+}

--- a/pkg/cmd/cli/schedule/pause.go
+++ b/pkg/cmd/cli/schedule/pause.go
@@ -114,6 +114,7 @@ func runPause(f client.Factory, o *cli.SelectOptions, paused bool, skipImmediate
 		res := new(velerov1api.ScheduleList)
 		err := crClient.List(context.TODO(), res, &ctrlclient.ListOptions{
 			LabelSelector: selector,
+			Namespace:     f.Namespace(),
 		})
 		if err != nil {
 			errs = append(errs, errors.WithStack(err))

--- a/pkg/cmd/cli/schedule/pause_test.go
+++ b/pkg/cmd/cli/schedule/pause_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
+	factorymocks "github.com/vmware-tanzu/velero/pkg/client/mocks"
+	"github.com/vmware-tanzu/velero/pkg/cmd/cli"
+	cmdtest "github.com/vmware-tanzu/velero/pkg/cmd/test"
+	"github.com/vmware-tanzu/velero/pkg/cmd/util/flag"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+func scheduleIsPaused(t *testing.T, crClient ctrlclient.Client, namespace, name string) bool {
+	t.Helper()
+
+	schedule := new(velerov1api.Schedule)
+	require.NoError(t, crClient.Get(t.Context(), ctrlclient.ObjectKey{Namespace: namespace, Name: name}, schedule))
+	return schedule.Spec.Paused
+}
+
+func TestRunPauseOnlyTouchesTheVeleroNamespace(t *testing.T) {
+	labeled := func(s *velerov1api.Schedule) *velerov1api.Schedule {
+		s.Labels = map[string]string{"foo": "bar"}
+		return s
+	}
+
+	tests := []struct {
+		name    string
+		options func(o *cli.SelectOptions)
+	}{
+		{
+			name:    "--all",
+			options: func(o *cli.SelectOptions) { o.All = true },
+		},
+		{
+			name: "--selector",
+			options: func(o *cli.SelectOptions) {
+				o.Selector = flag.LabelSelector{LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ours := labeled(builder.ForSchedule(cmdtest.VeleroNameSpace, "ours").CronSchedule("@daily").Result())
+			theirs := labeled(builder.ForSchedule("another-velero", "theirs").CronSchedule("@daily").Result())
+
+			crClient := velerotest.NewFakeControllerRuntimeClient(t, ours, theirs)
+
+			f := &factorymocks.Factory{}
+			f.On("Namespace").Return(cmdtest.VeleroNameSpace)
+			f.On("KubebuilderClient").Return(crClient, nil)
+
+			o := cli.NewSelectOptions("pause", "schedule")
+			tc.options(o)
+			require.NoError(t, o.Validate())
+
+			require.NoError(t, runPause(f, o, true, nil))
+
+			assert.True(t, scheduleIsPaused(t, crClient, cmdtest.VeleroNameSpace, "ours"))
+			assert.False(t, scheduleIsPaused(t, crClient, "another-velero", "theirs"))
+		})
+	}
+}
+
+func TestRunUnpauseOnlyTouchesTheVeleroNamespace(t *testing.T) {
+	paused := func(ns, name string) *velerov1api.Schedule {
+		s := builder.ForSchedule(ns, name).CronSchedule("@daily").Result()
+		s.Spec.Paused = true
+		return s
+	}
+
+	ours := paused(cmdtest.VeleroNameSpace, "ours")
+	theirs := paused("another-velero", "theirs")
+
+	crClient := velerotest.NewFakeControllerRuntimeClient(t, ours, theirs)
+
+	f := &factorymocks.Factory{}
+	f.On("Namespace").Return(cmdtest.VeleroNameSpace)
+	f.On("KubebuilderClient").Return(crClient, nil)
+
+	o := cli.NewSelectOptions("pause", "schedule")
+	o.All = true
+
+	require.NoError(t, runPause(f, o, false, nil))
+
+	assert.False(t, scheduleIsPaused(t, crClient, cmdtest.VeleroNameSpace, "ours"))
+	assert.True(t, scheduleIsPaused(t, crClient, "another-velero", "theirs"))
+}


### PR DESCRIPTION
# Please add a summary of your change

`velero schedule get`, `velero schedule describe`, `velero schedule pause`, `velero schedule unpause` and `velero repo get` list across every namespace in the cluster instead of the Velero namespace. Each of them builds a `ctrlclient.ListOptions` that carries a `LabelSelector` and no `Namespace`: `pkg/cmd/cli/schedule/get.go:61`, `pkg/cmd/cli/schedule/describe.go:59`, `pkg/cmd/cli/schedule/pause.go:115` and `pkg/cmd/cli/repo/get.go:61`.

The named-object branch a few lines above each of those already scopes to `f.Namespace()` (`schedule/get.go:51`, `schedule/describe.go:49`, `schedule/pause.go:98`, `repo/get.go:51`), and `schedule delete` scopes its list at `pkg/cmd/cli/schedule/delete.go:101`, as do `backup get`, `restore get`, `backup describe`, `restore describe` and `snapshot-location get`. So `velero schedule get foo` and `velero schedule get` disagree about which namespace they are reading from.

On the three read commands the effect is that another installation's Schedules and BackupRepositories appear in the output. `runPause` also writes. `velero schedule pause --all -n velero` collects Schedules from every namespace and then sets `Spec.Paused` on each one (`pause.go:141` and `pause.go:143`), so it pauses the schedules belonging to every other Velero installation in the cluster and prints `Schedule <name> paused successfully` for them. `velero schedule unpause --all` unpauses them through the same function.

The fix is `Namespace: f.Namespace()` on those four List calls.

Neither `pkg/cmd/cli/schedule` nor `pkg/cmd/cli/repo` had a test file, so the regression tests are new. Each seeds a fake controller-runtime client with one object in `velero-test` and one in `another-velero`, points the factory at `velero-test`, and asserts the object in `another-velero` is not listed, not described and not paused. All five fail on `main`:

```
$ go test -count=1 ./pkg/cmd/cli/schedule/... ./pkg/cmd/cli/repo/...
--- FAIL: TestNewGetCommandListsOnlyTheVeleroNamespace (0.00s)
    get_test.go:76: "NAME     STATUS ...\ntheirs   New ...\nours     New ..." should not contain "theirs"
--- FAIL: TestNewDescribeCommandDescribesOnlyTheVeleroNamespace (0.04s)
    describe_test.go:49: "Name:  theirs\nNamespace:  another-velero\n..." should not contain "theirs"
--- FAIL: TestRunPauseOnlyTouchesTheVeleroNamespace/--all (0.00s)
    pause_test.go:84: Should be false
--- FAIL: TestRunPauseOnlyTouchesTheVeleroNamespace/--selector (0.00s)
    pause_test.go:84: Should be false
--- FAIL: TestRunUnpauseOnlyTouchesTheVeleroNamespace (0.00s)
    pause_test.go:111: Should be true
FAIL    github.com/vmware-tanzu/velero/pkg/cmd/cli/schedule
FAIL    github.com/vmware-tanzu/velero/pkg/cmd/cli/repo
```

and pass with the change:

```
$ go test -count=1 ./pkg/cmd/cli/schedule/... ./pkg/cmd/cli/repo/...
ok      github.com/vmware-tanzu/velero/pkg/cmd/cli/schedule      0.865s
ok      github.com/vmware-tanzu/velero/pkg/cmd/cli/repo 1.485s
```

`go test ./pkg/cmd/...` passes, and `golangci-lint run --config .golangci.yaml ./pkg/cmd/cli/schedule/... ./pkg/cmd/cli/repo/...` on v2.12.0 reports nothing.

# Does your change fix a particular issue?

No issue filed for this one.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
