### PR TITLE
fix: bound VolumeSnapshot and VolumeSnapshotContent error retry by CSISnapshotTimeout

### DIFF
--- a/changelogs/unreleased/10483-webdevsamran
+++ b/changelogs/unreleased/10483-webdevsamran
@@ -1,0 +1,1 @@
+Bound VolumeSnapshot and VolumeSnapshotContent error retry by CSISnapshotTimeout during CSI async backup

--- a/pkg/backup/actions/csi/volumesnapshot_action.go
+++ b/pkg/backup/actions/csi/volumesnapshot_action.go
@@ -300,8 +300,20 @@ func (p *volumeSnapshotBackupItemAction) Progress(
 		if vs.Status.Error.Message != nil {
 			errorMessage = *vs.Status.Error.Message
 		}
-		p.log.Warnf("VolumeSnapshot has a temporary error %s. Snapshot controller will retry later.",
-			errorMessage)
+
+		timeout := backup.Spec.CSISnapshotTimeout.Duration
+		if timeout > 0 && time.Since(progress.Started) >= timeout {
+			p.log.Errorf("VolumeSnapshot %s/%s has a persistent error beyond CSISnapshotTimeout (%s): %s",
+				vs.Namespace, vs.Name, timeout, errorMessage)
+			progress.Completed = true
+			progress.Updated = time.Now()
+			progress.Err = fmt.Sprintf("VolumeSnapshot %s/%s has a persistent error: %s",
+				vs.Namespace, vs.Name, errorMessage)
+			return progress, nil
+		}
+
+		p.log.Warnf("VolumeSnapshot %s/%s has a temporary error %s. Snapshot controller will retry later.",
+			vs.Namespace, vs.Name, errorMessage)
 
 		return progress, nil
 	}
@@ -331,12 +343,23 @@ func (p *volumeSnapshotBackupItemAction) Progress(
 			progress.Completed = true
 			progress.Updated = now
 		} else if vsc.Status.Error != nil {
-			progress.Completed = true
-			progress.Updated = now
+			errorMessage := ""
 			if vsc.Status.Error.Message != nil {
-				progress.Err = *vsc.Status.Error.Message
+				errorMessage = *vsc.Status.Error.Message
 			}
-			p.log.Warnf("VolumeSnapshotContent meets an error %s.", progress.Err)
+
+			timeout := backup.Spec.CSISnapshotTimeout.Duration
+			if timeout > 0 && time.Since(progress.Started) >= timeout {
+				p.log.Errorf("VolumeSnapshotContent %s has a persistent error beyond CSISnapshotTimeout (%s): %s",
+					vsc.Name, timeout, errorMessage)
+				progress.Completed = true
+				progress.Updated = now
+				progress.Err = fmt.Sprintf("VolumeSnapshotContent %s has a persistent error: %s",
+					vsc.Name, errorMessage)
+			} else {
+				p.log.Warnf("VolumeSnapshotContent %s has a temporary error %s. Snapshot controller will retry later.",
+					vsc.Name, errorMessage)
+			}
 		}
 	}
 

