### PR TITLE
Fix schedule create dropping backup type

### DIFF
--- a/changelogs/unreleased/10526-Daniel-1600
+++ b/changelogs/unreleased/10526-Daniel-1600
@@ -1,0 +1,1 @@
+Fix schedule create dropping backup type

--- a/pkg/cmd/cli/schedule/create.go
+++ b/pkg/cmd/cli/schedule/create.go
@@ -163,6 +163,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 				ItemOperationTimeout:             metav1.Duration{Duration: o.BackupOptions.ItemOperationTimeout},
 				DataMover:                        o.BackupOptions.DataMover,
 				SnapshotMoveData:                 o.BackupOptions.SnapshotMoveData.Value,
+				BackupType:                       api.BackupType(o.BackupOptions.BackupType),
 			},
 			Schedule:                   o.Schedule,
 			UseOwnerReferencesInBackup: &o.UseOwnerReferencesInBackup,


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
`--backup-type` on `velero schedule create` is parsed and validated, but never copied into `schedule.Spec.Template.BackupType` when building the schedule. Every schedule created with this flag ends up with an empty backup type, and so does every backup it produces.
# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [X] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
