### PR TITLE
Do not panic when a port name in last-applied-configuration is not a string

### DIFF
--- a/changelogs/unreleased/10511-arpitjain099
+++ b/changelogs/unreleased/10511-arpitjain099
@@ -1,0 +1,1 @@
+Do not panic when a port name in the last-applied-configuration annotation is not a string

--- a/pkg/restore/actions/service_action.go
+++ b/pkg/restore/actions/service_action.go
@@ -190,11 +190,17 @@ func deleteNodePorts(service *corev1api.Service) error {
 					}
 					if nodePortInt > 0 {
 						portName, ok := p["name"]
-						if !ok {
+						switch name, isString := portName.(string); {
+						case !ok:
 							// unnamed port
 							unnamedPortInts.Insert(nodePortInt)
-						} else {
-							explicitNodePorts.Insert(portName.(string))
+						case isString:
+							explicitNodePorts.Insert(name)
+						default:
+							// The annotation is free-form JSON, so the name is
+							// not necessarily a string. One that is not cannot
+							// match a port on the service, so there is nothing
+							// to retain for it.
 						}
 					}
 				}

--- a/pkg/restore/actions/service_action_test.go
+++ b/pkg/restore/actions/service_action_test.go
@@ -698,3 +698,50 @@ func TestServiceActionExecute(t *testing.T) {
 		})
 	}
 }
+
+// The last-applied-configuration annotation is free-form JSON copied from the
+// backed up Service, so a port name in it need not be a string.
+func TestServiceActionExecuteWithNonStringPortName(t *testing.T) {
+	tests := []struct {
+		name              string
+		lastAppliedConfig string
+	}{
+		{
+			name:              "numeric port name",
+			lastAppliedConfig: `{"spec":{"ports":[{"name":8080,"nodePort":8080}]}}`,
+		},
+		{
+			name:              "object port name",
+			lastAppliedConfig: `{"spec":{"ports":[{"name":{"a":"b"},"nodePort":8080}]}}`,
+		},
+		{
+			name:              "null port name",
+			lastAppliedConfig: `{"spec":{"ports":[{"name":null,"nodePort":8080}]}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc := corev1api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "svc-1",
+					Annotations: map[string]string{annotationLastAppliedConfig: test.lastAppliedConfig},
+				},
+				Spec: corev1api.ServiceSpec{
+					Ports: []corev1api.ServicePort{{Name: "http", NodePort: 8080}},
+				},
+			}
+
+			unstructuredSvc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&svc)
+			require.NoError(t, err)
+
+			action := NewServiceAction(velerotest.NewLogger())
+			_, err = action.Execute(&velero.RestoreItemActionExecuteInput{
+				Item:           &unstructured.Unstructured{Object: unstructuredSvc},
+				ItemFromBackup: &unstructured.Unstructured{Object: unstructuredSvc},
+				Restore:        builder.ForRestore(api.DefaultNamespace, "").Result(),
+			})
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
#### Please add a summary of your change

`deleteNodePorts` reads `spec.ports` out of the `kubectl.kubernetes.io/last-applied-configuration` annotation. That annotation is free-form JSON carried over from the backed up Service, and the surrounding code already treats it that way: the port entry is asserted with comma-ok and skipped when it is not a map, and `nodePort` goes through a type switch covering `int32`, `float64` and `string`.

The port name was the one exception:

```go
explicitNodePorts.Insert(portName.(string))
```

so a name that is a number, an object or `null` takes the restore down with `panic: interface conversion: interface {} is float64, not string`.

This reads the name with comma-ok as well. A name that is not a string cannot match any `port.Name` on the service, so it belongs in neither `explicitNodePorts` nor `unnamedPortInts`, and the node port ends up cleared exactly as it would be for a port the annotation never mentioned.

#### Does your change fix a particular issue?

No linked issue. It is the same shape as the existing case "If PreserveNodePorts is false and HealthCheckNodePort is null in last-applied-configuration, it should not crash and the port should be cleared", one field over.

#### Please indicate you've done the following:

- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Created a [changelog file](https://github.com/vmware-tanzu/velero/tree/main/changelogs/unreleased).
- [x] Updated the corresponding documentation in `site/content/docs/main`. (no user-facing documentation change)

Verification: a table test in `pkg/restore/actions` drives `ServiceAction.Execute` with a numeric, an object and a null port name. All three panic on main and pass here. `go test ./pkg/restore/...` output is byte-identical against main apart from the new test, with no failures on either side.