--- a/pkg/backup/actions/csi/volumesnapshot_action_test.go
+++ b/pkg/backup/actions/csi/volumesnapshot_action_test.go
@@ -19,6 +19,7 @@ package csi
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -219,7 +220,7 @@ func TestVSProgress(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			name:        "VS status has error",
+			name:        "VS status has error, no CSISnapshotTimeout configured",
 			operationID: "ns/name/2024-04-11T18:49:00+08:00",
 			vs: builder.ForVolumeSnapshot("ns", "name").Status().
 				StatusError(snapshotv1api.VolumeSnapshotError{
@@ -227,6 +228,30 @@ func TestVSProgress(t *testing.T) {
 				}).Result(),
 			backup:      builder.ForBackup("velero", "backup").Result(),
 			expectedErr: false,
+		},
+		{
+			name:        "VS status has error within CSISnapshotTimeout",
+			operationID: "ns/name/" + time.Now().Format(time.RFC3339),
+			vs: builder.ForVolumeSnapshot("ns", "name").Status().
+				StatusError(snapshotv1api.VolumeSnapshotError{
+					Message: &errorStr,
+				}).Result(),
+			backup:      builder.ForBackup("velero", "backup").CSISnapshotTimeout(10 * time.Minute).Result(),
+			expectedErr: false,
+		},
+		{
+			name:        "VS status has persistent error beyond CSISnapshotTimeout",
+			operationID: "ns/name/2024-04-11T18:49:00+08:00",
+			vs: builder.ForVolumeSnapshot("ns", "name").Status().
+				StatusError(snapshotv1api.VolumeSnapshotError{
+					Message: &errorStr,
+				}).Result(),
+			backup:      builder.ForBackup("velero", "backup").CSISnapshotTimeout(10 * time.Minute).Result(),
+			expectedErr: false,
+			expectedProgress: &velero.OperationProgress{
+				Completed: true,
+				Err:       fmt.Sprintf("VolumeSnapshot ns/name has a persistent error: %s", errorStr),
+			},
 		},
 		{
 			name:        "Fail to get VSC",
@@ -259,7 +284,21 @@ func TestVSProgress(t *testing.T) {
 			expectedProgress: &velero.OperationProgress{Completed: true},
 		},
 		{
-			name:        "VSC status has error",
+			name:        "VSC status has error within CSISnapshotTimeout",
+			operationID: "ns/name/" + time.Now().Format(time.RFC3339),
+			vs: builder.ForVolumeSnapshot("ns", "name").Status().
+				ReadyToUse(true).BoundVolumeSnapshotContentName("vsc").Result(),
+			vsc: builder.ForVolumeSnapshotContent("vsc").
+				Status(&snapshotv1api.VolumeSnapshotContentStatus{
+					Error: &snapshotv1api.VolumeSnapshotError{
+						Message: &errorStr,
+					},
+				}).Result(),
+			backup:      builder.ForBackup("velero", "backup").CSISnapshotTimeout(10 * time.Minute).Result(),
+			expectedErr: false,
+		},
+		{
+			name:        "VSC status has persistent error beyond CSISnapshotTimeout",
 			operationID: "ns/name/2024-04-11T18:49:00+08:00",
 			vs: builder.ForVolumeSnapshot("ns", "name").Status().
 				ReadyToUse(true).BoundVolumeSnapshotContentName("vsc").Result(),
@@ -269,11 +308,11 @@ func TestVSProgress(t *testing.T) {
 						Message: &errorStr,
 					},
 				}).Result(),
-			backup:      builder.ForBackup("velero", "backup").Result(),
+			backup:      builder.ForBackup("velero", "backup").CSISnapshotTimeout(10 * time.Minute).Result(),
 			expectedErr: false,
 			expectedProgress: &velero.OperationProgress{
 				Completed: true,
-				Err:       "error",
+				Err:       fmt.Sprintf("VolumeSnapshotContent vsc has a persistent error: %s", errorStr),
 			},
 		},
 	}


### PR DESCRIPTION
﻿# Please add a summary of your change

In `pkg/backup/actions/csi/volumesnapshot_action.go`, `Progress()` previously treated `VolumeSnapshotContent` errors (`vsc.Status.Error != nil`) as terminal failures on first sight (marking `progress.Completed = true` and `progress.Err = *vsc.Status.Error.Message`), causing immediate backup failure (`PartiallyFailed`) when the external snapshotter controller encountered retryable provider errors (such as AWS `SnapshotCreationPerVolumeRateExceeded`). Conversely, `VolumeSnapshot` errors (`vs.Status.Error != nil`) were unconditionally treated as temporary, allowing them to hang until `itemOperationTimeout` (4 hours).

This PR brings consistent, symmetrical error handling to both `VolumeSnapshot` and `VolumeSnapshotContent`:
1. If `vsc.Status.Error != nil` occurs within the configured `backup.Spec.CSISnapshotTimeout`, Velero logs a warning and allows the external snapshotter controller to retry instead of terminating immediately.
2. If either `vs.Status.Error` or `vsc.Status.Error` persists beyond `backup.Spec.CSISnapshotTimeout`, Velero marks the operation failed with a descriptive error message, failing early rather than hanging until `ItemOperationTimeout`.
3. Added unit tests covering both transient (within timeout window) and persistent (beyond timeout) error scenarios for both `VolumeSnapshot` and `VolumeSnapshotContent`.
4. Added changelog entry in `changelogs/unreleased/10483-webdevsamran`.

# Does your change fix a particular issue?

Fixes #10483

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
