### PR TITLE
docs: fix VolumeGroupSnapshotClass example

### DIFF
--- a/changelogs/unreleased/10520-krishhna24
+++ b/changelogs/unreleased/10520-krishhna24
@@ -1,0 +1,1 @@
+Fix the VolumeGroupSnapshotClass example in the VolumeGroupSnapshot docs

--- a/site/content/docs/main/volume-group-snapshots.md
+++ b/site/content/docs/main/volume-group-snapshots.md
@@ -160,15 +160,14 @@ kubectl get volumegroupsnapshotclass -o wide
 **Important:** The VolumeGroupSnapshotClass must have the label `velero.io/csi-volumegroupsnapshot-class: "true"` for Velero to automatically discover and use it:
 
 ```yaml
-apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
+apiVersion: groupsnapshot.storage.k8s.io/v1beta2
 kind: VolumeGroupSnapshotClass
 metadata:
   name: csi-vgs-class
   labels:
     velero.io/csi-volumegroupsnapshot-class: "true"
-spec:
-  driver: ebs.csi.aws.com
-  deletionPolicy: Delete
+driver: ebs.csi.aws.com
+deletionPolicy: Delete
 ```
 
 Verify your VolumeGroupSnapshotClass has the correct label:

--- a/site/content/docs/v1.18/volume-group-snapshots.md
+++ b/site/content/docs/v1.18/volume-group-snapshots.md
@@ -160,15 +160,14 @@ kubectl get volumegroupsnapshotclass -o wide
 **Important:** The VolumeGroupSnapshotClass must have the label `velero.io/csi-volumegroupsnapshot-class: "true"` for Velero to automatically discover and use it:
 
 ```yaml
-apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
+apiVersion: groupsnapshot.storage.k8s.io/v1beta2
 kind: VolumeGroupSnapshotClass
 metadata:
   name: csi-vgs-class
   labels:
     velero.io/csi-volumegroupsnapshot-class: "true"
-spec:
-  driver: ebs.csi.aws.com
-  deletionPolicy: Delete
+driver: ebs.csi.aws.com
+deletionPolicy: Delete
 ```
 
 Verify your VolumeGroupSnapshotClass has the correct label:


### PR DESCRIPTION
## Thank you for contributing to Velero!

**Please add a summary of your change**

The example `VolumeGroupSnapshotClass` in the VGS docs cannot be applied as written. Two problems:

- `apiVersion` is `groupsnapshot.storage.k8s.io/v1alpha1`, which external-snapshotter v8.2.0+ does not serve.
- `driver` and `deletionPolicy` are nested under `spec`. On the CRD both are top level and required, and there is no `spec` field.

The same page already says Velero 1.18.1+ uses the v1beta2 API and needs external-snapshotter v8.2.0 or later, so the example contradicts its own prerequisites section a few lines above it.

**Does your change fix a particular issue?**

No issue filed. Found while setting up VolumeGroupSnapshot on a kind cluster for #7507.

**Please indicate you've done the following:**

- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Created a [changelog file](https://github.com/velero-io/velero/tree/main/changelogs/unreleased) or added `kind/changelog-not-required` label.
- [x] Updated the corresponding documentation in `site/content/docs/main`.

## Verification

Against a kind cluster running external-snapshotter v8.6.0 and csi-driver-host-path.

Documented example today:

```
$ kubectl apply --dry-run=server -f old.yaml
error: resource mapping not found for name: "csi-vgs-class" ...
no matches for kind "VolumeGroupSnapshotClass" in version "groupsnapshot.storage.k8s.io/v1alpha1"
ensure CRDs are installed first
```

Corrected example:

```
$ kubectl apply --dry-run=server -f new.yaml
volumegroupsnapshotclass.groupsnapshot.storage.k8s.io/csi-vgs-class created (server dry run)
```

The CRD confirms the field placement across every served version:

```
$ kubectl get crd volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io -o json | ...
v1       storage=False -> ['apiVersion','deletionPolicy','driver','kind','metadata','parameters']  required: ['deletionPolicy','driver']
v1beta1  storage=False -> ['apiVersion','deletionPolicy','driver','kind','metadata','parameters']  required: ['deletionPolicy','driver']
v1beta2  storage=True  -> ['apiVersion','deletionPolicy','driver','kind','metadata','parameters']  required: ['deletionPolicy','driver']
```

## Scope

Applied to `main` and `v1.18`, matching b8a121d0b ("Add external-snapshotter version requirement to VGS docs"), which touched the same file in the same two directories. `v1.17` carries the identical example; happy to include it if preferred.

`design/Implemented/volume-group-snapshot.md` also refers to `spec.driver` in prose. Left alone as an implemented design record, but flagging it here.
