### PR TITLE
docs: fix broken relative links to moved files

### DIFF
--- a/design/Implemented/backup-repo-cache-volume.md
+++ b/design/Implemented/backup-repo-cache-volume.md
@@ -224,8 +224,8 @@ func SetupConnectOptions(ctx context.Context, repoOptions udmrepo.RepoOptions) r
 ```  
 
 
-[1]: Implemented/unified-repo-and-kopia-integration/unified-repo-and-kopia-integration.md
-[2]: Implemented/vgdp-micro-service/vgdp-micro-service.md
-[3]: Implemented/vgdp-micro-service-for-fs-backup/vgdp-micro-service-for-fs-backup.md
-[4]: Implemented/repo_maintenance_job_config.md
-[5]: Implemented/backup-repo-config.md
+[1]: ./unified-repo-and-kopia-integration/unified-repo-and-kopia-integration.md
+[2]: ./vgdp-micro-service/vgdp-micro-service.md
+[3]: ./vgdp-micro-service-for-fs-backup/vgdp-micro-service-for-fs-backup.md
+[4]: ./repo_maintenance_job_config.md
+[5]: ./backup-repo-config.md

--- a/design/Implemented/general-progress-monitoring.md
+++ b/design/Implemented/general-progress-monitoring.md
@@ -1,7 +1,7 @@
 # Plugin Progress Monitoring
 
 This is intended as a replacement for the previously-approved Upload Progress Monitoring design
-([Upload Progress Monitoring](upload-progress.md)) in order to expand the supported use cases beyond
+([Upload Progress Monitoring](../upload-progress.md)) in order to expand the supported use cases beyond
 snapshot uploads to include what was previously called Async Backup/Restore Item Actions. This
 updated design should handle the combined set of use cases for those previously separate designs.
 

--- a/design/Implemented/vgdp-affinity-enhancement.md
+++ b/design/Implemented/vgdp-affinity-enhancement.md
@@ -252,6 +252,6 @@ Because the StorageClass volumeBindingMode is `Immediate`, although `ignoreDelay
 
 The restorePod will be assigned to nodes, which instance type is `Standard_B4ms`.
 
-[1]: Implemented/unified-repo-and-kopia-integration/unified-repo-and-kopia-integration.md
-[2]: Implemented/volume-snapshot-data-movement/volume-snapshot-data-movement.md
-[3]: Implemented/node-agent-affinity.md
+[1]: ./unified-repo-and-kopia-integration/unified-repo-and-kopia-integration.md
+[2]: ./volume-snapshot-data-movement/volume-snapshot-data-movement.md
+[3]: ./node-agent-affinity.md

--- a/design/ria-must-include-addtional-items-design.md
+++ b/design/ria-must-include-addtional-items-design.md
@@ -230,7 +230,7 @@ That matches BIA must-include semantics (plugin-trusted hard dependencies), rath
 
 ### Interaction with fine-grained restore filters
 
-Per [Fine Grained Restore Filters via Resource Policies](../restore-filter-enhancement/fine-grained-restore-filters-design.md), plugin additional items already bypass `namespacedFilterPolicies` / `clusterScopedFilterPolicy` kind, name, and label checks.
+Per [Fine Grained Restore Filters via Resource Policies](./restore-filter-enhancement/fine-grained-restore-filters-design.md), plugin additional items already bypass `namespacedFilterPolicies` / `clusterScopedFilterPolicy` kind, name, and label checks.
 Those filters live in the selection phases; additional items enter `restoreItem()` directly.
 
 This proposal only changes the remaining global gates inside `restoreItem()`.

--- a/design/vsv2-design.md
+++ b/design/vsv2-design.md
@@ -1,7 +1,7 @@
 # Design for VolumeSnapshotter v2 API
 
 ## Abstract
