### PR TITLE
fix(csi): don't fail a backup on a retryable VolumeSnapshotContent error

### DIFF
--- a/changelogs/unreleased/10484-dcoppa
+++ b/changelogs/unreleased/10484-dcoppa
@@ -1,0 +1,1 @@
+Do not fail a backup on a retryable VolumeSnapshotContent error; keep polling until the error outlives CSISnapshotTimeout

--- a/pkg/backup/actions/csi/volumesnapshot_action.go
+++ b/pkg/backup/actions/csi/volumesnapshot_action.go
@@ -341,7 +341,7 @@ func (p *volumeSnapshotBackupItemAction) Progress(
 			// clear on a later attempt. Treat it as terminal only once it has
 			// outlived CSISnapshotTimeout, the same bound the synchronous path
 			// applies while waiting for the handle. A backup created without
-			// that timeout set keeps the previous fail-fast behaviour.
+			// that timeout set keeps the previous fail-fast behavior.
 			timeout := backup.Spec.CSISnapshotTimeout.Duration
 			if timeout > 0 && now.Sub(progress.Started) < timeout {
 				p.log.Warnf("VolumeSnapshotContent %s has a temporary error %s. Snapshot controller will retry later.",

--- a/pkg/backup/actions/csi/volumesnapshot_action.go
+++ b/pkg/backup/actions/csi/volumesnapshot_action.go
@@ -331,12 +331,30 @@ func (p *volumeSnapshotBackupItemAction) Progress(
 			progress.Completed = true
 			progress.Updated = now
 		} else if vsc.Status.Error != nil {
+			errorMessage := ""
+			if vsc.Status.Error.Message != nil {
+				errorMessage = *vsc.Status.Error.Message
+			}
+
+			// The snapshot controller records retryable CSI errors on the
+			// VolumeSnapshotContent and requeues it, so an error seen here may
+			// clear on a later attempt. Treat it as terminal only once it has
+			// outlived CSISnapshotTimeout, the same bound the synchronous path
+			// applies while waiting for the handle. A backup created without
+			// that timeout set keeps the previous fail-fast behaviour.
+			timeout := backup.Spec.CSISnapshotTimeout.Duration
+			if timeout > 0 && now.Sub(progress.Started) < timeout {
+				p.log.Warnf("VolumeSnapshotContent %s has a temporary error %s. Snapshot controller will retry later.",
+					vsc.Name, errorMessage)
+
+				return progress, nil
+			}
+
 			progress.Completed = true
 			progress.Updated = now
-			if vsc.Status.Error.Message != nil {
-				progress.Err = *vsc.Status.Error.Message
-			}
-			p.log.Warnf("VolumeSnapshotContent meets an error %s.", progress.Err)
+			progress.Err = errorMessage
+			p.log.Warnf("VolumeSnapshotContent %s meets an error %s that outlived the CSI snapshot timeout %s.",
+				vsc.Name, errorMessage, timeout)
 		}
 	}
 

--- a/pkg/backup/actions/csi/volumesnapshot_action_test.go
+++ b/pkg/backup/actions/csi/volumesnapshot_action_test.go
@@ -19,6 +19,7 @@ package csi
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -270,6 +271,44 @@ func TestVSProgress(t *testing.T) {
 					},
 				}).Result(),
 			backup:      builder.ForBackup("velero", "backup").Result(),
+			expectedErr: false,
+			expectedProgress: &velero.OperationProgress{
+				Completed: true,
+				Err:       "error",
+			},
+		},
+		{
+			// The snapshot controller requeues retryable CSI errors, so an
+			// error younger than CSISnapshotTimeout must leave the operation
+			// running rather than failing the backup on first sight.
+			name:        "VSC error within CSISnapshotTimeout is not terminal",
+			operationID: "ns/name/" + time.Now().Format(time.RFC3339),
+			vs: builder.ForVolumeSnapshot("ns", "name").Status().
+				ReadyToUse(true).BoundVolumeSnapshotContentName("vsc").Result(),
+			vsc: builder.ForVolumeSnapshotContent("vsc").
+				Status(&snapshotv1api.VolumeSnapshotContentStatus{
+					Error: &snapshotv1api.VolumeSnapshotError{
+						Message: &errorStr,
+					},
+				}).Result(),
+			backup: builder.ForBackup("velero", "backup").
+				CSISnapshotTimeout(10 * time.Minute).Result(),
+			expectedErr:      false,
+			expectedProgress: &velero.OperationProgress{},
+		},
+		{
+			name:        "VSC error outliving CSISnapshotTimeout is terminal",
+			operationID: "ns/name/" + time.Now().Add(-time.Hour).Format(time.RFC3339),
+			vs: builder.ForVolumeSnapshot("ns", "name").Status().
+				ReadyToUse(true).BoundVolumeSnapshotContentName("vsc").Result(),
+			vsc: builder.ForVolumeSnapshotContent("vsc").
+				Status(&snapshotv1api.VolumeSnapshotContentStatus{
+					Error: &snapshotv1api.VolumeSnapshotError{
+						Message: &errorStr,
+					},
+				}).Result(),
+			backup: builder.ForBackup("velero", "backup").
+				CSISnapshotTimeout(10 * time.Minute).Result(),
 			expectedErr: false,
 			expectedProgress: &velero.OperationProgress{
 				Completed: true,


### PR DESCRIPTION
# Please add a summary of your change

`Progress()` in `pkg/backup/actions/csi/volumesnapshot_action.go` marked a backup
operation completed-with-error the first time it saw `vsc.Status.Error`, so any
retryable CSI error failed the backup immediately.

The snapshot controller records the CSI driver's error on the
VolumeSnapshotContent and then requeues the content, so the surface that carries
retryable errors was the one Velero treated as final. Observed with AWS
`SnapshotCreationPerVolumeRateExceeded` (an error whose own text advises
retrying with backoff) where Velero consumed the VSC error 13 ms after the
snapshot controller wrote it and 7 seconds after the backup started, while that
controller was already requeuing for a retry that would very likely have
succeeded.

This change keeps the operation running while the error is younger than
`CSISnapshotTimeout`, and treats it as terminal once it has outlived that
timeout:

```go
timeout := backup.Spec.CSISnapshotTimeout.Duration
if timeout > 0 && now.Sub(progress.Started) < timeout {
    p.log.Warnf("VolumeSnapshotContent %s has a temporary error %s. Snapshot controller will retry later.",
        vsc.Name, errorMessage)

    return progress, nil
}
```

Notes on the choices:

- **`CSISnapshotTimeout` as the bound.** It is the timeout that already governs
  how long a CSI snapshot may take, and it is what #9674 / #9727 propose for the
  VolumeSnapshot branch. Using it here leaves the two branches consistent
  instead of letting them diverge further, and it avoids waiting the much longer
  `itemOperationTimeout` for a genuinely stuck snapshot.
- **Operation age, not error age.** `progress.Started` comes from the
  operationID and needs no extra state. A VSC error means the snapshot is not
  ready, so operation age is a sound proxy for how long the failure has been in
  play.
- **Backwards compatible.** When `CSISnapshotTimeout` is zero - a Backup that
  never went through the controller's defaulting - the guard is skipped and the
  previous fail-fast behaviour is preserved. The existing
  `VSC status has error` test case passes unmodified, which demonstrates this.

Two test cases are added: a VSC error inside the timeout must leave the
operation running, and one that has outlived the timeout must complete with the
error. Both were mutation-checked - removing the guard (restoring the old
behaviour) fails the first, and inverting the comparison fails both. `Progress()`
is at 100% statement coverage.

# Does your change fix a particular issue?

Fixes #10483

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
