### PR TITLE
Regenerate CRDs for the sourceSize status field

### DIFF
--- a/config/crd/v1/bases/velero.io_podvolumebackups.yaml
+++ b/config/crd/v1/bases/velero.io_podvolumebackups.yaml
@@ -249,6 +249,10 @@ spec:
                 description: SnapshotID is the identifier for the snapshot of the
                   pod volume.
                 type: string
+              sourceSize:
+                description: SourceSize holds the total size of the source volume.
+                format: int64
+                type: integer
               startTimestamp:
                 description: |-
                   StartTimestamp records the time a backup was started.

--- a/config/crd/v2alpha1/bases/velero.io_datauploads.yaml
+++ b/config/crd/v2alpha1/bases/velero.io_datauploads.yaml
@@ -250,6 +250,10 @@ spec:
                 description: SnapshotID is the identifier for the snapshot in the
                   backup repository.
                 type: string
+              sourceSize:
+                description: SourceSize holds the total size of the source volume.
+                format: int64
+                type: integer
               startTimestamp:
                 description: |-
                   StartTimestamp records the time a backup was started.


### PR DESCRIPTION
## Thank you for contributing to Velero!

#### Please add a summary of your change

#10506 added `SourceSize` to the `PodVolumeBackup` and `DataUpload` status types but did not regenerate the CRD manifests. Without the field in the CRD schema, the API server silently drops `status.sourceSize` on write, so the recorded source size never reaches the cluster objects (observed on a kind cluster: the node-agent reports it, the stored PVB has no `sourceSize`).

This PR is the output of `hack/update-3generated-crd-code.sh` (controller-gen v0.16.5) with no other changes; the diff is exactly the two missing `sourceSize` schema entries.

#### Does your change fix a particular issue?

Follow-up to #10506. Needed by #10512, which reads `SourceSize` for the in-place restore capacity check.

#### Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/main/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