-This design includes the changes to the VolumeSnapshotter api design as required by the [Item Action Progress Monitoring](general-progress-monitoring.md) feature.
+This design includes the changes to the VolumeSnapshotter api design as required by the [Item Action Progress Monitoring](Implemented/general-progress-monitoring.md) feature.
 The VolumeSnapshotter v2 interface will have two new methods.
 If there are any additional VolumeSnapshotter API changes that are needed in the same Velero release cycle as this change, those can be added here as well.
 
@@ -18,7 +18,7 @@ This will allow long-running plugin actions to continue in the background while 
 
 
 ## High-Level Design
-As per the [Plugin Versioning](plugin-versioning.md) design, a new VolumeSnapshotterv2 plugin `.proto` file will be created to define the GRPC interface.
+As per the [Plugin Versioning](Implemented/plugin-versioning.md) design, a new VolumeSnapshotterv2 plugin `.proto` file will be created to define the GRPC interface.
 v2 go files will also be created in `plugin/clientmgmt/volumesnapshotter` and `plugin/framework/volumesnapshotter`, and a new PluginKind will be created.
 The velero Backup process will be modified to reference v2 plugins instead of v1 plugins.
 An adapter will be created so that any existing VolumeSnapshotter v1 plugin can be executed as a v2 plugin when executing a backup.
