### PR TITLE
Fix PV patch skip for pending PVCs using the default storage class

### DIFF
--- a/pkg/controller/restore_finalizer_controller.go
+++ b/pkg/controller/restore_finalizer_controller.go
@@ -51,6 +51,10 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/util/results"
 )
 
+// isDefaultStorageClassAnnotation is the standard Kubernetes annotation
+// marking a StorageClass as the cluster default.
+const isDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
+
 type restoreFinalizerReconciler struct {
 	client.Client
 	namespace         string
@@ -375,11 +379,27 @@ func (ctx *finalizerContext) patchDynamicPVWithVolumeInfo() (errs results.Result
 					// failures due to the PVC not being bound, which could cause a timeout and result in a failed restore.
 					if pvc.Status.Phase == corev1api.ClaimPending {
 						// check if storage class used has VolumeBindingMode as WaitForFirstConsumer
-						if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
-							scName := *pvc.Spec.StorageClassName
+						scName := ""
+						if pvc.Spec.StorageClassName != nil {
+							scName = *pvc.Spec.StorageClassName
+						}
+						if scName == "" {
+							// The PVC uses the cluster default storage class (nil/empty
+							// spec.storageClassName); resolve it to check its binding mode.
+							scList := &storagev1api.StorageClassList{}
+							if err = ctx.crClient.List(context.Background(), scList); err != nil {
+								return false, err
+							}
+							for i := range scList.Items {
+								if scList.Items[i].Annotations[isDefaultStorageClassAnnotation] == "true" {
+									scName = scList.Items[i].Name
+									break
+								}
+							}
+						}
+						if scName != "" {
 							sc := &storagev1api.StorageClass{}
 							err = ctx.crClient.Get(context.Background(), client.ObjectKey{Name: scName}, sc)
-
 							if err != nil {
 								return false, err
 							}

--- a/pkg/controller/restore_finalizer_pdpv_guard_test.go
+++ b/pkg/controller/restore_finalizer_pdpv_guard_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1api "k8s.io/api/core/v1"
+	storagev1api "k8s.io/api/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/velero/internal/volume"
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/builder"
+	velerotest "github.com/vmware-tanzu/velero/pkg/test"
+)
+
+// TestPatchDynamicPVDefaultSCGuard pins the behavior of the WFFC skip guard in
+// patchDynamicPVWithVolumeInfo for PVCs that consume the cluster default
+// StorageClass (StorageClassName nil or empty).
+func TestPatchDynamicPVDefaultSCGuard(t *testing.T) {
+	wffc := storagev1api.VolumeBindingWaitForFirstConsumer
+
+	volumeInfo := []*volume.BackupVolumeInfo{
+		{
+			BackupMethod: "PodVolumeBackup",
+			PVCName:      "pvc1",
+			PVName:       "pv1",
+			PVCNamespace: "ns1",
+			PVInfo: &volume.PVInfo{
+				ReclaimPolicy: string(corev1api.PersistentVolumeReclaimDelete),
+				Labels:        map[string]string{"app": "pdpv-guard"},
+			},
+		},
+	}
+
+	newCtx := func(t *testing.T) *finalizerContext {
+		fakeClient := velerotest.NewFakeControllerRuntimeClientBuilder(t).Build()
+		return &finalizerContext{
+			logger:          velerotest.NewLogger(),
+			crClient:        fakeClient,
+			restore:         builder.ForRestore(velerov1api.DefaultNamespace, "restore").Result(),
+			restoredPVCList: map[string]struct{}{"ns1/pvc1": {}},
+			volumeInfo:      volumeInfo,
+			resourceTimeout: 2 * time.Second,
+		}
+	}
+
+	createStorageClass := func(t *testing.T, ctx *finalizerContext, name string, bindingMode *storagev1api.VolumeBindingMode, annotations map[string]string) {
+		sc := builder.ForStorageClass(name).Provisioner("prov").Result()
+		sc.VolumeBindingMode = bindingMode
+		sc.Annotations = annotations
+		require.NoError(t, ctx.crClient.Create(t.Context(), sc))
+	}
+
+	t.Run("default SC via nil StorageClassName", func(t *testing.T) {
+		ctx := newCtx(t)
+		// A WFFC storage class exists in the cluster and is marked as the
+		// cluster default; a PVC with nil StorageClassName consumes it
+		// implicitly.
+		createStorageClass(t, ctx, "default-sc", &wffc, map[string]string{"storageclass.kubernetes.io/is-default-class": "true"})
+
+		pvc := builder.ForPersistentVolumeClaim("ns1", "pvc1").
+			Phase(corev1api.ClaimPending).
+			Result()
+		require.Nil(t, pvc.Spec.StorageClassName)
+		require.NoError(t, ctx.crClient.Create(t.Context(), pvc))
+
+		start := time.Now()
+		errs := ctx.patchDynamicPVWithVolumeInfo()
+		elapsed := time.Since(start)
+
+		// The guard fires for the cluster default storage class as well: skip,
+		// no polling to resourceTimeout expiry, no error.
+		require.Empty(t, errs.Namespaces)
+		t.Logf("guard fired via default SC resolution: consumed %v of the %v resourceTimeout", elapsed, ctx.resourceTimeout)
+	})
+
+	t.Run("default SC via empty StorageClassName", func(t *testing.T) {
+		ctx := newCtx(t)
+		createStorageClass(t, ctx, "default-sc", &wffc, map[string]string{"storageclass.kubernetes.io/is-default-class": "true"})
+
+		pvc := builder.ForPersistentVolumeClaim("ns1", "pvc1").
+			Phase(corev1api.ClaimPending).
+			Result()
+		empty := ""
+		pvc.Spec.StorageClassName = &empty
+		require.NoError(t, ctx.crClient.Create(t.Context(), pvc))
+
+		errs := ctx.patchDynamicPVWithVolumeInfo()
+
+		// The guard fires for the cluster default storage class as well: skip,
+		// no error.
+		require.Empty(t, errs.Namespaces)
+	})
+
+	t.Run("explicit WFFC SC skips", func(t *testing.T) {
+		ctx := newCtx(t)
+		createStorageClass(t, ctx, "sc-wffc", &wffc, nil)
+
+		pvc := builder.ForPersistentVolumeClaim("ns1", "pvc1").
+			StorageClass("sc-wffc").
+			Phase(corev1api.ClaimPending).
+			Result()
+		require.NoError(t, ctx.crClient.Create(t.Context(), pvc))
+
+		// The guard fires for an explicitly set WFFC storage class: skip, no
+		// polling, no error.
+		errs := ctx.patchDynamicPVWithVolumeInfo()
+		require.Empty(t, errs.Namespaces)
+	})
+
+	t.Run("nil VolumeBindingMode proceeds", func(t *testing.T) {
+		ctx := newCtx(t)
+		// Binding mode nil (unset) is not WFFC: the guard must not skip.
+		createStorageClass(t, ctx, "sc-immediate", nil, nil)
+
+		pvc := builder.ForPersistentVolumeClaim("ns1", "pvc1").
+			StorageClass("sc-immediate").
+			VolumeName("new-pv1").
+			Phase(corev1api.ClaimBound).
+			Result()
+		require.NoError(t, ctx.crClient.Create(t.Context(), pvc))
+
+		pv := builder.ForPersistentVolume("new-pv1").
+			ClaimRef("ns1", "pvc1").
+			Phase(corev1api.VolumeBound).
+			ReclaimPolicy(corev1api.PersistentVolumeReclaimRetain).
+			Result()
+		require.NoError(t, ctx.crClient.Create(t.Context(), pv))
+
+		errs := ctx.patchDynamicPVWithVolumeInfo()
+		require.Empty(t, errs.Namespaces)
+
+		// The patch path ran: PV ReclaimPolicy updated to the value from the
+		// BackupVolumeInfo (expectedPatch verification pattern).
+		got := &corev1api.PersistentVolume{}
+		require.NoError(t, ctx.crClient.Get(t.Context(), client.ObjectKey{Name: "new-pv1"}, got))
+		require.Equal(t, corev1api.PersistentVolumeReclaimDelete, got.Spec.PersistentVolumeReclaimPolicy)
+	})
+}


### PR DESCRIPTION
# Please add a summary of your change

- Pending PVCs whose `spec.storageClassName` is nil or empty (cluster default storage class) never reached the WaitForFirstConsumer skip added in #10271, so their PV patch step polled until `resourceTimeout` and failed the restore.
- This PR resolves the default storage class via the `storageclass.kubernetes.io/is-default-class` annotation and applies the same skip; regression tests cover nil/empty storage class names, the explicit WFFC skip, and the Immediate proceed path.

# Does your change fix a particular issue?

- No existing issue — found while writing regression tests for the guard added in #10271 (which shipped without tests).

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
