### PR TITLE
Fix schedule pause/delete swallowing lookup errors

### DIFF
--- a/pkg/cmd/cli/schedule/delete.go
+++ b/pkg/cmd/cli/schedule/delete.go
@@ -110,6 +110,9 @@ func Run(o *cli.DeleteOptions) error {
 		}
 	}
 	if len(schedules) == 0 {
+		if len(errs) > 0 {
+			return kubeerrs.NewAggregate(errs)
+		}
 		fmt.Println("No schedules found")
 		return nil
 	}

--- a/pkg/cmd/cli/schedule/pause.go
+++ b/pkg/cmd/cli/schedule/pause.go
@@ -125,6 +125,9 @@ func runPause(f client.Factory, o *cli.SelectOptions, paused bool, skipImmediate
 		}
 	}
 	if len(schedules) == 0 {
+		if len(errs) > 0 {
+			return kubeerrs.NewAggregate(errs)
+		}
 		fmt.Println("No schedules found")
 		return nil
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
`velero schedule pause`, `velero schedule unpause`, and `velero schedule delete`share a lookup step that resolves the schedule(s) to act on, either by name(`crClient.Get`) or via `--all`/`--selector` (`crClient.List`). Errors from that
lookup were collected into an `errs` slice, but the subsequent`if len(schedules) == 0` check only inspected `schedules`, not `errs`. As aresult, a failed lookup (e.g. a nonexistent schedule name, or a failed `List`
call) was treated identically to a genuinely empty, successful result: thecommand printed "No schedules found" and returned `nil` (success), silentlydiscarding the real error.

This fix checks `errs` before falling through to the "No schedules found"message, so a real lookup failure is returned as an error, while alegitimately empty result still succeeds as before.

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