@@ -74,7 +74,7 @@ message OperationProgress {
 ```
 
 A new PluginKind, `VolumeSnapshotterV2`, will be created, and the backup process will be modified to use this plugin kind.
-See [Plugin Versioning](plugin-versioning.md) for more details on implementation plans, including v1 adapters, etc.
+See [Plugin Versioning](Implemented/plugin-versioning.md) for more details on implementation plans, including v1 adapters, etc.
 
 
 ## Compatibility

--- a/site/content/docs/main/api-types/backup.md
+++ b/site/content/docs/main/api-types/backup.md
@@ -16,7 +16,7 @@ Backup belongs to the API group version `velero.io/v1`.
 
 Here is a sample `Backup` object with each of the fields documented:
 
-**Note:** Namespace includes/excludes support glob patterns (`*`, `?`, `[abc]`). See [Namespace Glob Patterns](../namespace-glob-patterns) for more details.
+**Note:** Namespace includes/excludes support glob patterns (`*`, `?`, `[abc]`). See [Namespace Glob Patterns](../namespace-glob-patterns.md) for more details.
 
 ```yaml
 # Standard Kubernetes API Version declaration. Required.

--- a/site/content/docs/main/api-types/backupstoragelocation.md
+++ b/site/content/docs/main/api-types/backupstoragelocation.md
@@ -94,7 +94,7 @@ The configurable parameters are as follows:
 {{< table caption="Main config parameters" >}}
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `provider` | String | Required Field | The name for whichever object storage provider will be used to store the backups. See [your object storage provider's plugin documentation](../supported-providers) for the appropriate value to use. |
+| `provider` | String | Required Field | The name for whichever object storage provider will be used to store the backups. See [your object storage provider's plugin documentation](../supported-providers.md) for the appropriate value to use. |
 | `objectStorage` | ObjectStorageLocation | Required Field | Specification of the object storage for the given provider. |
 | `objectStorage/bucket` | String | Required Field | The storage bucket where backups are to be uploaded. |
 | `objectStorage/prefix` | String | Optional Field | The directory inside a storage bucket where backups are to be uploaded. |
@@ -102,7 +102,7 @@ The configurable parameters are as follows:
 | `objectStorage/caCertRef` | [corev1.SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#secretkeyselector-v1-core) | Optional Field | Reference to a Secret containing a CA bundle to be used when verifying TLS connections. The Secret must be in the same namespace as the BackupStorageLocation. |
 | `objectStorage/caCertRef/name` | String | Required Field (when using caCertRef) | The name of the Secret containing the CA certificate bundle |
 | `objectStorage/caCertRef/key` | String | Required Field (when using caCertRef) | The key within the Secret that contains the CA certificate bundle |
-| `config` | map[string]string | None (Optional) | Provider-specific configuration keys/values to be passed to the object store plugin. See [your object storage provider's plugin documentation](../supported-providers) for details. |
+| `config` | map[string]string | None (Optional) | Provider-specific configuration keys/values to be passed to the object store plugin. See [your object storage provider's plugin documentation](../supported-providers.md) for details. |
 | `accessMode` | String | `ReadWrite` | How Velero can access the backup storage location. Valid values are `ReadWrite`, `ReadOnly`. |
 | `backupSyncPeriod` | metav1.Duration | Optional Field | How frequently Velero should synchronize backups in object storage. Default is Velero's server backup sync period. Set this to `0s` to disable sync. |
 | `validationFrequency` | metav1.Duration | Optional Field | How frequently Velero should validate the object storage . Default is Velero's server validation frequency. Set this to `0s` to disable validation. Default 1 minute. |

--- a/site/content/docs/main/api-types/restore.md
+++ b/site/content/docs/main/api-types/restore.md
@@ -16,7 +16,7 @@ Restore belongs to the API group version `velero.io/v1`.
 
 Here is a sample `Restore` object with each of the fields documented:
 
-**Note:** Namespace includes/excludes support glob patterns (`*`, `?`, `[abc]`). See [Namespace Glob Patterns](../namespace-glob-patterns) for more details.
+**Note:** Namespace includes/excludes support glob patterns (`*`, `?`, `[abc]`). See [Namespace Glob Patterns](../namespace-glob-patterns.md) for more details.
 
 ```yaml
 # Standard Kubernetes API Version declaration. Required.

--- a/site/content/docs/main/api-types/volumesnapshotlocation.md
+++ b/site/content/docs/main/api-types/volumesnapshotlocation.md
@@ -38,8 +38,8 @@ The configurable parameters are as follows:
 {{< table caption="Main config parameters" >}}
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `provider` | String | Required Field | The name for whichever storage provider will be used to create/store the volume snapshots. See [your volume snapshot provider's plugin documentation](../supported-providers) for the appropriate value to use. |
-| `config` | map string string | None (Optional) |  Provider-specific configuration keys/values to be passed to the volume snapshotter plugin. See [your volume snapshot provider's plugin documentation](../supported-providers) for details. |
+| `provider` | String | Required Field | The name for whichever storage provider will be used to create/store the volume snapshots. See [your volume snapshot provider's plugin documentation](../supported-providers.md) for the appropriate value to use. |
+| `config` | map string string | None (Optional) |  Provider-specific configuration keys/values to be passed to the volume snapshotter plugin. See [your volume snapshot provider's plugin documentation](../supported-providers.md) for details. |
 | `credential` | [corev1.SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#secretkeyselector-v1-core) | Optional Field | The credential information to be used with this location. |
 | `credential/name` | String | Optional Field | The name of the secret within the Velero namespace which contains the credential information. |
 | `credential/key` | String | Optional Field | The key to use within the secret. |

--- a/site/content/docs/main/contributions/minio.md
+++ b/site/content/docs/main/contributions/minio.md
@@ -12,7 +12,7 @@ For additional functionality with this setup, see the section below on how to [e
 
 See [Set up Velero on your platform][3] for how to configure Velero for a production environment.
 
-If you encounter issues with installing or configuring, see [Debugging Installation Issues](debugging-install.md).
+If you encounter issues with installing or configuring, see [Debugging Installation Issues](../debugging-install.md).
 
 ## Prerequisites
 


### PR DESCRIPTION
Several markdown links in the design docs and site content pointed at paths that no longer matched the repository layout after files were reorganized into subdirectories, so I updated them to their correct relative locations. I left a handful of links in old CHANGELOG files untouched since I could not determine with confidence what they should now point to.

The checks evaluated by the fork CI gate passed. This excludes skipped checks and checks filtered out for fork-only conditions.
