### PR TITLE
test: use the Kind constant instead of the string literal

### DIFF
--- a/changelogs/unreleased/10524-krishhna24
+++ b/changelogs/unreleased/10524-krishhna24
@@ -1,0 +1,1 @@
+Use the Kind constant instead of the kind string literal in the e2e tests

--- a/test/e2e/backups/deletion.go
+++ b/test/e2e/backups/deletion.go
@@ -88,8 +88,8 @@ func runBackupDeletionTests(client TestClient, veleroCfg VeleroConfig, backupLoc
 	nsCount := len(workloadNamespaceList)
 	workloadNamespaces := strings.Join(workloadNamespaceList[:], ",")
 
-	if useVolumeSnapshots && veleroCfg.CloudProvider == "kind" {
-		Skip("Volume snapshots not supported on kind")
+	if useVolumeSnapshots && veleroCfg.CloudProvider == Kind {
+		Skip(fmt.Sprintf("Volume snapshots not supported on %s", Kind))
 	}
 	oneHourTimeout, ctxCancel := context.WithTimeout(context.Background(), time.Minute*60)
 	defer ctxCancel()

--- a/test/e2e/basic/namespace-mapping.go
+++ b/test/e2e/basic/namespace-mapping.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/vmware-tanzu/velero/test"
 	. "github.com/vmware-tanzu/velero/test/e2e/test"
 	. "github.com/vmware-tanzu/velero/test/util/k8s"
 	. "github.com/vmware-tanzu/velero/test/util/kibishii"
@@ -34,7 +35,7 @@ func (n *NamespaceMapping) Init() error {
 	n.VeleroCfg.UseVolumeSnapshots = n.UseVolumeSnapshots
 	n.VeleroCfg.UseNodeAgent = !n.UseVolumeSnapshots
 	n.kibishiiData = &KibishiiData{Levels: 2, DirsPerLevel: 10, FilesPerLevel: 10, FileLength: 1024, BlockSize: 1024, PassNum: 0, ExpectedNodes: 2}
-	if n.VeleroCfg.CloudProvider == "kind" {
+	if n.VeleroCfg.CloudProvider == test.Kind {
 		n.kibishiiData = &KibishiiData{Levels: 0, DirsPerLevel: 0, FilesPerLevel: 0, FileLength: 0, BlockSize: 0, PassNum: 0, ExpectedNodes: 2}
 	}
 	backupType := "fs-backup"
@@ -70,7 +71,7 @@ func (n *NamespaceMapping) Init() error {
 		"create", "--namespace", n.VeleroCfg.VeleroNamespace, "backup", n.BackupName,
 		"--include-namespaces", strings.Join(*n.NSIncluded, ","), "--wait",
 	}
-	if n.VeleroCfg.CloudProvider == "kind" {
+	if n.VeleroCfg.CloudProvider == test.Kind {
 		// don't test volume snapshotter or file system backup on kind
 		n.BackupArgs = append(n.BackupArgs, "--snapshot-volumes=false")
 		n.UseVolumeSnapshots = false


### PR DESCRIPTION
## Thank you for contributing to Velero!

**Please add a summary of your change**

`test/types.go` defines `const Kind = "kind"` and most of the suite compares against it, but three sites still use the bare string literal.

`test/e2e/backups/deletion.go` is inconsistent with itself: the `BeforeEach` skip uses `Kind` and formats the provider into its message, while the skip in `runBackupDeletionTests` uses `"kind"` twice, once in the comparison and once hardcoded in the message. This change makes the two read identically.

`test/e2e/basic/namespace-mapping.go` dot-imports `test/e2e/test` but not `test`, so the constant was not in scope there. It now imports the `test` package by name and uses `test.Kind`, the same shape `test/e2e/migration/migration.go` already uses alongside its `framework` import. No second dot-import is added.

No behavioural change: the constant's value is exactly the string being replaced.

**Does your change fix a particular issue?**

No issue filed. Noticed while working on the KinD CSI e2e setup for #7507.

**Please indicate you've done the following:**

- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Created a [changelog file](https://github.com/velero-io/velero/tree/main/changelogs/unreleased) or added `kind/changelog-not-required` label.
- [ ] Updated the corresponding documentation in `site/content/docs/main`. Not applicable, no user-facing behaviour changes.

## Testing

`go build ./...` and `go vet ./e2e/basic/... ./e2e/backups/...` in `test/`, plus `make lint`, all clean. The import change in `namespace-mapping.go` is the only part that could fail to compile, and it does not.

I did not run the e2e suite for this. It substitutes a constant for its own value, so a kind run would cost around twenty minutes of CI for no new signal. Happy to run it if you would rather see it.
