### PR TITLE
Design: propose shared bounded Backup/Restore cancellation

### DIFF
--- a/design/restore-cancellation-design.md
+++ b/design/restore-cancellation-design.md
@@ -1,0 +1,296 @@
+# Explicit cancellation of Restores
+
+Status: proposal for discussion, revised after [sseago's feedback](https://github.com/velero-io/velero/issues/9190#issuecomment-5602961803); no API or implementation has been approved.
+Related issues: [restore cancellation #9190](https://github.com/velero-io/velero/issues/9190) and [backup cancellation #2098](https://github.com/velero-io/velero/issues/2098).
+Proposed implementation contributor: Ruslan Shaydullin; a design reviewer has not yet committed.
+The original restore request/direction belongs to Lyndon-Li and blackpiglet; sseago supplied the explicit-cancellation and shared-API direction.
+Source audit: `cbd9059f8006211170e2ac9911221f1ea30d1082`; earlier diagnostic probes ran on `193cfdc58f9bddf43be6196a29512c8a2d7f175d`.
+The intervening changes update gRPC and version-priority line-ending parsing; the audited cancellation and phase-writing paths are unchanged.
+Codex assisted the investigation, fixtures and drafting; independent source audits accompany this proposal, with review evidence retained by the contributor.
+
+## Abstract
+
+Introduce explicit cancellation of a non-terminal Restore while retaining its object and available diagnostic metadata.
+Use an API pattern compatible with future backup cancellation, stop further restore work, and report cancellation honestly without rolling back restored resources or data.
+
+## Background
+
+In #9190, sseago asks for cancellation as an operation distinct from deleting a Restore, with eventual APIs similar to backup cancellation.
+In [#2098](https://github.com/velero-io/velero/issues/2098#issuecomment-2634886944), an explicit spec field or a cancellation-request CR was discussed; later discussion favors preserving the object and using a distinct terminal [Canceled phase](https://github.com/velero-io/velero/issues/2098#issuecomment-2640290422).
+[Terminal backups remain unchanged when cancellation arrives too late](https://github.com/velero-io/velero/issues/2098#issuecomment-3211169866).
+These provide design direction; the exact shared API is still to be agreed with the backup contributors.
+
+The current Restore controller runs the restore synchronously within Reconcile, while independent operations and finalizer controllers perform later work and metadata writes.
+DataDownload and PodVolumeRestore already expose cancellation, and server startup already fails stale InProgress Restores and requests child cancellation.
+Three earlier component probes demonstrated deferred delete reconciliation, lack of explicit child coordination in the parent's delete branch, and continued real-engine item creation after a fake-API deletion request.
+Those tests describe existing Delete behavior; they do not test the API proposed here, real volume cancellation, Kubernetes GC, restart, or production data loss.
+
+## Goals
+
+- Provide an explicit, observable cancellation operation with a shared backup/restore API convention and an unambiguous completion race.
+- Stop participating producers and coordinate owned operations and cleanup while preserving Restore identity, diagnostics and destination storage.
+- Recover an accepted cancellation after process restart and prevent late normal writers from undoing its outcome.
+
+## Non Goals
+
+- Roll back already restored Kubernetes objects or bytes, resume a canceled Restore, or guarantee instantaneous physical termination across a partition.
+- Implement backup cancellation in this change, replace child cancellation protocols, or redesign the plugin interface.
+- Make deletion of every running Restore automatically request cancellation in this first implementation; concurrent deletion of an already accepted cancellation is covered below.
+
+## High-Level Design
+
+The preferred proposal is a namespaced `RestoreCancellationRequest` with an immutable target name and UID, accompanied by a `velero restore cancel NAME` command.
+The server accepts a request by a conditional update on the target Restore that records durable cancellation identity/time, installs its existing cleanup finalizer if necessary, and changes its phase to proposed `Canceling`.
+A coordinator independent of the busy Restore workqueue stops local producers, coordinates child/plugin outcomes and required temporary-resource cleanup, persists available diagnostics, and finally records proposed `Canceled`.
+Standalone cancellation does not invoke DeleteRestore or remove the Restore object, diagnostic metadata, or its ordinary external-resources finalizer.
+
+Request creation and cancellation acceptance are different events.
+All normal phase writers and the cancellation coordinator use the same UID/resourceVersion-checked transition contract, so normal terminal completion and cancellation acceptance have one ordering point.
+The in-memory execution registry makes cancellation responsive; the persisted Restore record makes it recoverable.
+Normal restore concurrency remains bounded by the existing worker limits.
+
+## Detailed Design
+
+### API proposal and backup alignment
+
+The following names and shapes are proposed for review, not existing API.
+A future `BackupCancellationRequest` should use the same target-identity, request-outcome and terminal-race conventions; backup repository/snapshot cleanup remains its own design.
+The backup issue is assigned to other contributors, so agreement on this shared pattern does not transfer that implementation to this contribution.
+
+```yaml
+apiVersion: velero.io/v1
+kind: RestoreCancellationRequest
+metadata:
+  generateName: restore-cancel-
+  namespace: velero
+spec:
+  target:
+    name: restore-example
+    uid: 5b857595-d70d-4f06-afb7-aa87c775c613
+```
+
+The example UID is illustrative; the CLI reads the real Restore UID immediately before creating the request.
+The target is always in the request's namespace, both target fields are required and nonempty, and the entire spec is immutable through CRD validation.
+Validate that the chosen immutability mechanism works at Velero's supported Kubernetes minimum before publishing the schema.
+The controller verifies the live UID before every target transition; a same-name replacement is never retargeted.
+
+| Object | Proposed state | Meaning |
+|---|---|---|
+| Request | New (including empty) | Submitted; the target has not necessarily accepted cancellation |
+| Request | InProgress | Its UID-matched target accepted cancellation or this request joined an accepted cancellation |
+| Request | Completed | Target reached Canceled under the contract below, or was already Canceled |
+| Request | Failed | Definitive rejection: TargetNotFound, TargetUIDMismatch, AlreadyTerminal, AlreadyDeleting or UnsupportedPhase; TargetLost means the result became unverifiable after acceptance |
+| Restore | Canceling | Cancellation was durably accepted; normal work must stop, required outcomes are still being reconciled |
+| Restore | Canceled | Producer and supported-operation/cleanup barriers completed; partial results remain available |
+
+Request status proposes `phase`, `reason`, `message`, `acceptedAt` and `completionTimestamp`.
+The new request CR has a status subresource: client-supplied status on create is ignored, and only the controller writes its result.
+Invalid or missing required spec fields are rejected by the API server; transient API errors are retried and do not become a definitive request Failed result.
+If an accepted target disappears or is replaced before a terminal result is observed, a surviving request reports Failed/TargetLost with its acceptedAt retained; this means its outcome is unknown, not that external work stopped or the Restore became Failed.
+Never retarget a replacement or infer success from absence.
+A blocked accepted cancellation whose target still exists stays InProgress with a concrete reason; it must not become Completed merely because a timer expired.
+
+Restore status proposes `cancellation` containing `requestUID`, `acceptedAt`, `completionTimestamp` and bounded `conditions` for ProducersStopped, OperationsSettled, TemporaryResourcesCleaned and DiagnosticsPersisted.
+The stored request UID is the identity of the first accepted logical cancellation; subsequent requests observe that same operation.
+Conditions carry normal True/False/Unknown, reason, message and transition time; they describe observations rather than unbounded lists of child objects.
+The existing Restore completion timestamp is set only when Canceled is committed, not when cancellation is requested.
+
+Current Restore has no status subresource.
+This proposal preserves that existing endpoint and uses conditional whole-object updates for the relevant status/finalizer transitions; introducing a Restore status subresource would require a separate compatibility decision.
+Write request acceptance only after the parent commit; a crash between these writes is repaired from the durable parent marker.
+All controller code sharing these transitions must use fresh reads and concurrency preconditions as described below.
+
+### CLI, authorization and request lifecycle
+
+`velero restore cancel NAME` reads the target, creates a UID-bound request and prints that submission is pending; an API create acknowledgment is not reported as completed cancellation.
+Proposed `--wait` observes the request and UID-matched Restore until Completed, definitive Failed, or the caller's wait timeout.
+A CLI timeout leaves server cancellation running; it must print the request identity so the operator can inspect the outcome later.
+Repeated CLI invocations may create separate request records, but they join one target cancellation.
+The CLI can poll the UID-matched Restore with get when its request disappears; a watch-based fallback additionally requires watch on restores.
+Request/get/describe output must show the actual request result and the target's phase without requiring users to infer success from deletion.
+
+Creating a cancellation request grants cancellation capability for any Restore in that namespace.
+It does not provide per-object authorization simply because the target has a UID.
+The minimal caller role needs get on restores and create/get/watch on restorecancellationrequests; it does not need Restore update, patch or delete.
+Controller roles add request list/watch/status permissions and the existing target/child permissions required by the lifecycle.
+Do not grant request creation to default read-only roles; cluster administrators must explicitly choose the namespace-wide cancellation capability.
+A supplied username/annotation is not a trustworthy caller identity and must not be used for an impersonated authorization check.
+
+Deleting a request before acceptance may withdraw that unaccepted submission; the controller must re-read it with no deletionTimestamp before attempting acceptance.
+Deletion can still race that read and acceptance on another object, so withdrawing a request is not a guaranteed cancellation-of-cancellation API.
+After acceptance, deleting the request never resumes work: Restore.status.cancellation is authoritative, and the coordinator also watches Canceling Restores directly.
+Request records need no finalizer to keep an accepted cancellation alive.
+This initial proposal leaves completed request retention to the operator, instead of adding a new automatic TTL policy.
+
+### Acceptance and the completion race
+
+Treat empty phase, New, InProgress, WaitingForPluginOperations, WaitingForPluginOperationsPartiallyFailed, Finalizing and FinalizingPartiallyFailed as cancellable.
+Completed, PartiallyFailed, Failed and FailedValidation are existing terminal outcomes and remain unchanged when an unaccepted cancellation is too late.
+A target already Canceled completes a new UID-matched request with reason AlreadyCanceled; a target Canceling joins its existing cancellation.
+An unknown phase is rejected explicitly rather than guessed to be cancellable.
+
+Acceptance is a single optimistic update of the freshly read Restore: verify UID/resourceVersion, require a cancellable phase and no deletionTimestamp, retain/add ExternalResourcesFinalizer, and atomically write Canceling plus the cancellation record.
+Normal completion and acceptance must use this same conditional update discipline.
+If normal terminal completion commits first, request processing observes AlreadyTerminal and does not mutate the Restore.
+If cancellation acceptance commits first, any old completion, validation-failure, finalization or startup-failure write must conflict and then preserve Canceling when it re-reads.
+
+The current PatchResource helper uses a plain merge patch; its retry helper repeats the same snapshots.
+It is therefore insufficient to add conditional writes only in the new coordinator.
+Introduce a scoped Restore-transition helper or equivalent at every participating writer, with UID checks, resourceVersion preconditions and a fresh decision on each retry; do not blindly replay stale normal status.
+This includes initial admission/validation, synchronous restore completion, plugin-operation phase updates, finalization and startup recovery.
+Ordinary counters and diagnostic patches also need to avoid replaying a stale phase or cancellation record.
+
+The ordering point governs the recorded outcome, not an impossible instantaneous barrier on all external side effects.
+A resource request already in flight may finish after acceptance.
+The completed ProducersStopped condition is the boundary after which participating local producers must not initiate further restore work.
+
+### Stop producers and coordinate existing controllers
+
+Register work under namespace/Restore UID before side effects, then make a fresh authoritative state check after registration.
+This closes the case where the cancellation observer saw the request before the producer registered.
+The observer cancels active contexts and prevents new registrations for an accepted cancellation; context cancellation alone is not acknowledgment that work exited.
+Thread the context through engine iteration, PVR waits, informer synchronization, restore hooks, relevant Kubernetes calls and server/leader shutdown.
+Keep the per-UID execution registry entry and hook cancellation/acknowledgment alive through operations and finalization; hooks can outlive the synchronous engine stage.
+Wait for participating work to acknowledge completion and repeat dependent-operation discovery after this barrier to capture late creations from previously admitted calls.
+Use a separate bounded reconciliation/persistence context for cancellation coordination, child patches and diagnostics; an already canceled work context cannot perform that cleanup.
+Do not terminate a shared plugin process to stop one Restore, and do not assume a wrapper context interrupts plugin methods that accept no context.
+
+The operations and restore-finalizer controllers must stop new restorative work and ordinary phase progression after cancellation wins.
+Allow only the agreed cancellation cleanup and diagnostic-persistence paths, under coordinated writer ownership.
+Persist partial resource/volume information and known operation IDs even when the synchronous engine exits by cancellation; do not lose them through an early-return path.
+Do not complete normal restore hooks or signal successful volume restoration merely to unblock destination pods.
+The recovery implications for partially restored workloads must be documented.
+
+### Children, plugins, storage and completion
+
+Reuse DD/PVR spec.cancel and their actual worker/informer handshake, preserving namespace, owner UID and compatible historical child identity checks.
+Completed or Failed children that won their own race remain valid terminal outcomes; do not rewrite all children to Canceled.
+The local microservice watcher Cancel method alone is insufficient because that method currently only logs.
+
+A child Canceled phase can precede best-effort temporary-resource cleanup.
+Require both the agreed operation result and observed safe cleanup for owned temporary resources; a terminal CR alone is not that evidence.
+Reconcile failed cleanup rather than forcibly removing child finalizers or releasing local watchers to manufacture completion.
+For supported in-place modes, verify existing destination PV/PVC ownership and preservation before enabling cancellation: the current generic cleanup can act on a temporary PVC bound to an existing target PV.
+Any missing preservation guard is an implementation prerequisite or an explicitly agreed unsupported-mode boundary, not a reproduced claim of data loss.
+
+Preserve every known plugin operation ID and request best-effort cancellation using its existing contract.
+A successful optional Cancel call is not proof of termination; unknown or unsupported results stay explicit.
+The engine currently learns the operation ID after Execute returns and persists its operation list after the synchronous stage.
+External work that starts before an ID is durably recorded cannot be guaranteed recoverable after a crash without another plugin/persistence contract.
+Retry behavior must account for ambiguous results and process crashes; exactly-once Cancel invocation is not promised.
+
+The proposed conservative completion policy keeps Restore Canceling and requests InProgress while producer acknowledgment, relevant operation termination, storage preservation or required cleanup is unresolved.
+A diagnostic deadline can expose a blocked condition and operator guidance, but does not automatically declare Canceled or force deletion.
+The deadline source/default and manual recovery guidance must be agreed before implementation; existing child cancellation grace periods are not automatically a new parent deadline.
+This can leave an unavailable-worker/plugin case pending indefinitely, so maintainers must explicitly accept the tradeoff or choose a visibly weaker bounded outcome.
+Canceled means the agreed control-plane and supported-operation contract completed; it is not a guarantee of physical process termination on an unreachable node or of rollback.
+
+Retain the Restore object, its normal cleanup finalizer, available logs, results, resource/volume summaries and operation metadata after standalone cancellation.
+Serialize final diagnostic persistence so a late normal writer cannot erase the cancellation outcome.
+For a Restore canceled before starting, there may be no object-store artifacts; represent that absence accurately instead of blocking on files that never existed.
+Persist durable execution/artifact availability information so download and CLI consumers can distinguish never-started work from a failed upload.
+A required operation-ID checkpoint failure blocks accounting for external work; an optional log upload failure must be reported without claiming logs exist.
+For partially executed work, the exact mandatory diagnostic set and handling of optional upload failures must be agreed before implementation; required persistence failures remain visible and retryable.
+
+### Delete interaction and restart
+
+If Delete wins before acceptance, reject the explicit request as AlreadyDeleting without rewriting the deleting Restore's outcome.
+Automatic cancellation for every pre-existing delete-first path is a separate scope decision.
+If cancellation was accepted first, the existing Restore deletion branch must wait for committed Canceled, including the agreed terminal diagnostic-persistence outcome and acknowledgment that every diagnostic/operation-metadata writer has exited, before calling DeleteRestore or removing its finalizer.
+The separate persistence context must be drained too; no cancellation or normal writer may upload metadata after deletion begins.
+A separate Delete can therefore remove a canceled record later; cancellation alone never does so.
+The finalizer installed atomically at acceptance also covers cancel-before-start followed immediately by Delete.
+This cancellation-first/delete-second protection is required in the first change because otherwise ordinary deletion can erase metadata the accepted coordinator still needs.
+
+After restart, scan accepted Canceling Restores independently of whether their original request CR still exists.
+Reuse current DD/PVR startup handling, but do not let the existing stale-InProgress-to-Failed path overwrite an accepted cancellation.
+Persist acceptedAt rather than restarting elapsed-time diagnostics from zero.
+An empty local registry after restart or leader change is not proof that remote work stopped; reconstruct known children/operation metadata and retain unresolved evidence.
+Old workers and callbacks must pass identity/state fences before updating outcomes.
+Validate RestoreUID on name-keyed operation-cache entries; do not use a restore-name label alone to authorize cleanup of temporary resources after a name is reused.
+
+### Compatibility and acceptance matrix
+
+| Case | Required result |
+|---|---|
+| Cancel New before any work | No producer starts after its admission check; Canceled retains the record; absent logs are reported as absent |
+| Request UID differs from live target | Definitive rejection; replacement Restore untouched |
+| Normal completion versus acceptance | Conditional update winner determines terminal no-op or Canceling; stale loser cannot overwrite |
+| Cancel every waiting/finalizing phase | Ordinary work/writes stop; only agreed cleanup/diagnostic paths continue |
+| In-flight child creation | ProducersStopped waits for acknowledgment; repeat discovery includes the late child |
+| Duplicate requests or deleted accepted request | One logical target cancellation continues; deletion of a request cannot resume restore |
+| Child completes before cancel patch | Preserve its terminal result and still verify required cleanup |
+| Plugin unsupported, unavailable or untracked | Explicit unresolved outcome; no invented termination acknowledgment |
+| Cancel then Delete / Delete then cancel | Respect both orderings; drain diagnostic writers too, with no late metadata recreation after deletion |
+| Restart around every acceptance/completion write | Durable cancellation survives; no stale Failed/Completed overwrite or renewed producer admission |
+| In-place full/incremental and destination volumes | Preserve pre-existing storage; partial restored bytes remain possible |
+| CLI wait/logs/describe/download | Canceled is recognized; supported diagnostics remain accessible; before-start absence is distinguished |
+| Another Restore or reused name | No collateral cancellation, phase update or metadata cleanup |
+
+## Alternatives Considered
+
+### Restore.spec.cancel
+
+This matches existing child flags and needs fewer resource types.
+It grants cancellation through broad Restore update/patch capability, has no separate request result for a too-late call, and requires explicit irreversible false-to-true semantics and UID/resourceVersion preconditions in the client.
+It remains a valid alternative if backup maintainers prefer it; request CRs are preferred here for separate permissions/results and the existing backup discussion.
+The coordination and writer-fencing requirements remain the same with either API.
+
+### Delete as the cancellation API
+
+This removes the record/results by design and conflicts with the requested explicit-cancellation semantics.
+Delete may later compose with cancellation internally, but must not define the user-facing cancellation operation.
+
+### A fully asynchronous Restore executor
+
+This can free the main workqueue but requires broader concurrency, shutdown and recovery redesign.
+The independent coordinator/registry is the narrower preferred proposal; neither approach avoids durable state and writer fencing.
+
+## Security Considerations
+
+Treat request creation as an explicit namespace-wide cancellation permission, not harmless read-only access.
+Require target namespace/name/UID checks and immutable request spec; protect controller-owned request status through its status subresource.
+Respect current Restore RBAC and do not claim that its existing main endpoint offers per-field status isolation.
+Use bounded messages that omit plugin credentials and secrets, keep request/Restore UIDs out of metric labels, and validate ownership before temporary-resource cleanup.
+Preserving destination backing storage is required even when a temporary object's name looks disposable.
+
+## Compatibility
+
+Add CRD/scheme/generated-client/deepcopy/RBAC/install changes, the two proposed Restore phase values and every affected phase consumer as one coherent rollout.
+Current consumers needing explicit review include restore create --wait, logs/describe output, download-request eligibility, phase metrics, normal and cancellation finalizers, startup recovery, serialization and tests.
+Current logs CLI excludes new phases; create --wait enumerates terminal states; download eligibility currently distinguishes New/FailedValidation but cannot by phase alone distinguish canceled-before-start artifacts.
+Do not announce a supported API with only some server components respecting cancellation.
+
+Use the upgraded schema and a fully upgraded Velero server for this feature; an old CLI has no cancel command and older phase consumers may misinterpret new states.
+Do not claim a rolling mixed-controller or downgrade combination is safe without validation.
+The first implementation needs an agreed supported-version/rollout contract and version-consistent installation manifests.
+No existing Restore is canceled merely by upgrading.
+
+## Implementation
+
+1. Agree the request-CR preference with the backup contributors and a reviewer, the terminal/unknown-operation contract, supported storage modes and rollout boundary.
+2. Implement the API plus identity/conditional-transition foundation, including all normal writers and cancellation-first deletion protection, without exposing a partially functioning cancel command.
+3. Integrate the observer/context/registry, child/plugin coordination, diagnostics and restart recovery; resolve confirmed storage-preservation prerequisites and coordinate adjacent worker PRs #10264/#10327.
+4. Add the command and phase consumers, then verify the acceptance matrix against real API/manager tests and disposable data-mover/CSI installations before documenting the feature as supported.
+
+Only a design document is being prepared now; no feature implementation or API schema has been committed.
+The earlier 4–8 focused engineering-week estimate is provisional and must be revisited after the API, storage and unknown-plugin decisions, excluding review latency.
+Prior diagnostic tests are preserved as baseline evidence; they have not been rerun or relabeled as explicit-cancel verification.
+
+## Open Issues
+
+- Do the backup contributors and reviewers prefer the proposed matching cancellation-request CRs or matching spec.cancel fields?
+- Is strict pending-on-unknown acceptable, or what explicitly weaker timeout outcome and recovery procedure should be exposed?
+- Which in-place/data-mover modes and third-party plugin outcomes can meet the initial completion contract?
+- What diagnostic deadline, request retention, user-facing condition details and rollout/version guarantees should be finalized before implementation?
+- Who can review the shared API and the cross-controller implementation, and should automatic delete-first cancellation be a separately reviewed follow-up?
+
+## Source References
+
+The following references pin the current behavior being changed, rather than describe an implemented cancellation API.
+
+- [Restore phases](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/apis/velero/v1/restore_types.go#L282-L335) and [CRD without a status subresource](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/config/crd/v1/bases/velero.io_restores.yaml#L629-L631).
+- [Current merge-patch retry helper](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/util/kube/client.go#L28-L44) and [primary phase writes](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/restore_controller.go#L240-L295).
+- [Operations controller](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/restore_operations_controller.go#L205-L350) and [finalizer phase writes](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/restore_finalizer_controller.go#L243-L255).
+- [Hook context lifetime](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/restore/restore.go#L2319-L2363) and [startup failure recovery](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/cmd/server/server.go#L1020-L1042).
+- [CLI terminal wait](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/cmd/cli/restore/create.go#L465-L466) and [download artifact eligibility](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/download_request_controller.go#L280-L287).

--- a/design/restore-cancellation-design.md
+++ b/design/restore-cancellation-design.md
@@ -19,6 +19,10 @@ In #9190, sseago asks for cancellation as an operation distinct from deleting a 
 In [#2098](https://github.com/velero-io/velero/issues/2098#issuecomment-2634886944), an explicit spec field or a cancellation-request CR was discussed; later discussion favors preserving the object and using a distinct terminal [Canceled phase](https://github.com/velero-io/velero/issues/2098#issuecomment-2640290422).
 [Terminal backups remain unchanged when cancellation arrives too late](https://github.com/velero-io/velero/issues/2098#issuecomment-3211169866).
 These provide design direction; the exact shared API is still to be agreed with the backup contributors.
+Joeavaikath's later [backup design #9284](https://github.com/velero-io/velero/pull/9284) proposed `Backup.spec.cancel`; that design and [implementation #9320](https://github.com/velero-io/velero/pull/9320) closed without merge on February 26, 2026.
+Their review discusses [keeping cancellation in the existing state machine](https://github.com/velero-io/velero/pull/9284#discussion_r2430934181), [waiting for synchronous actions to complete or time out](https://github.com/velero-io/velero/pull/9284#discussion_r2430951752), and alternatives for unconfirmed asynchronous cancellation.
+The earlier request-CR discussion is therefore not an accepted shared API; this proposal must resolve the later spec-field and controller-ownership feedback with those contributors before implementation.
+Backup data deletion in that discussion must not be applied to already restored destination data.
 
 The current Restore controller runs the restore synchronously within Reconcile, while independent operations and finalizer controllers perform later work and metadata writes.
 DataDownload and PodVolumeRestore already expose cancellation, and server startup already fails stale InProgress Restores and requests child cancellation.
@@ -157,6 +161,8 @@ Do not terminate a shared plugin process to stop one Restore, and do not assume 
 
 The operations and restore-finalizer controllers must stop new restorative work and ordinary phase progression after cancellation wins.
 Allow only the agreed cancellation cleanup and diagnostic-persistence paths, under coordinated writer ownership.
+The DownloadRequest controller is also a writer: requesting RestoreItemOperations can flush the in-memory operation map to object storage.
+Include that upload path in UID validation, persistence ownership and the deletion drain; reviewing its phase eligibility alone is insufficient.
 Persist partial resource/volume information and known operation IDs even when the synchronous engine exits by cancellation; do not lose them through an early-return path.
 Do not complete normal restore hooks or signal successful volume restoration merely to unblock destination pods.
 The recovery implications for partially restored workloads must be documented.
@@ -178,6 +184,9 @@ A successful optional Cancel call is not proof of termination; unknown or unsupp
 The engine currently learns the operation ID after Execute returns and persists its operation list after the synchronous stage.
 External work that starts before an ID is durably recorded cannot be guaranteed recoverable after a crash without another plugin/persistence contract.
 Retry behavior must account for ambiguous results and process crashes; exactly-once Cancel invocation is not promised.
+Native snapshot restores also call `VolumeSnapshotter.CreateVolumeFromSnapshot` synchronously, without a context or RIA operation ID.
+Fence admission before that call and include the call's return in producer acknowledgment; context cancellation cannot interrupt it or prove the provider operation ended.
+After an ambiguous call outcome or crash, retain the unresolved outcome until the supported provider contract supplies evidence, or explicitly exclude that mode from the initial guarantee.
 
 The proposed conservative completion policy keeps Restore Canceling and requests InProgress while producer acknowledgment, relevant operation termination, storage preservation or required cleanup is unresolved.
 A diagnostic deadline can expose a blocked condition and operator guidance, but does not automatically declare Canceled or force deletion.
@@ -202,12 +211,25 @@ A separate Delete can therefore remove a canceled record later; cancellation alo
 The finalizer installed atomically at acceptance also covers cancel-before-start followed immediately by Delete.
 This cancellation-first/delete-second protection is required in the first change because otherwise ordinary deletion can erase metadata the accepted coordinator still needs.
 
+Restore deletion can also originate from the backup-deletion controller, which deletes Restores referencing the Backup and waits for them to disappear.
+Today that controller removes backup snapshots/data and object-store backup artifacts before requesting Restore deletion; it deletes the Backup API object only after the Restore wait succeeds without errors.
+An unresolved Canceling Restore could exhaust that wait and leave a DeleteBackupRequest Processed with errors after destructive backup cleanup has already happened.
+Processed deletion requests are not automatically retried by that controller.
+Retaining the Backup API object alone therefore does not preserve the dependencies needed by cancellation.
+For the cancellation-first case, the preferred requirement is to preserve required backup data, identity/location information and diagnostic dependencies until the agreed cancellation and persistence barriers complete, coordinating before the first destructive backup-deletion action.
+Retain the dependencies needed to settle admitted operations or provide an agreed durable independent source; backup artifact deletion and Restore diagnostic-prefix deletion are separate operations.
+This requires an agreed ordering mechanism between cancellation acceptance and backup deletion; a point-in-time list of dependent Restores is not a sufficient race fence.
+If backup deletion has already begun or required backup information disappears independently, expose the unavailable dependency and unresolved outcome instead of inferring Canceled or taking a missing-backup finalization shortcut.
+The admission outcome, retained metadata and operator handling of these orderings must be agreed before implementation; the necessary backup-deletion integration is a Restore cancellation prerequisite, not an implementation of backup cancellation.
+
 After restart, scan accepted Canceling Restores independently of whether their original request CR still exists.
 Reuse current DD/PVR startup handling, but do not let the existing stale-InProgress-to-Failed path overwrite an accepted cancellation.
 Persist acceptedAt rather than restarting elapsed-time diagnostics from zero.
 An empty local registry after restart or leader change is not proof that remote work stopped; reconstruct known children/operation metadata and retain unresolved evidence.
 Old workers and callbacks must pass identity/state fences before updating outcomes.
 Validate RestoreUID on name-keyed operation-cache entries; do not use a restore-name label alone to authorize cleanup of temporary resources after a name is reused.
+The current hook tracker is also name-keyed and reports complete when no tracker exists.
+Neither a missing tracker after restart nor a same-name entry supplies UID-specific acknowledgment that an old hook finished; recovery must preserve that uncertainty until the agreed hook outcome can be established.
 
 ### Compatibility and acceptance matrix
 
@@ -221,10 +243,15 @@ Validate RestoreUID on name-keyed operation-cache entries; do not use a restore-
 | Duplicate requests or deleted accepted request | One logical target cancellation continues; deletion of a request cannot resume restore |
 | Child completes before cancel patch | Preserve its terminal result and still verify required cleanup |
 | Plugin unsupported, unavailable or untracked | Explicit unresolved outcome; no invented termination acknowledgment |
+| Native snapshot call admitted before cancellation | Wait for the supported call/outcome acknowledgment; an ambiguous provider result remains unresolved |
 | Cancel then Delete / Delete then cancel | Respect both orderings; drain diagnostic writers too, with no late metadata recreation after deletion |
+| Operation download races cancellation or Delete | Fence the DownloadRequest-triggered upload by UID and drain it before deleting metadata |
+| Backup deletion while cancellation is unresolved | Apply the agreed ordering before destructive backup cleanup; expose defer/failure or unavailable dependencies without false Canceled or silent diagnostic loss |
 | Restart around every acceptance/completion write | Durable cancellation survives; no stale Failed/Completed overwrite or renewed producer admission |
+| Restart loses hook tracker or a name is reused | Missing/name-only hook state cannot acknowledge the prior Restore's producers |
 | In-place full/incremental and destination volumes | Preserve pre-existing storage; partial restored bytes remain possible |
 | CLI wait/logs/describe/download | Canceled is recognized; supported diagnostics remain accessible; before-start absence is distinguished |
+| Phase metrics race normal completion and cancellation | Count committed outcomes once; a losing normal transition cannot report successful completion |
 | Another Restore or reused name | No collateral cancellation, phase update or metadata cleanup |
 
 ## Alternatives Considered
@@ -232,6 +259,7 @@ Validate RestoreUID on name-keyed operation-cache entries; do not use a restore-
 ### Restore.spec.cancel
 
 This matches existing child flags and needs fewer resource types.
+It also matches the closed backup design #9284 and remains a concrete shared-API candidate, not merely a hypothetical alternative.
 It grants cancellation through broad Restore update/patch capability, has no separate request result for a too-late call, and requires explicit irreversible false-to-true semantics and UID/resourceVersion preconditions in the client.
 It remains a valid alternative if backup maintainers prefer it; request CRs are preferred here for separate permissions/results and the existing backup discussion.
 The coordination and writer-fencing requirements remain the same with either API.
@@ -262,6 +290,7 @@ Current logs CLI excludes new phases; create --wait enumerates terminal states; 
 Do not announce a supported API with only some server components respecting cancellation.
 
 Use the upgraded schema and a fully upgraded Velero server for this feature; an old CLI has no cancel command and older phase consumers may misinterpret new states.
+An older Restore CRD explicitly rejects Canceling/Canceled phase writes because its phase enum lacks those values; update the CRD before the server uses them.
 Do not claim a rolling mixed-controller or downgrade combination is safe without validation.
 The first implementation needs an agreed supported-version/rollout contract and version-consistent installation manifests.
 No existing Restore is canceled merely by upgrading.
@@ -283,6 +312,7 @@ Prior diagnostic tests are preserved as baseline evidence; they have not been re
 - Is strict pending-on-unknown acceptable, or what explicitly weaker timeout outcome and recovery procedure should be exposed?
 - Which in-place/data-mover modes and third-party plugin outcomes can meet the initial completion contract?
 - What diagnostic deadline, request retention, user-facing condition details and rollout/version guarantees should be finalized before implementation?
+- How should cancellation acceptance and backup deletion order their work to retain required dependencies, and what defer/retry or Processed-with-errors outcome should operators see when cancellation is unresolved or backup cleanup has already begun?
 - Who can review the shared API and the cross-controller implementation, and should automatic delete-first cancellation be a separately reviewed follow-up?
 
 ## Source References
@@ -294,3 +324,6 @@ The following references pin the current behavior being changed, rather than des
 - [Operations controller](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/restore_operations_controller.go#L205-L350) and [finalizer phase writes](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/restore_finalizer_controller.go#L243-L255).
 - [Hook context lifetime](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/restore/restore.go#L2319-L2363) and [startup failure recovery](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/cmd/server/server.go#L1020-L1042).
 - [CLI terminal wait](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/cmd/cli/restore/create.go#L465-L466) and [download artifact eligibility](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/download_request_controller.go#L280-L287).
+- [Download-triggered operation upload](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/download_request_controller.go#L221-L226) and [name-keyed operation flush](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/itemoperationmap/restore_operation_map.go#L99-L113).
+- [Native snapshot restore call](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/restore/pv_restorer.go#L71-L100) and [absent-hook completion](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/internal/hook/hook_tracker.go#L231-L238).
+- [Backup cleanup before Restore deletion and its final request outcome](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/backup_deletion_controller.go#L265-L445).

--- a/design/restore-cancellation-design.md
+++ b/design/restore-cancellation-design.md
@@ -1,319 +1,330 @@
-# Explicit cancellation of Restores
+# Shared Backup/Restore cancellation contract and Restore integration
 
-Status: proposal for discussion, revised after [sseago's feedback](https://github.com/velero-io/velero/issues/9190#issuecomment-5602961803); no API or implementation has been approved.
+Status: proposal revised after Joeavaikath's [shared API](https://github.com/velero-io/velero/pull/10509#issuecomment-5639307429) and [bounded cancellation](https://github.com/velero-io/velero/pull/10509#issuecomment-5639336763) feedback; no API or implementation has been approved.
 Related issues: [restore cancellation #9190](https://github.com/velero-io/velero/issues/9190) and [backup cancellation #2098](https://github.com/velero-io/velero/issues/2098).
-Proposed implementation contributor: Ruslan Shaydullin; a design reviewer has not yet committed.
-The original restore request/direction belongs to Lyndon-Li and blackpiglet; sseago supplied the explicit-cancellation and shared-API direction.
+Proposed Restore implementation contributor: Ruslan Shaydullin; Backup lifecycle and implementation ownership remain coordinated with the backup contributors.
+The original restore request/direction belongs to Lyndon-Li and blackpiglet; sseago requested a unified design, and Joeavaikath supplied the shared field and completion contract used here.
 Source audit: `cbd9059f8006211170e2ac9911221f1ea30d1082`; earlier diagnostic probes ran on `193cfdc58f9bddf43be6196a29512c8a2d7f175d`.
-The intervening changes update gRPC and version-priority line-ending parsing; the audited cancellation and phase-writing paths are unchanged.
-Codex assisted the investigation, fixtures and drafting; independent source audits accompany this proposal, with review evidence retained by the contributor.
+Codex assisted the investigation, fixtures and drafting; independent source/design reviews accompany this proposal, with evidence retained by the contributor.
 
 ## Abstract
 
-Introduce explicit cancellation of a non-terminal Restore while retaining its object and available diagnostic metadata.
-Use an API pattern compatible with future backup cancellation, stop further restore work, and report cancellation honestly without rolling back restored resources or data.
+Use a one-way `spec.cancel: true` field and a shared, bounded best-effort cancellation contract for Backup and Restore, retaining the parent object and available diagnostics.
+Specify Restore integration under that contract: stop admitting new work, attempt cancellation where a usable mechanism exists, and reach `Canceled` by the cancellation deadline without claiming rollback or proven termination of every external effect.
 
 ## Background
 
-In #9190, sseago asks for cancellation as an operation distinct from deleting a Restore, with eventual APIs similar to backup cancellation.
-In [#2098](https://github.com/velero-io/velero/issues/2098#issuecomment-2634886944), an explicit spec field or a cancellation-request CR was discussed; later discussion favors preserving the object and using a distinct terminal [Canceled phase](https://github.com/velero-io/velero/issues/2098#issuecomment-2640290422).
-[Terminal backups remain unchanged when cancellation arrives too late](https://github.com/velero-io/velero/issues/2098#issuecomment-3211169866).
-These provide design direction; the exact shared API is still to be agreed with the backup contributors.
-Joeavaikath's later [backup design #9284](https://github.com/velero-io/velero/pull/9284) proposed `Backup.spec.cancel`; that design and [implementation #9320](https://github.com/velero-io/velero/pull/9320) closed without merge on February 26, 2026.
-Their review discusses [keeping cancellation in the existing state machine](https://github.com/velero-io/velero/pull/9284#discussion_r2430934181), [waiting for synchronous actions to complete or time out](https://github.com/velero-io/velero/pull/9284#discussion_r2430951752), and alternatives for unconfirmed asynchronous cancellation.
-The earlier request-CR discussion is therefore not an accepted shared API; this proposal must resolve the later spec-field and controller-ownership feedback with those contributors before implementation.
-Backup data deletion in that discussion must not be applied to already restored destination data.
+In #9190, sseago distinguishes cancellation from deletion and asks that Backup and Restore use a unified API and behavior.
+Joeavaikath's earlier [backup design #9284](https://github.com/velero-io/velero/pull/9284) proposed `Backup.spec.cancel`; that design and implementation #9320 closed without merge on February 26, 2026.
+His current review favors the field over a request CR because per-attempt audit records and cancellation-specific caller RBAC are not established product requirements.
+His completion model groups work by its state when cancellation arrives: not yet admitted, started without an effective cancellation path, or started with a usable asynchronous cancellation path.
+The common API, race ordering and terminal meaning below apply to both parent kinds; the Restore sections provide this contribution's lifecycle details for joint review with the Backup design.
+Backup-specific repository/snapshot cleanup does not authorize deleting already restored destination objects or data.
 
-The current Restore controller runs the restore synchronously within Reconcile, while independent operations and finalizer controllers perform later work and metadata writes.
-DataDownload and PodVolumeRestore already expose cancellation, and server startup already fails stale InProgress Restores and requests child cancellation.
-Three earlier component probes demonstrated deferred delete reconciliation, lack of explicit child coordination in the parent's delete branch, and continued real-engine item creation after a fake-API deletion request.
-Those tests describe existing Delete behavior; they do not test the API proposed here, real volume cancellation, Kubernetes GC, restart, or production data loss.
+The current Restore controller performs synchronous work within Reconcile, while operations and finalizer controllers perform later work and metadata writes.
+DataDownload (DD) and PodVolumeRestore (PVR) already expose cancellation, and startup recovery already fails stale InProgress Restores and requests child cancellation.
+Three historical component probes demonstrated deferred delete reconciliation, missing explicit child coordination in the parent's delete branch, and continued real-engine item creation after a fake-API deletion request.
+They are baseline Delete observations, not tests of this proposed API, real volume cancellation, restart or production data loss.
 
 ## Goals
 
-- Provide an explicit, observable cancellation operation with a shared backup/restore API convention and an unambiguous completion race.
-- Stop participating producers and coordinate owned operations and cleanup while preserving Restore identity, diagnostics and destination storage.
-- Recover an accepted cancellation after process restart and prevent late normal writers from undoing its outcome.
+- Give Backup and Restore the same cancellation intent, terminal-completion race and bounded best-effort user experience.
+- Stop admitting further work and attempt supported cancellation while preserving parent identity, available diagnostics and existing destination storage.
+- Recover durable cancellation after restart and prevent late normal writers from changing its terminal outcome.
 
 ## Non Goals
 
-- Roll back already restored Kubernetes objects or bytes, resume a canceled Restore, or guarantee instantaneous physical termination across a partition.
-- Implement backup cancellation in this change, replace child cancellation protocols, or redesign the plugin interface.
-- Make deletion of every running Restore automatically request cancellation in this first implementation; concurrent deletion of an already accepted cancellation is covered below.
+- Roll back restored objects/bytes, resume a canceled operation, or prove physical termination of unreachable provider/plugin work.
+- Implement Backup cancellation in this PR, add a cancellation-request CR, or redesign third-party plugin interfaces.
+- Automatically convert every Delete into cancellation; deletion of a parent with an already accepted cancellation is covered separately.
 
 ## High-Level Design
 
-The preferred proposal is a namespaced `RestoreCancellationRequest` with an immutable target name and UID, accompanied by a `velero restore cancel NAME` command.
-The server accepts a request by a conditional update on the target Restore that records durable cancellation identity/time, installs its existing cleanup finalizer if necessary, and changes its phase to proposed `Canceling`.
-A coordinator independent of the busy Restore workqueue stops local producers, coordinates child/plugin outcomes and required temporary-resource cleanup, persists available diagnostics, and finally records proposed `Canceled`.
-Standalone cancellation does not invoke DeleteRestore or remove the Restore object, diagnostic metadata, or its ordinary external-resources finalizer.
+Clients set `spec.cancel: true` on the existing Backup or Restore, using identity and concurrency checks.
+The responsible controller records acceptance and a fixed deadline in `status.cancellation`, closes admission and enters `Canceling` without waiting for the synchronous workqueue to become free.
+It fences new work, signals participating local contexts, requests supported child/plugin cancellation and observes results only within the remaining budget.
+It commits `Canceled` once work has settled or the deadline expires, retaining explicit residual/unknown outcomes instead of extending `Canceling` indefinitely.
+Cancellation does not call DeleteRestore, remove the parent, or undo work already performed.
 
-Request creation and cancellation acceptance are different events.
-All normal phase writers and the cancellation coordinator use the same UID/resourceVersion-checked transition contract, so normal terminal completion and cancellation acceptance have one ordering point.
-The in-memory execution registry makes cancellation responsive; the persisted Restore record makes it recoverable.
-Normal restore concurrency remains bounded by the existing worker limits.
+A successful spec patch means requested, not accepted or completed.
+All normal writers must observe the same cancellation intent and use UID/resourceVersion-checked transitions, so they cannot commit ordinary completion after cancellation has won the race.
+Durable status governs recovery; local execution tracking makes cancellation responsive but is not proof that remote work stopped.
+Parent cancellation completion and eligibility for subsequent destructive deletion are separate states.
 
 ## Detailed Design
 
-### API proposal and backup alignment
+### Shared API and status
 
-The following names and shapes are proposed for review, not existing API.
-A future `BackupCancellationRequest` should use the same target-identity, request-outcome and terminal-race conventions; backup repository/snapshot cleanup remains its own design.
-The backup issue is assigned to other contributors, so agreement on this shared pattern does not transfer that implementation to this contribution.
+The field and status names below are proposed for joint Backup/Restore review, not implemented APIs.
+The intent is the same for either kind:
 
 ```yaml
-apiVersion: velero.io/v1
-kind: RestoreCancellationRequest
-metadata:
-  generateName: restore-cancel-
-  namespace: velero
 spec:
-  target:
-    name: restore-example
-    uid: 5b857595-d70d-4f06-afb7-aa87c775c613
+  cancel: true
 ```
 
-The example UID is illustrative; the CLI reads the real Restore UID immediately before creating the request.
-The target is always in the request's namespace, both target fields are required and nonempty, and the entire spec is immutable through CRD validation.
-Validate that the chosen immutability mechanism works at Velero's supported Kubernetes minimum before publishing the schema.
-The controller verifies the live UID before every target transition; a same-name replacement is never retargeted.
+`cancel` is an optional Boolean, with omission equivalent to false.
+The supported transition is false/absent to true; repeated true is idempotent, and clearing it does not provide a resume operation.
+A schema-valid object created with true is canceled before execution or runtime backup lookup; schema validation still applies to the create itself.
+Admission must reject a subsequent true-to-false/unset transition at the feature's supported Kubernetes versions.
+Velero currently advertises a Kubernetes compatibility floor that predates CEL validation, so this is an explicit implementation gate: agree a compatible admission mechanism or a feature version boundary before exposing the API.
+Do not silently ship a CEL-only guarantee to older API servers or introduce a webhook/version-floor change without review.
+The controller also latches accepted cancellation in status and must never resume because a stale or misconfigured writer cleared the flag.
 
-| Object | Proposed state | Meaning |
-|---|---|---|
-| Request | New (including empty) | Submitted; the target has not necessarily accepted cancellation |
-| Request | InProgress | Its UID-matched target accepted cancellation or this request joined an accepted cancellation |
-| Request | Completed | Target reached Canceled under the contract below, or was already Canceled |
-| Request | Failed | Definitive rejection: TargetNotFound, TargetUIDMismatch, AlreadyTerminal, AlreadyDeleting or UnsupportedPhase; TargetLost means the result became unverifiable after acceptance |
-| Restore | Canceling | Cancellation was durably accepted; normal work must stop, required outcomes are still being reconciled |
-| Restore | Canceled | Producer and supported-operation/cleanup barriers completed; partial results remain available |
+The parent UID identifies the operation being canceled; there is no second object, request UID, per-invocation result, request retention policy or request-deletion lifecycle.
+Proposed `status.cancellation` fields are `acceptedAt`, `deadline`, `completionTimestamp`, `reason` and a bounded set of `conditions`.
+`acceptedAt` and `deadline` are written together once; the original deadline is not reset by duplicate requests, config changes, reconciliation or restart.
+The parent's existing completion timestamp is set when `Canceled` is committed, never when intent is merely submitted.
+Suggested completion reasons are `WorkSettled` and `DeadlineExceeded`; neither implies rollback.
+Conditions summarize `AdmissionClosed`, `LocalWorkStopped`, `OperationsSettled`, `TemporaryResourcesCleaned` and `DiagnosticsPersisted`, with True/False/Unknown, reason, bounded message and transition time.
+Only admission closure and completion of the bounded orchestration define the parent terminal contract; operation, cleanup, local-exit and diagnostic conditions may remain False or Unknown at `Canceled`.
+Retain known operation IDs and residual details in the normal operation metadata where available, rather than an unbounded list in status or metric labels.
+A missing handle is recorded as unavailable; it is not invented from a name or treated as successful cancellation.
 
-Request status proposes `phase`, `reason`, `message`, `acceptedAt` and `completionTimestamp`.
-The new request CR has a status subresource: client-supplied status on create is ignored, and only the controller writes its result.
-Invalid or missing required spec fields are rejected by the API server; transient API errors are retried and do not become a definitive request Failed result.
-If an accepted target disappears or is replaced before a terminal result is observed, a surviving request reports Failed/TargetLost with its acceptedAt retained; this means its outcome is unknown, not that external work stopped or the Restore became Failed.
-Never retarget a replacement or infer success from absence.
-A blocked accepted cancellation whose target still exists stays InProgress with a concrete reason; it must not become Completed merely because a timer expired.
+| Parent state | Meaning |
+|---|---|
+| Non-terminal, `spec.cancel: true`, no acceptance | Cancellation requested; no acceptance/deadline has yet been committed |
+| `Canceling` | Accepted, admission closed, bounded cancellation work is in progress |
+| `Canceled` | Velero completed its bounded best-effort cancellation orchestration; residual effects and incomplete cleanup remain explicitly observable |
+| An earlier terminal phase | Cancellation arrived too late; the original outcome and completion timestamp remain unchanged |
 
-Restore status proposes `cancellation` containing `requestUID`, `acceptedAt`, `completionTimestamp` and bounded `conditions` for ProducersStopped, OperationsSettled, TemporaryResourcesCleaned and DiagnosticsPersisted.
-The stored request UID is the identity of the first accepted logical cancellation; subsequent requests observe that same operation.
-Conditions carry normal True/False/Unknown, reason, message and transition time; they describe observations rather than unbounded lists of child objects.
-The existing Restore completion timestamp is set only when Canceled is committed, not when cancellation is requested.
+Both current Backup and Restore CRDs lack a status subresource.
+This design retains their existing endpoint and uses conditional parent updates; controller ownership of cancellation status is a convention, not per-field RBAC isolation.
+Adding a status subresource would be a separate compatibility change.
+A shared status/transition helper can encode the common contract, while each kind supplies its phase set and operation adapters.
+Backup phases must be classified from its own API rather than copied blindly from Restore; Finalizing and FinalizingPartiallyFailed are not terminal outcomes.
 
-Current Restore has no status subresource.
-This proposal preserves that existing endpoint and uses conditional whole-object updates for the relevant status/finalizer transitions; introducing a Restore status subresource would require a separate compatibility decision.
-Write request acceptance only after the parent commit; a crash between these writes is repaired from the durable parent marker.
-All controller code sharing these transitions must use fresh reads and concurrency preconditions as described below.
+### CLI and authorization
 
-### CLI, authorization and request lifecycle
+The proposed commands are `velero restore cancel NAME` and the corresponding `velero backup cancel NAME` under the shared contract.
+This contribution implements only the Restore side after design agreement; publishing a shared field does not authorize a nonfunctional Backup command.
+The CLI reads the target, records its UID and resourceVersion, and conditionally patches only `spec.cancel` with both identity and concurrency preconditions.
+On conflict, read again, require the same UID, and decide again; never cancel a replacement object that reused the name.
+A missing target, unknown phase or already deleting target is reported without claiming cancellation acceptance.
+A target already in a normal terminal phase is a no-op: do not patch it or rewrite its outcome.
+A Canceling/Canceled target is reported as the existing operation, with its original deadline and any residual conditions.
 
-`velero restore cancel NAME` reads the target, creates a UID-bound request and prints that submission is pending; an API create acknowledgment is not reported as completed cancellation.
-Proposed `--wait` observes the request and UID-matched Restore until Completed, definitive Failed, or the caller's wait timeout.
-A CLI timeout leaves server cancellation running; it must print the request identity so the operator can inspect the outcome later.
-Repeated CLI invocations may create separate request records, but they join one target cancellation.
-The CLI can poll the UID-matched Restore with get when its request disappears; a watch-based fallback additionally requires watch on restores.
-Request/get/describe output must show the actual request result and the target's phase without requiring users to infer success from deletion.
+After a write, read back the same UID and flag; an API-server acknowledgment is insufficient if an older schema pruned the field.
+Print requested until the controller has committed acceptance; report the phase, acceptance/deadline and completion reason when available.
+Proposed `--wait` observes the same UID until Canceled, a too-late normal terminal outcome, deletion/replacement, or a caller-side timeout.
+A CLI timeout does not clear intent or extend the server deadline; print the target identity and current state for later inspection.
+`Canceled` ends the wait even if operation/cleanup conditions are unresolved, and the CLI displays those warnings without presenting cancellation as a successful Backup/Restore.
+No per-invocation audit trail is created; Kubernetes audit logging remains available according to cluster configuration.
 
-Creating a cancellation request grants cancellation capability for any Restore in that namespace.
-It does not provide per-object authorization simply because the target has a UID.
-The minimal caller role needs get on restores and create/get/watch on restorecancellationrequests; it does not need Restore update, patch or delete.
-Controller roles add request list/watch/status permissions and the existing target/child permissions required by the lifecycle.
-Do not grant request creation to default read-only roles; cluster administrators must explicitly choose the namespace-wide cancellation capability.
-A supplied username/annotation is not a trustworthy caller identity and must not be used for an impersonated authorization check.
+The minimal caller role needs get and patch on the relevant parent resource; polling uses get and an optional watch implementation additionally needs watch.
+This is broad parent mutation authority, not a cancellation-only permission; controller roles retain the permissions needed for the target and child operations.
+Do not add patch rights to read-only roles, use caller-supplied identity annotations as authorization, or claim namespace/name/UID checks create field-level access control.
 
-Deleting a request before acceptance may withdraw that unaccepted submission; the controller must re-read it with no deletionTimestamp before attempting acceptance.
-Deletion can still race that read and acceptance on another object, so withdrawing a request is not a guaranteed cancellation-of-cancellation API.
-After acceptance, deleting the request never resumes work: Restore.status.cancellation is authoritative, and the coordinator also watches Canceling Restores directly.
-Request records need no finalizer to keep an accepted cancellation alive.
-This initial proposal leaves completed request retention to the operator, instead of adding a new automatic TTL policy.
+### Intent, acceptance and normal completion
 
-### Acceptance and the completion race
+Restore cancellable phases are empty/New, InProgress, WaitingForPluginOperations, WaitingForPluginOperationsPartiallyFailed, Finalizing and FinalizingPartiallyFailed.
+Completed, PartiallyFailed, Failed and FailedValidation are normal terminal outcomes; Canceling/Canceled are handled idempotently.
+Backup uses the same cancellable phases plus Queued and ReadyToStart, with the same four normal terminal outcomes; Backup Deleting is a delete-first state even before checking deletionTimestamp.
+Unknown phases are not guessed to be cancellable.
 
-Treat empty phase, New, InProgress, WaitingForPluginOperations, WaitingForPluginOperationsPartiallyFailed, Finalizing and FinalizingPartiallyFailed as cancellable.
-Completed, PartiallyFailed, Failed and FailedValidation are existing terminal outcomes and remain unchanged when an unaccepted cancellation is too late.
-A target already Canceled completes a new UID-matched request with reason AlreadyCanceled; a target Canceling joins its existing cancellation.
-An unknown phase is rejected explicitly rather than guessed to be cancellable.
+The linearization point against normal terminal completion is the conditional intent write on a cancellable, non-deleting object.
+If normal completion commits first, the CLI conflict/no-op path leaves that terminal outcome alone.
+An arbitrary direct patch of true to an already terminal object also cannot create an accepted cancellation or rewrite its phase/timestamps.
+If true commits first while the object is cancellable and non-deleting, every fresh normal phase writer must route it to cancellation acceptance instead of committing ordinary success, failure or finalization.
+A stale normal writer must conflict and make that fresh decision, preserving both the flag and any existing cancellation status.
+Acceptance is the controller's subsequent conditional update: verify UID/resourceVersion, require a cancellable non-deleting target and write Canceling with acceptedAt/deadline.
+For Restore, that update also retains/adds its ExternalResourcesFinalizer; Backup's deletion protection belongs to its kind-specific lifecycle and does not use the Restore finalizer.
+The time between intent and this update is visibly requested, not a false claim that the deadline has already begun.
+If Delete has already acquired a deletionTimestamp before acceptance, the cancel request is not accepted and this initial design leaves delete-first behavior unchanged.
 
-Acceptance is a single optimistic update of the freshly read Restore: verify UID/resourceVersion, require a cancellable phase and no deletionTimestamp, retain/add ExternalResourcesFinalizer, and atomically write Canceling plus the cancellation record.
-Normal completion and acceptance must use this same conditional update discipline.
-If normal terminal completion commits first, request processing observes AlreadyTerminal and does not mutate the Restore.
-If cancellation acceptance commits first, any old completion, validation-failure, finalization or startup-failure write must conflict and then preserve Canceling when it re-reads.
+The current merge-patch helper retries the same snapshots and cannot enforce this contract by itself.
+All participating writers need a scoped transition helper or equivalent using fresh reads, UID validation and resourceVersion preconditions, including validation/admission, synchronous completion, operations, finalization and startup recovery.
+Counters and diagnostic patches must not replay stale phase, spec or cancellation fields; metrics reflect committed transitions rather than a losing writer's intent.
+Admission checks cover pending true as well as accepted cancellation, including a create with true before the existing validateAndComplete/backup-fetch path.
+An external call already admitted before the fence can still finish afterward; acceptance is not an instantaneous physical stop barrier.
 
-The current PatchResource helper uses a plain merge patch; its retry helper repeats the same snapshots.
-It is therefore insufficient to add conditional writes only in the new coordinator.
-Introduce a scoped Restore-transition helper or equivalent at every participating writer, with UID checks, resourceVersion preconditions and a fresh decision on each retry; do not blindly replay stale normal status.
-This includes initial admission/validation, synchronous restore completion, plugin-operation phase updates, finalization and startup recovery.
-Ordinary counters and diagnostic patches also need to avoid replaying a stale phase or cancellation record.
+### Deadline and operation classes
 
-The ordering point governs the recorded outcome, not an impossible instantaneous barrier on all external side effects.
-A resource request already in flight may finish after acceptance.
-The completed ProducersStopped condition is the boundary after which participating local producers must not initiate further restore work.
+Propose a shared server `--cancellation-timeout` with a finite positive default of **1 minute**, subject to maintainer review and validation for supported deployments.
+This is a proposed parent policy, not an existing Velero default or a reuse of child cancellation grace periods.
+Persist `deadline = acceptedAt + timeout` at acceptance and schedule reconciliation for that deadline independently of long-running operations.
+Each attempt, wait and diagnostic/cleanup operation uses the remaining budget; a retry or newly discovered operation never gets a new full timeout.
+If all admitted work has settled and available cleanup/diagnostic outcomes are recorded earlier, complete with WorkSettled; otherwise complete with DeadlineExceeded when the budget is exhausted.
+A non-interruptible call, unavailable child, missing ID, failed cleanup or failed object-store diagnostic upload cannot hold the parent in Canceling beyond that budget.
+This bounds controller waiting while the controller and Kubernetes API are available; it cannot guarantee a persisted phase update during a server/API outage.
+After an outage, an expired accepted deadline is finalized on recovery without starting a new grace period, recording unfinished attempts/uncertainty.
 
-### Stop producers and coordinate existing controllers
+The following table applies Joeavaikath's operation classes to both workflows.
+It describes proposed behavior rather than claiming every current path already implements it.
 
-Register work under namespace/Restore UID before side effects, then make a fresh authoritative state check after registration.
-This closes the case where the cancellation observer saw the request before the producer registered.
-The observer cancels active contexts and prevents new registrations for an accepted cancellation; context cancellation alone is not acknowledgment that work exited.
-Thread the context through engine iteration, PVR waits, informer synchronization, restore hooks, relevant Kubernetes calls and server/leader shutdown.
-Keep the per-UID execution registry entry and hook cancellation/acknowledgment alive through operations and finalization; hooks can outlive the synchronous engine stage.
-Wait for participating work to acknowledge completion and repeat dependent-operation discovery after this barrier to capture late creations from previously admitted calls.
-Use a separate bounded reconciliation/persistence context for cancellation coordination, child patches and diagnostics; an already canceled work context cannot perform that cleanup.
-Do not terminate a shared plugin process to stop one Restore, and do not assume a wrapper context interrupts plugin methods that accept no context.
+| State at cancellation | Backup examples | Restore examples | Shared behavior |
+|---|---|---|---|
+| Not yet admitted | Queued items, native snapshot call not invoked, New/Prepared PVB or DU | Unprocessed items, volume restore not invoked, New/Prepared PVR or DD | Fence admission; do not start that work |
+| Started without an effective cancellation path | Inline work, native snapshot calls, hooks, object-store work, observable but non-cancelable CSI snapshot creation | Inline item/Kubernetes writes, plugin execution without a durable operation ID, native volume-from-snapshot calls, hooks, object-store work | Use available local signals, record uncertainty, and complete the parent by the deadline without rollback or waiting for proof of stop |
+| Started async work with usable cancellation support | PVB/DU and item operations with a persisted ID and plugin-supported Cancel | PVR/DD and item operations with a persisted ID and plugin-supported Cancel | Request existing child spec.cancel or plugin Cancel; observe only within the remaining budget, then complete the parent |
 
-The operations and restore-finalizer controllers must stop new restorative work and ordinary phase progression after cancellation wins.
-Allow only the agreed cancellation cleanup and diagnostic-persistence paths, under coordinated writer ownership.
-The DownloadRequest controller is also a writer: requesting RestoreItemOperations can flush the in-memory operation map to object storage.
-Include that upload path in UID validation, persistence ownership and the deletion drain; reviewing its phase eligibility alone is insufficient.
-Persist partial resource/volume information and known operation IDs even when the synchronous engine exits by cancellation; do not lose them through an early-return path.
-Do not complete normal restore hooks or signal successful volume restoration merely to unblock destination pods.
-The recovery implications for partially restored workloads must be documented.
+An asynchronous operation whose ID was never durably persisted belongs to the second class at cancellation time, including after a crash.
+A successful optional plugin Cancel can be a no-op; it is not proof that external work ended.
+Child terminal states that won their own race are preserved rather than rewritten to Canceled.
+At the deadline, the parent may be Canceled while children remain Canceling/InProgress or external operations continue; diagnostics must make that distinction explicit.
+Existing child controllers may finish their own cancellation and cleanup afterward without reopening the parent or rewriting its terminal reason/deadline.
 
-### Children, plugins, storage and completion
+### Restore producers, callbacks and bounded coordination
 
-Reuse DD/PVR spec.cancel and their actual worker/informer handshake, preserving namespace, owner UID and compatible historical child identity checks.
-Completed or Failed children that won their own race remain valid terminal outcomes; do not rewrite all children to Canceled.
-The local microservice watcher Cancel method alone is insufficient because that method currently only logs.
+Use a responsive cancellation observer/coordinator independent of the busy synchronous Restore workqueue, with namespace/UID-scoped execution tracking and a shared transition contract.
+Register work before side effects and make a fresh authoritative admission check after registration, so an observer that ran before registration cannot miss the work permanently.
+Close future producer admission for the UID, cancel participating contexts, and check the durable intent/state before every subsequent Velero-controlled work item, hook or external call.
+Context cancellation does not itself acknowledge producer exit, and a returning old call must not start its next step after admission closes.
+An unavailable authoritative check must not permit new work.
+Thread cancellation through engine iteration, PVR waits, informer synchronization, hooks and relevant Kubernetes calls where the API supports it.
+Keep execution identity through operations/finalization, since hooks can outlive the synchronous engine stage.
+Observe acknowledgments and repeat child discovery to include late creations from calls admitted before the fence, but stop waiting at the parent deadline.
+A late child found after completion can receive best-effort cancellation through its existing path; it does not restart the parent or extend its deadline.
 
-A child Canceled phase can precede best-effort temporary-resource cleanup.
-Require both the agreed operation result and observed safe cleanup for owned temporary resources; a terminal CR alone is not that evidence.
-Reconcile failed cleanup rather than forcibly removing child finalizers or releasing local watchers to manufacture completion.
-For supported in-place modes, verify existing destination PV/PVC ownership and preservation before enabling cancellation: the current generic cleanup can act on a temporary PVC bound to an existing target PV.
-Any missing preservation guard is an implementation prerequisite or an explicitly agreed unsupported-mode boundary, not a reproduced claim of data loss.
+The coordinator must not synchronously wait on a plugin Progress/Cancel method or native provider call whose API does not accept its context.
+Use bounded per-UID and global execution capacity, track outstanding calls, and do not spawn an unbounded new goroutine on every reconcile.
+At deadline, leave unreturned calls visible as unresolved; keep their capacity accounted for until they return or the owning process exits.
+Unavailable capacity or an exhausted budget is an explicit NotAttempted/Unconfirmed outcome, not an unbounded queue ahead of the terminal update.
+Do not kill a shared plugin process to cancel one Restore or pretend a context wrapper terminated its call.
+The cancellation timer/status path must remain runnable when all cancellation-call workers are occupied.
 
-Preserve every known plugin operation ID and request best-effort cancellation using its existing contract.
-A successful optional Cancel call is not proof of termination; unknown or unsupported results stay explicit.
-The engine currently learns the operation ID after Execute returns and persists its operation list after the synchronous stage.
-External work that starts before an ID is durably recorded cannot be guaranteed recoverable after a crash without another plugin/persistence contract.
-Retry behavior must account for ambiguous results and process crashes; exactly-once Cancel invocation is not promised.
-Native snapshot restores also call `VolumeSnapshotter.CreateVolumeFromSnapshot` synchronously, without a context or RIA operation ID.
-Fence admission before that call and include the call's return in producer acknowledgment; context cancellation cannot interrupt it or prove the provider operation ended.
-After an ambiguous call outcome or crash, retain the unresolved outcome until the supported provider contract supplies evidence, or explicitly exclude that mode from the initial guarantee.
+Only agreed cancellation coordination, bounded diagnostics and safe cleanup may run after acceptance; ordinary operations/finalizer phase progression and restorative work stop.
+Late local/remote results may be recorded as residual diagnostics by the designated owner without reopening Canceled, counting normal success, or restarting hooks/volume restoration.
+Fence these writes by UID and lifecycle, including DownloadRequest-triggered operation uploads and name-keyed operation caches.
+An already-issued object-store write may finish after terminal cancellation; that unresolved writer matters to subsequent deletion, not to the parent deadline.
+Do not signal successful volume restoration merely to unblock a partially restored workload.
 
-The proposed conservative completion policy keeps Restore Canceling and requests InProgress while producer acknowledgment, relevant operation termination, storage preservation or required cleanup is unresolved.
-A diagnostic deadline can expose a blocked condition and operator guidance, but does not automatically declare Canceled or force deletion.
-The deadline source/default and manual recovery guidance must be agreed before implementation; existing child cancellation grace periods are not automatically a new parent deadline.
-This can leave an unavailable-worker/plugin case pending indefinitely, so maintainers must explicitly accept the tradeoff or choose a visibly weaker bounded outcome.
-Canceled means the agreed control-plane and supported-operation contract completed; it is not a guarantee of physical process termination on an unreachable node or of rollback.
+### Children, storage and diagnostics
 
-Retain the Restore object, its normal cleanup finalizer, available logs, results, resource/volume summaries and operation metadata after standalone cancellation.
-Serialize final diagnostic persistence so a late normal writer cannot erase the cancellation outcome.
-For a Restore canceled before starting, there may be no object-store artifacts; represent that absence accurately instead of blocking on files that never existed.
-Persist durable execution/artifact availability information so download and CLI consumers can distinguish never-started work from a failed upload.
-A required operation-ID checkpoint failure blocks accounting for external work; an optional log upload failure must be reported without claiming logs exist.
-For partially executed work, the exact mandatory diagnostic set and handling of optional upload failures must be agreed before implementation; required persistence failures remain visible and retryable.
+Reuse DD/PVR spec.cancel and their actual worker/informer protocol, with namespace, owner UID and compatible historical identity checks.
+The local microservice watcher's Cancel method alone currently only logs, so it is not a substitute for the real child cancellation path.
+A child Canceled phase can precede cleanup; record operation and cleanup outcomes separately and preserve valid Completed/Failed child outcomes.
+Never force-remove child finalizers or delete destination storage to manufacture cancellation completion.
+For in-place restore, validate/fix preservation guards in the actual cancellation cleanup before enabling that fan-out: a temporary PVC can reference an existing destination PV.
+If a cleanup/cancellation path cannot preserve that storage, do not invoke the destructive path; record it as unavailable and agree the supported mode boundary before implementation.
+Skipping unsafe cleanup or exposing a residual resource must not turn into an indefinite parent Canceling state.
 
-### Delete interaction and restart
+Preserve known operation IDs and attempt supported plugin cancellation; ambiguous replies and crash recovery do not imply exactly-once invocation.
+Native CreateVolumeFromSnapshot has neither a context parameter nor an RIA operation ID; an admitted call can remain unresolved after the parent deadline.
+Missing IDs/handles or provider confirmation are residual evidence, not reasons to invent termination acknowledgment or wait forever.
 
-If Delete wins before acceptance, reject the explicit request as AlreadyDeleting without rewriting the deleting Restore's outcome.
-Automatic cancellation for every pre-existing delete-first path is a separate scope decision.
-If cancellation was accepted first, the existing Restore deletion branch must wait for committed Canceled, including the agreed terminal diagnostic-persistence outcome and acknowledgment that every diagnostic/operation-metadata writer has exited, before calling DeleteRestore or removing its finalizer.
-The separate persistence context must be drained too; no cancellation or normal writer may upload metadata after deletion begins.
-A separate Delete can therefore remove a canceled record later; cancellation alone never does so.
-The finalizer installed atomically at acceptance also covers cancel-before-start followed immediately by Delete.
-This cancellation-first/delete-second protection is required in the first change because otherwise ordinary deletion can erase metadata the accepted coordinator still needs.
+Retain the parent, its ordinary cleanup finalizer, available logs/results, resource/volume summaries and known operation metadata after standalone cancellation.
+Use a separate bounded persistence context, since an already canceled work context cannot perform cancellation status/diagnostic work.
+Try to persist partial execution and artifact availability, with one owner preventing late normal writes from erasing the cancellation result.
+Failed optional uploads, unavailable operation-ID checkpoints and missing never-created artifacts must be represented accurately in status; none delays parent completion past deadline.
+The small parent status update is still required to record Canceled, and an unavailable Kubernetes API is reported as a persistence outage rather than a completed state that was never written.
+Before-start cancellation may legitimately have no object-store artifacts; logs/describe/download must distinguish that from failed persistence after execution.
+Completed cancellation never means that all diagnostics were successfully saved.
 
-Restore deletion can also originate from the backup-deletion controller, which deletes Restores referencing the Backup and waits for them to disappear.
-Today that controller removes backup snapshots/data and object-store backup artifacts before requesting Restore deletion; it deletes the Backup API object only after the Restore wait succeeds without errors.
-An unresolved Canceling Restore could exhaust that wait and leave a DeleteBackupRequest Processed with errors after destructive backup cleanup has already happened.
-Processed deletion requests are not automatically retried by that controller.
-Retaining the Backup API object alone therefore does not preserve the dependencies needed by cancellation.
-For the cancellation-first case, the preferred requirement is to preserve required backup data, identity/location information and diagnostic dependencies until the agreed cancellation and persistence barriers complete, coordinating before the first destructive backup-deletion action.
-Retain the dependencies needed to settle admitted operations or provide an agreed durable independent source; backup artifact deletion and Restore diagnostic-prefix deletion are separate operations.
-This requires an agreed ordering mechanism between cancellation acceptance and backup deletion; a point-in-time list of dependent Restores is not a sufficient race fence.
-If backup deletion has already begun or required backup information disappears independently, expose the unavailable dependency and unresolved outcome instead of inferring Canceled or taking a missing-backup finalization shortcut.
-The admission outcome, retained metadata and operator handling of these orderings must be agreed before implementation; the necessary backup-deletion integration is a Restore cancellation prerequisite, not an implementation of backup cancellation.
+### Delete, backup dependencies and restart
 
-After restart, scan accepted Canceling Restores independently of whether their original request CR still exists.
-Reuse current DD/PVR startup handling, but do not let the existing stale-InProgress-to-Failed path overwrite an accepted cancellation.
-Persist acceptedAt rather than restarting elapsed-time diagnostics from zero.
-An empty local registry after restart or leader change is not proof that remote work stopped; reconstruct known children/operation metadata and retain unresolved evidence.
-Old workers and callbacks must pass identity/state fences before updating outcomes.
-Validate RestoreUID on name-keyed operation-cache entries; do not use a restore-name label alone to authorize cleanup of temporary resources after a name is reused.
-The current hook tracker is also name-keyed and reports complete when no tracker exists.
-Neither a missing tracker after restart nor a same-name entry supplies UID-specific acknowledgment that an old hook finished; recovery must preserve that uncertainty until the agreed hook outcome can be established.
+Cancellation retains the parent; deletion is a separately requested destructive operation.
+For Delete after accepted cancellation, the finalizer waits for the parent terminal phase and for UID-scoped metadata writers to drain or an effective storage-write fence to prevent late writes.
+This includes the independent cancellation persistence context, normal writers and DownloadRequest-triggered uploads.
+Canceled alone is not a writer-drain signal: a synchronous object-store call admitted earlier may still return after the deadline.
+Do not call DeleteRestore/remove its finalizer while that can recreate the metadata being deleted.
+If safe deletion remains unverifiable, retain the finalizer with an explicit deletion blocker and operator guidance; the cancellation result stays terminal Canceled.
+Do not force-finalize deletion, prolong the cancellation deadline, or promise bounded destructive deletion as part of this feature.
+The finalizer installed at acceptance also protects cancel-before-start followed by Delete; deleting the parent before cancellation acceptance is covered by the delete-first ordering above.
 
-### Compatibility and acceptance matrix
+Backup deletion also deletes dependent Restores, but currently removes backup snapshots/data and backup-store artifacts before it requests those Restore deletions.
+Retaining only the Backup API object does not preserve those dependencies, and a Processed DeleteBackupRequest with errors is not automatically retried.
+For accepted cancellation, coordinate required source/diagnostic dependencies before the first destructive backup-deletion action during the bounded cancellation window, or persist an independent description of them.
+A point-in-time dependent-Restore list is not a sufficient ordering fence; the shared design needs explicit ownership/concurrency checks between acceptance and backup deletion.
+Cancellation completion releases any hold whose only purpose was waiting for external operation outcomes; unconfirmed remote termination must not imply indefinite retention of source backup data under this cancellation contract.
+Separate deletion safety checks for in-flight metadata writers still apply to the relevant prefixes and objects, and may visibly defer deletion.
+If backup cleanup has already started or a dependency vanishes, record DependencyUnavailable and the best available cancellation attempt, then still complete by the deadline.
+Do not infer rollback, successful resource cleanup or available diagnostics from a missing Backup.
+The exact backup-deletion ordering/ownership and operator retry behavior need joint review; this Restore integration is not an implementation of Backup cancellation.
+
+On restart, observe both non-terminal spec.cancel intent and accepted Canceling objects independently of the old synchronous worker.
+A requested but unaccepted intent is accepted when possible; an accepted one uses its persisted deadline and never receives a new budget.
+Startup stale-InProgress failure handling must defer to cancellation intent/status rather than overwrite it with Failed.
+Reconstruct known children and durable operation handles, using only the remaining budget; unavailable handles/old hooks are Unknown.
+A missing local registry or name-keyed hook tracker is not evidence that prior work exited.
+Late callbacks, reused names, metrics and metadata cleanup must all verify UID and terminal ownership; do not authorize cleanup using a name-only label.
+
+### Acceptance matrix
 
 | Case | Required result |
 |---|---|
-| Cancel New before any work | No producer starts after its admission check; Canceled retains the record; absent logs are reported as absent |
-| Request UID differs from live target | Definitive rejection; replacement Restore untouched |
-| Normal completion versus acceptance | Conditional update winner determines terminal no-op or Canceling; stale loser cannot overwrite |
-| Cancel every waiting/finalizing phase | Ordinary work/writes stop; only agreed cleanup/diagnostic paths continue |
-| In-flight child creation | ProducersStopped waits for acknowledgment; repeat discovery includes the late child |
-| Duplicate requests or deleted accepted request | One logical target cancellation continues; deletion of a request cannot resume restore |
-| Child completes before cancel patch | Preserve its terminal result and still verify required cleanup |
-| Plugin unsupported, unavailable or untracked | Explicit unresolved outcome; no invented termination acknowledgment |
-| Native snapshot call admitted before cancellation | Wait for the supported call/outcome acknowledgment; an ambiguous provider result remains unresolved |
-| Cancel then Delete / Delete then cancel | Respect both orderings; drain diagnostic writers too, with no late metadata recreation after deletion |
-| Operation download races cancellation or Delete | Fence the DownloadRequest-triggered upload by UID and drain it before deleting metadata |
-| Backup deletion while cancellation is unresolved | Apply the agreed ordering before destructive backup cleanup; expose defer/failure or unavailable dependencies without false Canceled or silent diagnostic loss |
-| Restart around every acceptance/completion write | Durable cancellation survives; no stale Failed/Completed overwrite or renewed producer admission |
-| Restart loses hook tracker or a name is reused | Missing/name-only hook state cannot acknowledge the prior Restore's producers |
-| In-place full/incremental and destination volumes | Preserve pre-existing storage; partial restored bytes remain possible |
-| CLI wait/logs/describe/download | Canceled is recognized; supported diagnostics remain accessible; before-start absence is distinguished |
-| Phase metrics race normal completion and cancellation | Count committed outcomes once; a losing normal transition cannot report successful completion |
-| Another Restore or reused name | No collateral cancellation, phase update or metadata cleanup |
+| Create/New with cancel true | No execution or runtime backup lookup; accept and retain Canceled with accurate artifact absence |
+| False/absent to true; repeat true; reset attempt | Intent set once; duplicate does not reset deadline; reset rejected by supported admission enforcement and never resumes an accepted cancellation |
+| Stale client or reused name | UID/resourceVersion conflict, re-read same UID only; replacement untouched |
+| Normal terminal commit before intent | CLI no-op; late direct patch cannot change original phase/timestamps |
+| Intent commits before ordinary completion/failure | Stale writer conflicts; fresh writer routes to acceptance and cannot overwrite cancellation |
+| Cancel any waiting/finalizing phase | Ordinary phase progression and new restorative work stop; bounded coordination continues |
+| Already-deleting/unknown phase | No false acceptance or guessed transition |
+| In-flight child creation or late call return | Rediscover/attempt child cancellation; no next work item, parent reopening or fresh grace period |
+| Async cancel acknowledged before deadline | Preserve actual child outcome; complete early only when work has settled |
+| Unsupported/untracked/plugin call never returns | Residual/Unknown or NotAttempted detail; Canceled by deadline, no unbounded worker spawning |
+| Native provider call, hook or admitted write continues | Deadline completion does not claim termination/rollback; late results cannot resume work |
+| Failed cleanup or diagnostic upload | Canceled by deadline with False/Unknown conditions; never manufacture successful cleanup/artifacts |
+| Cancel then Delete / Delete then acceptance | Separate ordering; terminal cancellation can coexist with a visible deletion blocker |
+| Operation download races cancellation/Delete | UID-owned upload obeys lifecycle fence; Delete waits for writer safety, not just Canceled |
+| Backup deletion or missing dependencies | Respect bounded-window ordering, expose unavailable dependencies and residual effects; do not extend cancellation deadline |
+| Restart before acceptance, during grace, after expiry | Recover durable intent; reuse deadline; expired cancellation finalizes without a new wait |
+| Lost hook tracker or missing operation ID after crash | Unknown outcome; deadline still completes parent |
+| Controller/API outage over deadline | No false persisted completion; finalize accepted expired cancellation on recovery |
+| In-place full/incremental restore | No destructive cancellation cleanup of pre-existing storage; partial restored bytes remain possible |
+| CLI wait/logs/describe/download and metrics | Canceled ends wait and is distinct from normal success; residual details/absent artifacts visible; committed outcome counted once |
+| Unrelated parent or reused name | No collateral cancellation, status update or metadata cleanup |
 
 ## Alternatives Considered
 
-### Restore.spec.cancel
+### Separate cancellation-request CRs
 
-This matches existing child flags and needs fewer resource types.
-It also matches the closed backup design #9284 and remains a concrete shared-API candidate, not merely a hypothetical alternative.
-It grants cancellation through broad Restore update/patch capability, has no separate request result for a too-late call, and requires explicit irreversible false-to-true semantics and UID/resourceVersion preconditions in the client.
-It remains a valid alternative if backup maintainers prefer it; request CRs are preferred here for separate permissions/results and the existing backup discussion.
-The coordination and writer-fencing requirements remain the same with either API.
+A request CR provides a first-class per-attempt record and separate create permission, following an existing Velero request pattern.
+Those benefits do not eliminate the hard cancellation work, and neither is an established requirement here.
+Prefer the smaller target field as requested in review, avoiding duplicate-request handling, cross-object acceptance recovery, retention and request-deletion semantics.
+Revisit a separate request API only if those product requirements are explicitly adopted.
 
-### Delete as the cancellation API
+### Remain Canceling until every outcome is proven
 
-This removes the record/results by design and conflicts with the requested explicit-cancellation semantics.
-Delete may later compose with cancellation internally, but must not define the user-facing cancellation operation.
+This preserves a stronger terminal interpretation but can wait indefinitely on plugins, providers, lost IDs or unreachable workers.
+The selected contract is bounded best effort: parent termination is separate from residual operation/cleanup evidence and later deletion safety.
+A timeout is not relabeled as proof of stop.
 
-### A fully asynchronous Restore executor
+### Delete as cancellation or a fully asynchronous executor
 
-This can free the main workqueue but requires broader concurrency, shutdown and recovery redesign.
-The independent coordinator/registry is the narrower preferred proposal; neither approach avoids durable state and writer fencing.
+Delete removes the record and conflicts with retaining cancellation results; automatic delete-first cancellation remains a follow-up scope decision.
+A fully asynchronous executor could free the main workqueue, but requires broader concurrency/shutdown changes and does not remove the need for a durable deadline and fenced normal writers.
+A responsive observer with shared transition logic is the narrower Restore integration proposed here; Backup should use the same contract with its appropriate controller arrangement.
 
 ## Security Considerations
 
-Treat request creation as an explicit namespace-wide cancellation permission, not harmless read-only access.
-Require target namespace/name/UID checks and immutable request spec; protect controller-owned request status through its status subresource.
-Respect current Restore RBAC and do not claim that its existing main endpoint offers per-field status isolation.
-Use bounded messages that omit plugin credentials and secrets, keep request/Restore UIDs out of metric labels, and validate ownership before temporary-resource cleanup.
-Preserving destination backing storage is required even when a temporary object's name looks disposable.
+Setting cancel requires parent mutation authority and can disrupt workloads; it is not harmless read-only access or a separate cancellation-only RBAC verb.
+Use UID/resourceVersion preconditions and enforce one-way admission semantics at supported feature versions; do not present main-endpoint status as protected by /status RBAC.
+Bound cancellation-call capacity, retries, status messages and diagnostics, omit secrets/provider credentials, and keep UIDs out of metric labels.
+Validate ownership before cleanup, preserve destination backing storage, and retain visible uncertainty rather than performing unsafe cleanup to satisfy a deadline.
 
 ## Compatibility
 
-Add CRD/scheme/generated-client/deepcopy/RBAC/install changes, the two proposed Restore phase values and every affected phase consumer as one coherent rollout.
-Current consumers needing explicit review include restore create --wait, logs/describe output, download-request eligibility, phase metrics, normal and cancellation finalizers, startup recovery, serialization and tests.
-Current logs CLI excludes new phases; create --wait enumerates terminal states; download eligibility currently distinguishes New/FailedValidation but cannot by phase alone distinguish canceled-before-start artifacts.
-Do not announce a supported API with only some server components respecting cancellation.
+Ship the spec/status additions, Canceling/Canceled phases, generated types/clients/CRDs and all relevant phase consumers as a coherent, feature-supported server/schema combination.
+Use the common contract for Backup and Restore, but do not expose a kind's cancellation command/field as supported before that kind's controllers and storage adapters honor it.
+The admission mechanism, shared enablement sequence and any feature-specific Kubernetes floor require maintainer agreement; the repository's older Kubernetes compatibility declaration is not evidence CEL rules work there.
+No new CR kind, request controller or request RBAC is needed.
 
-Use the upgraded schema and a fully upgraded Velero server for this feature; an old CLI has no cancel command and older phase consumers may misinterpret new states.
-An older Restore CRD explicitly rejects Canceling/Canceled phase writes because its phase enum lacks those values; update the CRD before the server uses them.
-Do not claim a rolling mixed-controller or downgrade combination is safe without validation.
-The first implementation needs an agreed supported-version/rollout contract and version-consistent installation manifests.
-No existing Restore is canceled merely by upgrading.
+Review restore create --wait, cancel wait, logs/describe, downloads, phase metrics, deletion/finalization, startup recovery, serialization and tests.
+Current logs/wait code enumerates phases; older CRDs omit cancel and reject new phase enum values, so a patch acknowledgment alone is not sufficient feature detection.
+Feature support requires matched schema/server and an explicit capability/version check plus UID/flag/status readback in the new CLI.
+An old CLI lacks cancel; older clients/servers can misinterpret the field and phases, and mixed-server rollout or downgrade safety must be validated before promising support.
+Upgrading must not set cancellation on existing objects.
 
 ## Implementation
 
-1. Agree the request-CR preference with the backup contributors and a reviewer, the terminal/unknown-operation contract, supported storage modes and rollout boundary.
-2. Implement the API plus identity/conditional-transition foundation, including all normal writers and cancellation-first deletion protection, without exposing a partially functioning cancel command.
-3. Integrate the observer/context/registry, child/plugin coordination, diagnostics and restart recovery; resolve confirmed storage-preservation prerequisites and coordinate adjacent worker PRs #10264/#10327.
-4. Add the command and phase consumers, then verify the acceptance matrix against real API/manager tests and disposable data-mover/CSI installations before documenting the feature as supported.
+1. Agree this shared spec/status/race/deadline contract with Joeavaikath, sseago and the backup contributors, including admission enforcement, default timeout and version/enablement boundaries.
+2. Implement the common identity/transition/deadline foundation and phase consumers; audit every normal writer and pending-intent path before exposing a command.
+3. Integrate Restore observation, bounded producer/child/plugin coordination, diagnostics and restart recovery; resolve storage-preservation and Delete/backup-dependency ordering, coordinating with worker PRs #10264/#10327.
+4. Coordinate Backup-specific adapters/cleanup and feature exposure with its contributors under the same accepted contract; do not design its terminal semantics independently.
+5. Verify the matrix with API/manager/fake-clock tests, blocked plugin/late-writer cases and disposable data-mover/CSI installations before documenting a supported feature.
 
-Only a design document is being prepared now; no feature implementation or API schema has been committed.
-The earlier 4–8 focused engineering-week estimate is provisional and must be revisited after the API, storage and unknown-plugin decisions, excluding review latency.
-Prior diagnostic tests are preserved as baseline evidence; they have not been rerun or relabeled as explicit-cancel verification.
+This PR changes a design document only; no runtime feature, schema or cancel command is implemented.
+Historical probes are preserved as baseline evidence and have not been rerun or relabeled as cancellation verification.
+Implementation effort and supported storage modes remain to be estimated after the joint API, admission and lifecycle decisions.
 
 ## Open Issues
 
-- Do the backup contributors and reviewers prefer the proposed matching cancellation-request CRs or matching spec.cancel fields?
-- Is strict pending-on-unknown acceptable, or what explicitly weaker timeout outcome and recovery procedure should be exposed?
-- Which in-place/data-mover modes and third-party plugin outcomes can meet the initial completion contract?
-- What diagnostic deadline, request retention, user-facing condition details and rollout/version guarantees should be finalized before implementation?
-- How should cancellation acceptance and backup deletion order their work to retain required dependencies, and what defer/retry or Processed-with-errors outcome should operators see when cancellation is unresolved or backup cleanup has already begun?
-- Who can review the shared API and the cross-controller implementation, and should automatic delete-first cancellation be a separately reviewed follow-up?
+- Confirm the proposed 1-minute configurable cancellation budget and shared status/condition names; the bounded terminal meaning is the selected proposal, not an unresolved strict-pending alternative.
+- Select compatible one-way field admission enforcement and a feature version/enablement contract without silently raising Velero's advertised Kubernetes minimum.
+- Agree Backup-specific operation adapters, repository/snapshot cleanup and joint implementation ownership under this shared API.
+- Finalize bounded-window dependency ordering with backup deletion, writer-drain/fencing mechanisms for subsequent Delete, and operator retry guidance for blocked deletion.
+- Validate in-place/data-mover cleanup preservation and third-party capability reporting for the first supported modes.
 
 ## Source References
 
@@ -327,3 +338,7 @@ The following references pin the current behavior being changed, rather than des
 - [Download-triggered operation upload](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/download_request_controller.go#L221-L226) and [name-keyed operation flush](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/itemoperationmap/restore_operation_map.go#L99-L113).
 - [Native snapshot restore call](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/restore/pv_restorer.go#L71-L100) and [absent-hook completion](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/internal/hook/hook_tracker.go#L231-L238).
 - [Backup cleanup before Restore deletion and its final request outcome](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/backup_deletion_controller.go#L265-L445).
+- [Backup phase enumeration](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/apis/velero/v1/backup_types.go#L296-L364), [Backup CRD endpoint](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/config/crd/v1/bases/velero.io_backups.yaml#L711), and [expected/tested Kubernetes compatibility](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/README.md#L55-L69).
+- [Optional RIA Cancel semantics](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/plugin/velero/restoreitemaction/v2/restore_item_action.go#L57-L61) and [Progress/Cancel gRPC calls](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/plugin/framework/restoreitemaction/v2/restore_item_action_client.go#L137-L179).
+- [Current child cancellation delays](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/data_upload_controller.go#L64-L65), [watcher Cancel](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/datapath/micro_service_watcher.go#L419-L421), and [DD Canceled transition before cleanup](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/controller/data_download_controller.go#L575-L601).
+- [In-place cleanup preservation surface](https://github.com/velero-io/velero/blob/cbd9059f8006211170e2ac9911221f1ea30d1082/pkg/exposer/generic_restore.go#L507-L508) and [Kubernetes transition-rule support/immutability guidance](https://kubernetes.io/blog/2022/09/29/enforce-immutability-using-cel/).


### PR DESCRIPTION
# Please add a summary of your change

Propose a shared Backup/Restore cancellation contract using one-way `spec.cancel: true`, controller-recorded acceptance and a persisted finite deadline, with Restore-specific integration for #9190.
`Canceled` means Velero closed admission and completed its bounded best-effort cancellation orchestration; it does not claim rollback or proven termination of every provider/plugin effect.
Unknown operations, incomplete cleanup and missing diagnostics remain visible at the deadline.

The design covers the intent/normal-completion race, existing child/plugin cancellation paths, bounded handling of non-interruptible calls, restart recovery, late writers, and preservation of restored destination storage.
Subsequent Delete still requires safe metadata-writer drain/fencing; terminal cancellation alone does not authorize destructive cleanup.

The proposed parent timeout defaults to one minute, subject to joint review.
Shared admission enforcement and feature-version compatibility, Backup-specific lifecycle adapters and deletion/dependency ordering require agreement before implementation.
This PR contains a design document only; no runtime feature, CRD or CLI command is implemented.

# Does your change fix a particular issue?

Related to #9190 and #2098; this design PR closes neither issue.
Credit: Lyndon-Li and blackpiglet for the original Restore request/direction, sseago for unified API guidance, and Joeavaikath for the shared-field and bounded-completion review.

# Validation

Checked the revised contract against source at `cbd9059` and independently reviewed shared API/race semantics plus bounded cancellation, restart and deletion behavior.
Design-template headings, Markdown structure, pinned source anchors and `git diff --check` pass.
No runtime or feature tests were run for this documentation change; earlier deletion probes remain historical component diagnostics.

# Please indicate you've done the following:

- [x] Accepted the DCO; design commits include the contributor's sign-off.
- [ ] Changelog: design-only documentation; awaiting `changelog-not-required` classification after the existing command.
- [ ] Documentation in `site/content/docs/main`: not applicable until the feature is implemented.

AI assistance was used for source investigation, review and drafting; the API and implementation remain subject to human maintainer review.
